### PR TITLE
Add script to upload dicom images

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,41 @@
+FROM jodogne/orthanc-plugins
+
+RUN apt-get update && apt-get install -y nginx curl unzip
+
+# ENVIRONMENT VARIABLES
+ENV METEOR_VERSION 1.2.1
+ENV OHIF_PATH /opt/OHIF
+ENV OHIF_VIEWER_PATH $OHIF_PATH/OHIFViewer
+
+# METEOR SETUP
+RUN curl -L https://install.meteor.com/ | sh
+
+RUN cd /opt/ && \
+	echo "Downgrading meteor version \"$METEOR_VERSION\" (compatibility tuning). Be patient..." && \
+	meteor create downgrade --release $METEOR_VERSION > /dev/null && \
+	rm -rf downgrade && \
+	echo "Done."
+
+# PROXY SETUP (solve CORS problem)
+COPY ./contents/nginx.conf /etc/nginx/nginx.conf
+
+# OHIF SETUP
+RUN cd /opt/ && curl -o ohif.zip https://codeload.github.com/OHIF/Viewers/zip/master && \
+	unzip ohif.zip && \
+	mv Viewers-master $OHIF_PATH
+
+COPY ./contents/dockerSettings.json /opt/
+
+COPY ./contents/dockerEntrypoint.sh /opt/
+
+RUN chmod a+x /opt/dockerEntrypoint.sh
+
+WORKDIR $OHIF_VIEWER_PATH
+
+EXPOSE 8080
+
+EXPOSE 3000
+
+ENTRYPOINT /opt/dockerEntrypoint.sh \
+	--release $METEOR_VERSION \
+	--settings /opt/dockerSettings.json --verbose

--- a/docker/contents/dockerEntrypoint.sh
+++ b/docker/contents/dockerEntrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+nginx
+
+Orthanc /etc/orthanc &
+
+export PACKAGE_DIRS=../Packages
+export LC_ALL="C.UTF-8"
+
+locale
+
+meteor $@

--- a/docker/contents/dockerSettings.json
+++ b/docker/contents/dockerSettings.json
@@ -1,0 +1,27 @@
+{
+  "dicomWeb" : {
+    "endpoints": [
+      {
+        "name": "Orthanc",
+        "wadoUriRootNOTE" : "either this uri is not correct for wado-uri or wado-uri is not configured on orthanc currently",
+        "wadoUriRoot" : "http://localhost:8080/wado",
+        "qidoRoot": "http://localhost:8080/dicom-web",
+        "wadoRoot": "http://localhost:8080/dicom-web",
+        "qidoSupportsIncludeField": false,
+        "imageRendering" : "wadouri",
+        "requestOptions" : {
+          "auth": "orthanc:orthanc",
+          "logRequests" : true,
+          "logResponses" : false,
+          "logTiming" : true
+        }
+      }
+    ]
+  },
+  "dimse" : {
+    "host" : "localhost",
+    "port" : 4242,
+    "hostAE" : "ORTHANC"
+  },
+  "defaultServiceType": "dicomWeb"
+}

--- a/docker/contents/nginx.conf
+++ b/docker/contents/nginx.conf
@@ -1,0 +1,36 @@
+user www-data;
+worker_processes 4;
+pid /run/nginx.pid;
+
+events {
+	worker_connections 768;
+	# multi_accept on;
+}
+
+http {
+	access_log /var/log/nginx/access.log;
+	error_log /var/log/nginx/error.log;
+
+	sendfile on;
+	tcp_nopush on;
+	tcp_nodelay on;
+	keepalive_timeout 65;
+	types_hash_max_size 2048;
+	client_max_body_size 3M;
+
+	gzip on;
+	gzip_disable "msie6";
+
+	upstream orthanc {
+		server 127.0.0.1:8042;
+	}
+
+	server {
+		listen 8080;
+
+		location / {
+			add_header 'Access-Control-Allow-Origin' '*';
+			proxy_pass http://orthanc/;
+		}
+	}
+}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '2'
+services:
+  viewer:
+    build: .
+    volumes:
+      - ../orthanc-backup:/var/lib/orthanc/db
+      - ..:/opt/OHIF
+    ports:
+      - "4242:4242"
+      - "8080:8080"
+      - "3000:3000"

--- a/scripts/dicom_upload.sh
+++ b/scripts/dicom_upload.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+HOST=$DICOMWEB_HOST
+PORT=$DICOMWEB_PORT
+
+if [[ -f "$1" ]]; then
+	DICOM_FILE=$1
+
+	OUTPUT=$(curl -v "http://$HOST:$PORT/instances/" -H "Origin: http://$HOST:$PORT" -H 'Accept-Encoding: gzip, deflate'-H 'Connection: keep-alive' --compressed --data-binary @"$DICOM_FILE" 2> /dev/null)
+
+	DICOM_ID=$(echo $OUTPUT |sed -e 's/.*"id"\s*:\s*"\([a-zA-Z0-9-]\+\)".*/\1/gI')
+	DICOM_PATH=$(echo $OUTPUT |sed -e 's/.*"path"\s*:\s*"\([^"]\+\)".*/\1/gI')
+
+	if [[ -n "$DICOM_ID" ]]; then
+		echo File: $DICOM_FILE
+		echo Id: $DICOM_ID
+		echo Path: $DICOM_PATH
+		echo
+	else
+		echo "The image was not uploaded" >/dev/stderr
+		exit 1
+	fi
+elif [[ -d "$1" ]]; then
+	DICOM_DIR=$1
+
+	find "$DICOM_DIR" -type f -iregex '.*\(dcm\|dicom\)' | xargs -n1 -I{} "$0" "{}"
+fi
+
+exit 0


### PR DESCRIPTION
Hi there,
Since I needed to upload multiple dicom images to orthanc server I think this script would be useful. I propose to include this script in the original project to use mainly in development environment.
This script uses curl to upload a single dicom file or a directory recursively filtering by `*.dcm` and `*.dicom` extensions . 

Usage:
```sh
DICOMWEB_HOST=<HOST> DICOMWEB_PORT=<PORT> scripts/dicom_upload.sh <DIRECTORY>|<FILE>
```