### PR TITLE
Add script to upload dicom images

### DIFF
--- a/scripts/dicom_upload.sh
+++ b/scripts/dicom_upload.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+HOST=$DICOMWEB_HOST
+PORT=$DICOMWEB_PORT
+
+if [[ -f "$1" ]]; then
+	DICOM_FILE=$1
+
+	OUTPUT=$(curl -v "http://$HOST:$PORT/instances/" -H "Origin: http://$HOST:$PORT" -H 'Accept-Encoding: gzip, deflate'-H 'Connection: keep-alive' --compressed --data-binary @"$DICOM_FILE" 2> /dev/null)
+
+	DICOM_ID=$(echo $OUTPUT |sed -e 's/.*"id"\s*:\s*"\([a-zA-Z0-9-]\+\)".*/\1/gI')
+	DICOM_PATH=$(echo $OUTPUT |sed -e 's/.*"path"\s*:\s*"\([^"]\+\)".*/\1/gI')
+
+	if [[ -n "$DICOM_ID" ]]; then
+		echo File: $DICOM_FILE
+		echo Id: $DICOM_ID
+		echo Path: $DICOM_PATH
+		echo
+	else
+		echo "The image was not uploaded" >/dev/stderr
+		exit 1
+	fi
+elif [[ -d "$1" ]]; then
+	DICOM_DIR=$1
+
+	find "$DICOM_DIR" -type f -iregex '.*\(dcm\|dicom\)' | xargs -n1 -I{} "$0" "{}"
+fi
+
+exit 0


### PR DESCRIPTION
Hi there,
Since I needed to upload multiple dicom images to orthanc server I think this script would be useful. I propose to include this script in the original project to use mainly in development environment.
This script uses curl to upload a single dicom file or a directory recursively filtering by `*.dcm` and `*.dicom` extensions . 

Usage:

``` sh
DICOMWEB_HOST=<HOST> DICOMWEB_PORT=<PORT> scripts/dicom_upload.sh <DIRECTORY>|<FILE>
```
