### PR TITLE
Add default user/pass to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Community
 Have questions?  Try posting in the [OHIF forum](http://forum.ohif.org/).
 
 ### Docker usage
+Following the instructions below, the docker image will listen for DICOM connections on port 4242, and for web traffic on port 8042. The default username for the web interface is `orthanc`, and the password is `orthanc`.
 #### Temporary data storage
 ````
 docker run --rm -p 4242:4242 -p 8042:8042 jodogne/orthanc-plugins


### PR DESCRIPTION
It took a lot of time, googling and luck to figure out the default username/password for the docker image. Adding it to the README would probably be a good idea.