### PR TITLE
OHIF-110: context-menu for measurements in the viewport

### DIFF
--- a/Packages/ohif-core/client/components/base/mixins/dropdown.js
+++ b/Packages/ohif-core/client/components/base/mixins/dropdown.js
@@ -105,10 +105,19 @@ OHIF.mixins.dropdown = new OHIF.Mixin({
 
                 // Change the dropdown position if mouse event was given
                 if (event) {
+                    const originalEventTouches = event.originalEvent.touches;
                     const position = {
-                        left: event.clientX,
-                        top: event.clientY
+                      left: 0,
+                      top: 0
                     };
+
+                    if (originalEventTouches && originalEventTouches.length > 0) {
+                        position.left = originalEventTouches[0].pageX;
+                        position.top = originalEventTouches[0].pageY;
+                    } else {
+                        position.left = event.clientX;
+                        position.top = event.clientY
+                    }
 
                     if (centered) {
                         // Center the dropdown menu based on the event mouse position

--- a/Packages/ohif-viewerbase/client/components/viewer/toolContextMenu/toolContextMenu.js
+++ b/Packages/ohif-viewerbase/client/components/viewer/toolContextMenu/toolContextMenu.js
@@ -1,0 +1,70 @@
+import { Template } from 'meteor/templating';
+import { ReactiveVar } from 'meteor/reactive-var';
+import { toolManager } from '../../../lib/toolManager';
+
+const toolTypes = ['length', 'simpleAngle', 'probe', 'ellipticalRoi', 'rectangleRoi', 'arrowAnnotate'];
+const TypeToLabelMap = {
+    length: 'Length',
+    simpleAngle: 'Angle',
+    probe: 'Probe',
+    ellipticalRoi: 'Elliptical ROI',
+    rectangleRoi: 'Rectangle ROI',
+    arrowAnnotate: 'Annotation'
+};
+let dropdownItems = [{
+    actionType: 'Delete',
+    action: ({nearbyToolData, eventData}) => {
+        const element = eventData.element
+
+        cornerstoneTools.removeToolState(element, nearbyToolData.toolType, nearbyToolData.tool);
+        cornerstone.updateImage(element);
+    }
+}];
+let timer = 0;
+
+const getTypeText = function(toolData, actionType) {
+    const toolType = toolData.toolType;
+    let message = `${TypeToLabelMap[toolType]}`;
+
+    if (toolType === 'arrowAnnotate') {
+        message = `${message} "${toolData.tool.text}"`
+    }
+
+    return `${actionType} ${message}`;
+};
+
+const createDropdown = function (event, eventData, isTouchEvent = false) {
+    const nearbyToolData = toolManager.getNearbyToolData(eventData.element, eventData.currentPoints.canvas, toolTypes);
+
+    // Annotate tools for touch events already have a press handle to edit it, has a better UX for deleting it
+    if (isTouchEvent && nearbyToolData.toolType === 'arrowAnnotate') {
+      return;
+    }
+
+    if (nearbyToolData) {
+        dropdownItems.forEach(function(item) {
+            item.params = {
+                eventData,
+                nearbyToolData
+            };
+            item.text = getTypeText(nearbyToolData, item.actionType);
+        });
+
+        OHIF.ui.showDropdown(dropdownItems, {
+            menuClasses: 'dropdown-menu-left',
+            event: eventData.event
+        });
+    }
+};
+
+Template.viewerMain.events({
+    'CornerstoneToolsMouseClick .imageViewerViewport'(event, instance, eventData) {
+        if (event.which === 3) {
+            createDropdown(event, eventData);
+        }
+    },
+
+    'CornerstoneToolsTouchPress .imageViewerViewport'(event, instance, eventData) {
+        createDropdown(event, eventData, true);
+    }
+});

--- a/Packages/ohif-viewerbase/package.js
+++ b/Packages/ohif-viewerbase/package.js
@@ -146,6 +146,8 @@ Package.onUse(function(api) {
     api.addFiles('client/components/viewer/viewerMain/viewerMain.js', 'client');
     api.addFiles('client/components/viewer/viewerMain/viewerMain.styl', 'client');
 
+    api.addFiles('client/components/viewer/toolContextMenu/toolContextMenu.js', 'client');
+
     api.addFiles('client/components/viewer/imageControls/imageControls.html', 'client');
     api.addFiles('client/components/viewer/imageControls/imageControls.js', 'client');
     api.addFiles('client/components/viewer/imageControls/imageControls.styl', 'client');


### PR DESCRIPTION
# Feature
Image measurements shall be removable through a dialog toggled by 
1 - Right-clicking on the measurement;
2 - Long-pressing on the measurement on a touch-capable device;

# Code
There were a few edge cases to take care of. First of all is how cornerstone name their tools and how it names its manager, there are mismatches for `simpleAngle`, which uses the toolManager `angle`, and `arrowAnnotate` which uses `annotate`.

The second catch was the `arrowAnnotate` which already had a solution for removing the annotation for mobile. When you do a long touch you can edit the annotation and there is a button to remove it. So I decided to keep that behavior and to not add the context-menu for that.

# Demos
Example for desktop:
![context-menu](https://user-images.githubusercontent.com/5274353/30929323-80a644d2-a394-11e7-93b8-6fc90aa257e5.gif)

Example for mobile:
![context-menu-mobile](https://user-images.githubusercontent.com/5274353/30929334-884eff94-a394-11e7-9fb8-ee064efea266.gif)
