### PR TITLE
OHIF-113: added element verification before tool activation.

### DIFF
--- a/Packages/ohif-viewerbase/client/lib/toolManager.js
+++ b/Packages/ohif-viewerbase/client/lib/toolManager.js
@@ -1,6 +1,7 @@
 import { Session } from 'meteor/session';
 import { $ } from 'meteor/jquery';
 import { OHIF } from 'meteor/ohif:core';
+import { _ } from 'meteor/underscore';
 import { getFrameOfReferenceUID } from './getFrameOfReferenceUID';
 import { updateCrosshairsSynchronizer } from './updateCrosshairsSynchronizer';
 import { crosshairsSynchronizers } from './crosshairsSynchronizers';
@@ -403,6 +404,30 @@ export const toolManager = {
             toolManager.init();
         }
 
+        let $elements;
+        if (!elements || !elements.length) {
+            $elements = $('.imageViewerViewport');
+        } else {
+            $elements = $(elements);
+        }
+
+        const checkElementEnabled = function(allElementsEnabled, element) {
+            try {
+                cornerstone.getEnabledElement(element);
+
+                return allElementsEnabled;
+            } catch (error) {
+                return true;
+            }
+        }
+
+        if ($elements.toArray().reduce(checkElementEnabled, false)) {
+            // if at least one element is not enabled, we do not activate tool.
+            OHIF.log.info(`Could not activate tool ${tool} due to an viewport not being enabled. Try again later.`);
+
+            return;
+        }
+
         /**
          * TODO: Add textMarkerDialogs template to OHIF's
          */
@@ -427,13 +452,6 @@ export const toolManager = {
 
         if (!tool) {
             tool = defaultTool;
-        }
-
-        let $elements;
-        if (!elements || !elements.length) {
-            $elements = $('.imageViewerViewport');
-        } else {
-            $elements = $(elements);
         }
 
         // Otherwise, set the active tool for all viewport elements

--- a/Packages/ohif-viewerbase/client/lib/toolManager.js
+++ b/Packages/ohif-viewerbase/client/lib/toolManager.js
@@ -419,11 +419,11 @@ export const toolManager = {
             } catch (error) {
                 return true;
             }
-        }
+        };
 
         if ($elements.toArray().reduce(checkElementEnabled, false)) {
             // if at least one element is not enabled, we do not activate tool.
-            OHIF.log.info(`Could not activate tool ${tool} due to an viewport not being enabled. Try again later.`);
+            OHIF.log.info(`Could not activate tool ${tool} due to a viewport not being enabled. Try again later.`);
 
             return;
         }


### PR DESCRIPTION
# Issue
Switching tools while one of the viewports are loading throws an uncaught error. This is a bug in the toolManager, in which we need to add a better handler to this kind of situation.

# Solution
Before doing any kind of activation through cornerstone I added a check for all elements we want to activate the tool. I added this snippet before all the logic because I wanted to avoid to do any kind of action if any of the elements was yet not enabled. This would prevent to execute any undo action and more complex logic to restore the last state.