### PR TITLE
OHIF-170: using getString to get accession number for QIDO calls

### DIFF
--- a/Packages/ohif-study-list/server/services/qido/studies.js
+++ b/Packages/ohif-study-list/server/services/qido/studies.js
@@ -69,7 +69,7 @@ function resultDataToStudies(resultData) {
             // 00080005 = SpecificCharacterSet
             studyDate: DICOMWeb.getString(study['00080020']),
             studyTime: DICOMWeb.getString(study['00080030']),
-            accessionNumber: DICOMWeb.getNumber(study['00080050']),
+            accessionNumber: DICOMWeb.getString(study['00080050']),
             referringPhysicianName: DICOMWeb.getString(study['00080090']),
             // 00081190 = URL
             patientName: DICOMWeb.getName(study['00100010']),


### PR DESCRIPTION
# Issue
We were referring the accession number as a number and not as a string as the documentation says: http://dicom.nema.org/dicom/2013/output/chtml/part06/chapter_6.html

# Solution
It was right for the DIMSE server, we were only doing it wrong with the QIDO implementation

This addresses #109 