### PR TITLE
Feature: DIMSE proxy

### DIFF
--- a/OHIFViewer/client/routes.js
+++ b/OHIFViewer/client/routes.js
@@ -16,10 +16,19 @@ Router.route('/studylist', function() {
     this.render('ohifViewer', { data: { template: 'studylist' } });
 }, { name: 'studylist' });
 
-Router.route('/viewer/:studyInstanceUids', function() {
-    const studyInstanceUids = this.params.studyInstanceUids.split(';');
-    OHIF.viewerbase.renderViewer(this, { studyInstanceUids }, 'ohifViewer');
-}, { name: 'viewerStudies' });
+Router.route('/viewer/:studyInstanceUids', {
+    name: 'viewerStudies',
+    action: function() {
+      const studyInstanceUids = this.params.studyInstanceUids.split(';');
+  
+      Meteor.call('MoveRequest', {
+        studyInstanceUid: studyInstanceUids[0]
+      }, function(error, result){
+        console.log("DONE", error, result);
+      });
+  
+      OHIF.viewerbase.renderViewer(this, { studyInstanceUids }, 'ohifViewer');
+  } });
 
 // OHIF #98 Show specific series of study
 Router.route('/study/:studyInstanceUid/series/:seriesInstanceUids', function () {

--- a/OHIFViewer/docker-compose.yml
+++ b/OHIFViewer/docker-compose.yml
@@ -1,0 +1,30 @@
+version: '2'
+
+services:
+  pacs:
+    image: jodogne/orthanc-plugins:1.3.1
+    volumes:
+      - ./UniCa/extra/config/pacs.json5:/etc/orthanc/orthanc.json:ro
+    ports:
+      - 8042:8042
+      - 4242:4242
+    command: "/etc/orthanc/orthanc.json --verbose"
+    networks:
+      main:
+        aliases:
+          - pacs
+
+  orthanc:
+    image: jodogne/orthanc-plugins:1.3.1
+    volumes:
+      - ./UniCa/extra/config/orthanc.json5:/etc/orthanc/orthanc.json:ro
+    ports:
+      - 8043:8042
+      - 4243:4242
+    networks:
+      main:
+        aliases:
+          - orthanc
+
+networks:
+  main:

--- a/OHIFViewer/package.json
+++ b/OHIFViewer/package.json
@@ -9,7 +9,8 @@
   },
   "devDependencies": {},
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "METEOR_PACKAGE_DIRS=\"../Packages\" meteor --settings ../config/orthancDIMSEproxy.json"
   },
   "author": "",
   "license": "MIT"

--- a/Packages/ohif-dicom-services/package.js
+++ b/Packages/ohif-dicom-services/package.js
@@ -35,5 +35,8 @@ Package.onUse(function(api) {
     api.addFiles('server/DIMSE/Connection.js', 'server');
     api.addFiles('server/DIMSE/DIMSE.js', 'server');
 
+    // Server imports
+    api.addFiles('server/index.js', 'server');
+
     api.export('DIMSE', 'server');
 });

--- a/Packages/ohif-dicom-services/server/DIMSE/CSocket.js
+++ b/Packages/ohif-dicom-services/server/DIMSE/CSocket.js
@@ -587,7 +587,7 @@ CSocket.prototype.storeInstance = function(sopClassUID, sopInstanceUID, options)
 
 CSocket.prototype.moveInstances = function(destination, params, options) {
     var sendParams = Object.assign({
-        0x00080052: C.QUERY_RETRIEVE_LEVEL_IMAGE,
+        0x00080052: C.QUERY_RETRIEVE_LEVEL_STUDY,
     }, params);
     options = Object.assign({
         context: C.SOP_STUDY_ROOT_MOVE

--- a/Packages/ohif-dicom-services/server/index.js
+++ b/Packages/ohif-dicom-services/server/index.js
@@ -1,0 +1,1 @@
+import './methods';

--- a/Packages/ohif-dicom-services/server/methods/index.js
+++ b/Packages/ohif-dicom-services/server/methods/index.js
@@ -1,0 +1,1 @@
+import './moveRequest.js';

--- a/Packages/ohif-dicom-services/server/methods/moveRequest.js
+++ b/Packages/ohif-dicom-services/server/methods/moveRequest.js
@@ -1,0 +1,27 @@
+import { Meteor } from 'meteor/meteor';
+import { OHIF } from 'meteor/ohif:core';
+
+Meteor.methods({
+    MoveRequest(options) {
+        // Get the server data. This is user-defined in the config.json files or through servers
+        // configuration modal
+        const server = OHIF.servers.getCurrentServer();
+
+        if (!server) {
+            throw new Meteor.Error('improper-server-config', 'No properly configured server was available over DICOMWeb or DIMSE.');
+        }
+
+        try {
+            if (server.type === 'dimse') {
+                console.log("*** Move request, called DIMSE with option *** ", options)
+
+                return DIMSE.moveInstances(options);
+            } else {
+                throw new Meteor.Error('improper-server-config', 'Server is not DIMSE. Must be DIMSE for C-MOVE to work')
+            }
+        } catch (error) {
+            OHIF.log.error(error);
+            OHIF.log.trace();
+        }
+    },
+});

--- a/config/orthancDIMSEproxy.json
+++ b/config/orthancDIMSEproxy.json
@@ -1,0 +1,42 @@
+{
+  "servers": {
+    "dimse": [{
+      "name": "ORTHANC_DIMSE",
+      "wadoUriRoot": "http://localhost:8043/wado",
+      "requestOptions": {
+        "auth": "orthanc:orthanc",
+        "logRequests": true,
+        "logResponses": false,
+        "logTiming": true
+      },
+      "peers": [
+        {
+          "host": "localhost",
+          "port": 4242,
+          "aeTitle": "ORTHANC",
+          "default": true,
+          "server": false
+        },
+        {
+          "host": "0.0.0.0",
+          "port": 11112,
+          "aeTitle": "OHIFDCM",
+          "default": true,
+          "server": true
+        }
+      ]
+    }]
+  },
+  "defaultServiceType": "dimse",
+  "dropCollections": true,
+  "public": {
+    "verifyEmail": false,
+    "ui": {
+        "studyListFunctionsEnabled": true,
+        "leftSidebarOpen": false,
+        "displaySetNavigationLoopOverSeries": false,
+        "displaySetNavigationMultipleViewports": true,
+        "autoPositionMeasurementsTextCallOuts": "TRLB"
+    }
+  }
+}


### PR DESCRIPTION
As discussed in #145, this shows how to use the OHIFViewer and a dicomWeb proxy to emulate true DIMSE functionality. OHIF is fully capable of communicating via DIMSE but cannot receive image data over this protocol. 
The process is shown in the following flow chart:

![DIMSE proxy flowchart](https://user-images.githubusercontent.com/4786811/39818840-28137f60-53a2-11e8-8c8e-27d0263a5a6f.png) 

The main changes to the OHIF code are:
`OHIFViewer/client/routes.js`: Perform a serverside move request of the selected studies to the PACS server before redirecting to the viewer.

`Packages/ohif-dicom-services/server/DIMSE/DIMSE.js`:
1. Force synchronous execution (with `future.wait()`), so the viewer is not rendered before the C-MOVE is done
2. Initiate a C-MOVE request on the STUDY level with the DicomWeb proxy as destination (the destination is hardcoded as of now). 

I have included a new server config file `config/orthancDIMSEproxy.json` for this setup and a `docker-compose.yml` for setting up a dummy PACS and a DicomWeb proxy using Orthanc for testing. 

For testing, follow this workflow:
1. Start OHIFviewer the old way using the included start script in `OHIFViewer/package.json`
2. Start the two orthanc servers with `OHIFViewer/docker-compose.yml`
3. Upload a DICOM series to the "PACS" server at localhost:8042
4. Open OHIFViewer at localhost:3000, this study should now be in the study list (fetched via DIMSE)
5. Double click the study. The study should now have been moved to the DicomWeb proxy server at localhost:8043 and loaded into OHIF via WADO.

