### PR TITLE
feature(custom subtools into toolbar) colormap-custom subtools 

### DIFF
--- a/Packages/ohif-viewerbase/client/components/viewer/toolbarSectionButton/toolbarSectionButton.html
+++ b/Packages/ohif-viewerbase/client/components/viewer/toolbarSectionButton/toolbarSectionButton.html
@@ -3,7 +3,7 @@
         {{>UI.dynamic template=this.buttonTemplateName data=this}}
     {{else}}
         <div id="{{this.id}}" tabindex="1"
-            class="toolbarSectionButton rp-x-1 {{this.classes}} {{activeClass}} {{#if or this.disabled (disableButton)}}disabled{{/if}} {{#if this.subTools}}expandable{{/if}}"
+            class="toolbarSectionButton rp-x-1 {{this.classes}} {{activeClass}} {{#if or this.disabled (disableButton)}}disabled{{/if}} {{#if hasSubTools}}expandable{{/if}}"
             title="{{this.tooltipTitle}}">
             <div class="svgContainer">
                 {{#let svg=svgLink icon=iconClasses}}
@@ -18,18 +18,24 @@
             </div>
             <div class="buttonLabel">
                 <span>{{this.title}}</span>
-                {{#if this.subTools}}
+                {{#if hasSubTools}}
                     <i class="fa fa-caret-down expanded-status" aria-hidden="true"></i>
                 {{/if}}
             </div>
-            {{#if this.subTools}}
+            {{#if hasSubTools}}
                 <div class="toolbarSectionDrawerContainer">
                     <div class="toolbarSectionDrawer">
-                        {{#each subTool in this.subTools}}
-                            {{>toolbarSectionButton subTool}}
-                        {{/each}}
+                        {{#if this.subToolsTemplateName}}
+                            {{>UI.dynamic template=this.subToolsTemplateName data=this}}
+                        {{else}}
+                            {{#if this.subTools}}
+                                {{#each subTool in this.subTools}}
+                                    {{>toolbarSectionButton subTool}}
+                                {{/each}}
+                            {{/if}}
+                        {{/if}}
                     </div>
-                </div>
+                </div>         
             {{/if}}
         </div>
     {{/if}}

--- a/Packages/ohif-viewerbase/client/components/viewer/toolbarSectionButton/toolbarSectionButton.js
+++ b/Packages/ohif-viewerbase/client/components/viewer/toolbarSectionButton/toolbarSectionButton.js
@@ -106,6 +106,10 @@ Template.toolbarSectionButton.helpers({
         const isCommandDisabled = OHIF.commands.isDisabled(instance.data.id);
         const isFunctionDisabled = instance.data.disableFunction && instance.data.disableFunction();
         return isCommandDisabled || isFunctionDisabled;
+    },
+
+    hasSubTools() {
+        return this.subTools || this.subToolsTemplateName;
     }
 });
 
@@ -113,9 +117,12 @@ Template.toolbarSectionButton.events({
     'click .toolbarSectionButton:not(.expandable)'(event, instance) {
         // Prevent the event from bubbling to parent tools
         event.stopPropagation();
+        const $currentTarget = $(event.currentTarget);
 
-        // Stop here if the button is disabled
-        if ($(event.currentTarget).hasClass('disabled')) return;
+        // Stop here if the button is disabled or customAction
+        if ($currentTarget.hasClass('disabled') || $currentTarget.hasClass('customAction')) {
+            return;
+        }
 
         // Run the command attached to the button
         OHIF.commands.run(instance.data.id);


### PR DESCRIPTION
Changing toolBarSection to accept custom template subtools. 
I.e. coder could pass his own template as part of subtools for specific tool button.
