### PR TITLE
Fix importStudies dialog when import fails

### DIFF
--- a/Packages/ohif-study-list/client/lib/importStudies.js
+++ b/Packages/ohif-study-list/client/lib/importStudies.js
@@ -104,7 +104,7 @@ const importStudiesInternal = (studiesToImport, dialog) => {
                     const { numberOfStudiesImported, numberOfStudiesFailed } = studyImportStatus;
                     dialog.update(numberOfStudiesImported);
 
-                    if (numberOfStudiesImported === numberOfStudies) {
+                    if ((numberOfStudiesImported + numberOfStudiesFailed) === numberOfStudies) {
                         //  The entire import operation is completed, so remove the study import status item
                         Meteor.call('removeStudyImportStatus', studyImportStatus._id);
 


### PR DESCRIPTION
If an import happens to fail the dialog promise never resolves. 

This is because `numberOfStudiesFailed` is incremented on error but `numberOfStudiesImported` is not, so the branch  to resolve or reject is never taken.