### PR TITLE
feat(netlify) Add static site deployment from Netlify

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,5 @@
+##### Looking for your Deploy Preview? - <a onclick="function redirect() { window.location.href='/viewer/?url=https://s3.eu-central-1.amazonaws.com/ohif-viewer/sampleDICOM.json'; } redirect();">Deploy Preview for Viewer</a>
+
 # Introduction
 
 The [Open Health Imaging Foundation](https://www.ohif.org) is developing an open source framework for constructing web-based medical imaging applications. The application framework is built using modern HTML / CSS / JavaScript and uses [Cornerstone](https://cornerstonejs.org/) at its core to display and manipulate medical images. It is built with Meteor, a Node.js-based full-stack JavaScript platform.

--- a/docs/package.json
+++ b/docs/package.json
@@ -38,5 +38,8 @@
     "gitbook-plugin-github": "^3.0.0",
     "gitbook-plugin-sitemap": "^1.2.0",
     "gitbook-plugin-theme-cornerstone": "^1.1.1"
+  },
+  "devDependencies": {
+    "gitbook-cli": "^2.3.2"
   }
 }

--- a/generateStaticSite.sh
+++ b/generateStaticSite.sh
@@ -1,0 +1,24 @@
+cd docs
+npm -v
+node -v 
+echo 'Installing Gitbook CLI'
+npm install
+
+echo 'Running Gitbook installation'
+./node_modules/gitbook-cli/bin/gitbook.js install
+./node_modules/gitbook-cli/bin/gitbook.js build
+cd ..
+
+# Build and copy the StandaloneViewer into the static directory
+cd StandaloneViewer
+echo $DEPLOY_PRIME_URL
+export ROOT_URL=$DEPLOY_PRIME_URL:/viewer/
+export METEOR_PACKAGE_DIRS="../../Packages"
+mkdir buildDirectory
+cd StandaloneViewer
+npm install -g meteor-build-client-fixed@0.4.3
+meteor-build-client-fixed --version
+curl https://install.meteor.com | /bin/sh
+export PATH=$HOME/.meteor:$PATH
+meteor npm install
+meteor-build-client-fixed ../../docs/_book/viewer -u $ROOT_URL --path './'

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "dependencies": {},
   "devDependencies": {},
   "scripts": {
-    "test": "./test/testApp.sh"
+    "test": "./test/testApp.sh",
+    "staticDeploy": "./generateStaticSite.sh"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Add /viewer/?url=https://raw.githubusercontent.com/galelis/testData/master/studyWithMeasurements.json

to the Netlify deploy preview URL.

Example: https://deploy-preview-232--ohif.netlify.com/viewer/?url=https://raw.githubusercontent.com/galelis/testData/master/studyWithMeasurements.json

TODO:
- Stop using gh-pages branch to host docs? Use Netlify instead? TBD...