### PR TITLE
Bump version of dcmJS into cornerstone package

### DIFF
--- a/Packages/ohif-cornerstone/package.js
+++ b/Packages/ohif-cornerstone/package.js
@@ -11,7 +11,7 @@ Npm.depends({
     'cornerstone-math': '0.1.6',
     'dicom-parser': '1.8.0',
     'cornerstone-wado-image-loader': '2.1.4',
-    'dcmjs': '0.1.3'
+    'dcmjs': '0.1.5'
 });
 
 Package.onUse(function(api) {


### PR DESCRIPTION
## Bug Fix
- dcmJS was not being transpiled so it was generating an issue on IE11, 0.1.5 dcmJS version has now webpack with babel, so it will fix the issue on IE11 

Closes Issue #258 

