### PR TITLE
BugFix(#183): Avoid adding focus on a viewport that is already activated

### DIFF
--- a/Packages/ohif-viewerbase/client/components/viewer/imageViewerViewport/imageViewerViewport.js
+++ b/Packages/ohif-viewerbase/client/components/viewer/imageViewerViewport/imageViewerViewport.js
@@ -400,7 +400,6 @@ const loadDisplaySetIntoViewport = (data, templateData) => {
             const element = (eventData && eventData.element) || (event && event.currentTarget);
             if (!element) return;
             const $element = $(element);
-            $element.focus();
 
             // Stop here if we don't have eventData set
             if (!eventData) return;
@@ -410,6 +409,8 @@ const loadDisplaySetIntoViewport = (data, templateData) => {
             // If it was, no changes are necessary, so stop here.
             const activeViewportIndex = Session.get('activeViewport');
             if (viewportIndex === activeViewportIndex) return;
+            
+            $element.focus();
 
             OHIF.log.info('imageViewerViewport sendActivationTrigger');
 


### PR DESCRIPTION
## Changes
- Activate focus on element (viewport) only if its not activate already.  

(closes #183)