### PR TITLE
fix(client-only): Fix client-only Server & CurrentServer usage

### DIFF
--- a/OHIFViewer/client/config.js
+++ b/OHIFViewer/client/config.js
@@ -30,3 +30,9 @@ Meteor.startup(function() {
         }
     });
 });
+
+if (Meteor.settings &&
+    Meteor.settings.public &&
+    Meteor.settings.public.clientOnly === true) {
+    Meteor.disconnect();
+}

--- a/OHIFViewer/client/routes.js
+++ b/OHIFViewer/client/routes.js
@@ -1,3 +1,4 @@
+import { Meteor } from "meteor/meteor";
 import { Router } from 'meteor/clinical:router';
 import { OHIF } from 'meteor/ohif:core';
 
@@ -12,7 +13,9 @@ Router.configure({
 //
 // In this case, the developer is required to add Servers and specify
 // a CurrentServer with some other approach (e.g. a separate script).
-if (Meteor.settings.public && Meteor.settings.public.clientOnly !== true) {
+if (Meteor.settings &&
+    Meteor.settings.public &&
+    Meteor.settings.public.clientOnly !== true) {
     Router.waitOn(function() {
         return [
             Meteor.subscribe('servers'),

--- a/Packages/ohif-hanging-protocols/client/protocolStore/defaultStrategy.js
+++ b/Packages/ohif-hanging-protocols/client/protocolStore/defaultStrategy.js
@@ -1,3 +1,5 @@
+import { Meteor } from "meteor/meteor";
+q
 // The ProtocolStore default strategy is used to persist hanging protocols in
 // the MongoDB collection 'HangingProtocols' in the application server.
 
@@ -303,7 +305,9 @@ var clientOnlyStrategy = (function () {
 // If we are running a disconnect client similar to the StandaloneViewer
 // (see https://docs.ohif.org/standalone-viewer/usage.html) we don't want
 // our HangingProtocol strategy to try to use Meteor methods or Pub / Sub
-if (Meteor.settings.public && Meteor.settings.public.clientOnly === true) {
+if (Meteor.settings &&
+    Meteor.settings.public &&
+    Meteor.settings.public.clientOnly === true) {
     HP.ProtocolStore.setStrategy(clientOnlyStrategy);
 } else {
     HP.ProtocolStore.setStrategy(defaultStrategy);

--- a/Packages/ohif-hanging-protocols/client/protocolStore/defaultStrategy.js
+++ b/Packages/ohif-hanging-protocols/client/protocolStore/defaultStrategy.js
@@ -1,5 +1,4 @@
 import { Meteor } from "meteor/meteor";
-q
 // The ProtocolStore default strategy is used to persist hanging protocols in
 // the MongoDB collection 'HangingProtocols' in the application server.
 
@@ -11,11 +10,6 @@ var defaultStrategy = (function () {
         console.log('Inserting default protocols');
 
         addProtocol(HP.defaultProtocol);
-
-        //addProtocol(HP.testProtocol);
-        /* HP.demoProtocols.forEach(protocol => {
-            addProtocol(protocol);
-        });*/
     }
 
     function getDatabaseIdByProtocolId(protocolId) {

--- a/Packages/ohif-servers/both/collections/currentServer.js
+++ b/Packages/ohif-servers/both/collections/currentServer.js
@@ -3,7 +3,7 @@ import { OHIF } from 'meteor/ohif:core';
 
 // CurrentServer is a single document collection to describe which of the Servers is being used
 let collectionName = 'currentServer';
-if (Meteor.settings.public && Meteor.settings.public.clientOnly === true) {
+if (Meteor.settings && Meteor.settings.public && Meteor.settings.public.clientOnly === true) {
     collectionName = null;
 }
 

--- a/Packages/ohif-servers/both/collections/currentServer.js
+++ b/Packages/ohif-servers/both/collections/currentServer.js
@@ -2,7 +2,12 @@ import { Mongo } from 'meteor/mongo';
 import { OHIF } from 'meteor/ohif:core';
 
 // CurrentServer is a single document collection to describe which of the Servers is being used
-const CurrentServer = new Mongo.Collection('currentServer');
+let collectionName = 'currentServer';
+if (Meteor.settings.public && Meteor.settings.public.clientOnly === true) {
+    collectionName = null;
+}
+
+const CurrentServer = new Mongo.Collection(collectionName);
 CurrentServer._debugName = 'CurrentServer';
 OHIF.servers.collections.currentServer = CurrentServer;
 

--- a/Packages/ohif-servers/both/collections/servers.js
+++ b/Packages/ohif-servers/both/collections/servers.js
@@ -3,7 +3,7 @@ import { OHIF } from 'meteor/ohif:core';
 // import { Servers as ServerSchema } from 'meteor/ohif:servers/both/schema/servers.js';
 
 let collectionName = 'servers';
-if (Meteor.settings.public && Meteor.settings.public.clientOnly === true) {
+if (Meteor.settings && Meteor.settings.public && Meteor.settings.public.clientOnly === true) {
     collectionName = null;
 }
 

--- a/Packages/ohif-servers/both/collections/servers.js
+++ b/Packages/ohif-servers/both/collections/servers.js
@@ -2,8 +2,13 @@ import { Mongo } from 'meteor/mongo';
 import { OHIF } from 'meteor/ohif:core';
 // import { Servers as ServerSchema } from 'meteor/ohif:servers/both/schema/servers.js';
 
+let collectionName = 'servers';
+if (Meteor.settings.public && Meteor.settings.public.clientOnly === true) {
+    collectionName = null;
+}
+
 // Servers describe the DICOM servers configurations
-const Servers = new Mongo.Collection('servers');
+const Servers = new Mongo.Collection(collectionName);
 // TODO: Make the Schema match what we are currently sticking into the Collection
 //Servers.attachSchema(ServerSchema);
 Servers._debugName = 'Servers';

--- a/Packages/ohif-servers/client/collections/index.js
+++ b/Packages/ohif-servers/client/collections/index.js
@@ -1,1 +1,0 @@
-import './subscriptions.js';

--- a/Packages/ohif-servers/client/collections/subscriptions.js
+++ b/Packages/ohif-servers/client/collections/subscriptions.js
@@ -1,4 +1,0 @@
-import { Meteor } from 'meteor/meteor';
-
-Meteor.subscribe('servers');
-Meteor.subscribe('currentServer');

--- a/Packages/ohif-servers/client/index.js
+++ b/Packages/ohif-servers/client/index.js
@@ -1,2 +1,2 @@
-import './collections';
+import './startup.js';
 import './components';

--- a/Packages/ohif-servers/client/startup.js
+++ b/Packages/ohif-servers/client/startup.js
@@ -2,7 +2,8 @@
 import { Meteor } from "meteor/meteor";
 import { Servers, CurrentServer } from 'meteor/ohif:servers/both/collections';
 
-if (Meteor.settings.public &&
+if (Meteor.settings &&
+    Meteor.settings.public &&
     Meteor.settings.public.clientOnly === true &&
     Meteor.settings.public.servers) {
     OHIF.log.info('Updating servers information from JSON configuration');

--- a/Packages/ohif-servers/client/startup.js
+++ b/Packages/ohif-servers/client/startup.js
@@ -1,0 +1,31 @@
+// Check the servers on meteor startup
+import { Meteor } from "meteor/meteor";
+import { Servers, CurrentServer } from 'meteor/ohif:servers/both/collections';
+
+if (Meteor.settings.public &&
+    Meteor.settings.public.clientOnly === true &&
+    Meteor.settings.public.servers) {
+    OHIF.log.info('Updating servers information from JSON configuration');
+
+    const servers = Meteor.settings.public.servers;
+
+    Object.keys(servers).forEach((serverType) => {
+        const endpoints = servers[serverType];
+        endpoints.forEach((endpoint) => {
+            const server = Object.assign({}, endpoint);
+            server.origin = 'json';
+            server.type = serverType;
+
+            Servers.insert(server);
+        });
+    });
+
+    const newServer = Servers.findOne();
+
+    CurrentServer.insert({
+        serverId: newServer._id
+    });
+
+    console.log('test');
+}
+

--- a/Packages/ohif-servers/server/startup.js
+++ b/Packages/ohif-servers/server/startup.js
@@ -5,7 +5,8 @@ import { Servers } from 'meteor/ohif:servers/both/collections';
 import { ServerConfiguration } from 'meteor/ohif:servers/both/schema/servers.js';
 
 // Check the servers on meteor startup
-if (Meteor.settings.public &&
+if (Meteor.settings &&
+    Meteor.settings.public &&
     Meteor.settings.public.clientOnly !== true) {
 
     Meteor.startup(function() {

--- a/Packages/ohif-servers/server/startup.js
+++ b/Packages/ohif-servers/server/startup.js
@@ -5,30 +5,34 @@ import { Servers } from 'meteor/ohif:servers/both/collections';
 import { ServerConfiguration } from 'meteor/ohif:servers/both/schema/servers.js';
 
 // Check the servers on meteor startup
-Meteor.startup(function() {
-    OHIF.log.info('Updating servers information from JSON configuration');
+if (Meteor.settings.public &&
+    Meteor.settings.public.clientOnly !== true) {
 
-    _.each(Meteor.settings.servers, function(endpoints, serverType) {
-        _.each(endpoints, function(endpoint) {
-            const server = _.clone(endpoint);
-            server.origin = 'json';
-            server.type = serverType;
+    Meteor.startup(function() {
+        OHIF.log.info('Updating servers information from JSON configuration');
 
-            // Try to find a server with the same name/type/origin combination
-            const existingServer = Servers.findOne({
-                name: server.name,
-                type: server.type,
-                origin: server.origin
+        _.each(Meteor.settings.servers, function(endpoints, serverType) {
+            _.each(endpoints, function(endpoint) {
+                const server = _.clone(endpoint);
+                server.origin = 'json';
+                server.type = serverType;
+
+                // Try to find a server with the same name/type/origin combination
+                const existingServer = Servers.findOne({
+                    name: server.name,
+                    type: server.type,
+                    origin: server.origin
+                });
+
+                // Check if server was already added. Update it if so and insert if not
+                if (existingServer) {
+                    Servers.update(existingServer._id, { $set: server });
+                } else {
+                    Servers.insert(server);
+                }
             });
-
-            // Check if server was already added. Update it if so and insert if not
-            if (existingServer) {
-                Servers.update(existingServer._id, { $set: server });
-            } else {
-                Servers.insert(server);
-            }
         });
-    });
 
-    OHIF.servers.control.resetCurrentServer();
-});
+        OHIF.servers.control.resetCurrentServer();
+    });
+}


### PR DESCRIPTION
Addresses #275

- Add startup.js to copy public.servers into the client Minimongo collection if we are using public.clientOnly = true
- Set CurrentServer and Servers collection to client-only if clientOnly = true
- Call Meteor.disconnect() if we are using clientOnly = true
- Guard If statements requiring Meteor.settings.public, since it was not defined on the Standalone Viewer

