### PR TITLE
Standalone Viewer Authorization Header

### DIFF
--- a/StandaloneViewer/StandaloneViewer/client/config.js
+++ b/StandaloneViewer/StandaloneViewer/client/config.js
@@ -21,4 +21,15 @@ Meteor.startup(function() {
 
     cornerstoneWADOImageLoader.webWorkerManager.initialize(config);
     cornerstoneWebImageLoader.external.cornerstone = cornerstone;
+
+    let configureAuthorization = {
+        beforeSend: function(xhr){
+            if (OHIF.viewer.authorizationToken) {
+                xhr.setRequestHeader('Authorization', OHIF.viewer.authorizationToken);
+            }
+        }
+    };
+
+    cornerstoneWADOImageLoader.configure(configureAuthorization);
+    cornerstoneWebImageLoader.configure(configureAuthorization);
 });

--- a/StandaloneViewer/StandaloneViewer/routes.js
+++ b/StandaloneViewer/StandaloneViewer/routes.js
@@ -94,6 +94,14 @@ if (Meteor.isClient) {
             oReq.open('GET', url);
             oReq.setRequestHeader('Accept', 'application/json')
 
+            // Add token in the request authorization header
+            // if a token fragment parameter is present
+            const tokenParam = this.params.hash ? this.params.hash.match(/(?:token)=(.*?)(?:&|$)/) : null;
+            if (tokenParam) {
+                OHIF.viewer.authorizationToken = "Bearer " + tokenParam[1];
+                oReq.setRequestHeader('Authorization', OHIF.viewer.authorizationToken);
+            }
+
             // Fire the request to the server
             oReq.send();
         },

--- a/docs/standalone-viewer/usage.md
+++ b/docs/standalone-viewer/usage.md
@@ -70,6 +70,16 @@ It is possible to build this standalone viewer to run as a client-only bundle of
 
     Open your web browser and navigate to http://localhost:3000/sampleJPEG.json or http://localhost:3000/sampleDICOM.json
 
+    ## Authorization Header
+
+    A ```token``` fragment parameter can be specified. If present this value will be used for http bearer authorization when making requests for the above JSON, and when retrieving images using the Cornerstone Image Loaders.
+
+    Example :
+
+    ```
+    http://localhost:3000/sampleDICOM.json#token=1a2b3c4d
+    ```
+
 
 ### Testing the Sample client-only build
 For the sake of simplicity we have also included a pre-built client-only version of the standalone viewer, which can be found in the SampleClientOnlyBuild folder.


### PR DESCRIPTION
A token fragment parameter can be specified. If present this value will be used for http bearer authorization when making requests.

A fragment parameter is used instead of a query parameter so that the token is never sent over the network.

Example :
 http://localhost:3000/?url=https://some.website.io/sampleDICOM.json#token=1a2b3c4d

Fixes #140 