### PR TITLE
Update cornerstone libs (wado) to latest and fix Incorrect ultrasound measurement #319

### DIFF
--- a/Packages/ohif-cornerstone/package.js
+++ b/Packages/ohif-cornerstone/package.js
@@ -6,11 +6,11 @@ Package.describe({
 
 Npm.depends({
     hammerjs: '2.0.8',
-    'cornerstone-core': '2.2.7',
+    'cornerstone-core': '2.2.8',
     'cornerstone-tools': '2.4.0',
-    'cornerstone-math': '0.1.6',
-    'dicom-parser': '1.8.0',
-    'cornerstone-wado-image-loader': '2.1.4',
+    'cornerstone-math': '0.1.7',
+    'dicom-parser': '1.8.3',
+    'cornerstone-wado-image-loader': '2.2.3',
     'dcmjs': '0.2.1'
 });
 


### PR DESCRIPTION
Fixed #319 by this update to the cornerstoneWADOImageLoader: 
https://github.com/cornerstonejs/cornerstoneWADOImageLoader/pull/215
