### PR TITLE
Update references to meteor-build-client-fixed to use the new version…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,12 +76,12 @@ jobs:
         - cd StandaloneViewer
         - mkdir buildDirectory
         - cd StandaloneViewer
-        - npm install -g meteor-build-client-fixed@0.4.3
-        - meteor-build-client-fixed --version
+        - npm install -g meteor-build-client-fixed2@0.4.3-b
+        - meteor-build-client-fixed2 --version
         - curl https://install.meteor.com | /bin/sh
         - meteor npm install
       script:
-        - meteor-build-client-fixed ~/standaloneViewerBuild -u $ROOT_URL
+        - meteor-build-client-fixed2 ~/standaloneViewerBuild -u $ROOT_URL --legacy
       after_success:
         - ls ~/standaloneViewerBuild
         - ls /home/travis

--- a/docs/standalone-viewer/usage.md
+++ b/docs/standalone-viewer/usage.md
@@ -29,16 +29,16 @@ http://localhost:3000/testDICOMs
 
 It is possible to build this standalone viewer to run as a client-only bundle of HTML, JavaScript, and CSS.
 
-1. First, install [meteor-build-client-fixed](https://github.com/brettg2/meteor-build-client/).
+1. First, install [meteor-build-client-fixed2](https://www.npmjs.com/package/meteor-build-client-fixed2).
 
   ````bash
-  sudo npm install -g meteor-build-client-fixed
+  sudo npm install -g meteor-build-client-fixed2
   ````
 
 2. Next, build the client bundle into an output folder ("myOutputFolder") with a base URL ("localhost:3000"). In production, this would be the URL where the Viewer is available.
 
   ````
-  METEOR_PACKAGE_DIRS="../../Packages" meteor-build-client-fixed ../myOutputFolder -u localhost:3000
+  METEOR_PACKAGE_DIRS="../../Packages" meteor-build-client-fixed2 ../myOutputFolder -u localhost:3000 --legacy
   ````
 
 3. Test the bundled client-side package locally.

--- a/generateStaticSite.sh
+++ b/generateStaticSite.sh
@@ -16,9 +16,9 @@ export ROOT_URL=$DEPLOY_PRIME_URL:/viewer/
 export METEOR_PACKAGE_DIRS="../../Packages"
 mkdir buildDirectory
 cd StandaloneViewer
-npm install -g meteor-build-client-fixed@0.4.3
-meteor-build-client-fixed --version
+npm install -g meteor-build-client-fixed2@0.4.3-b
+meteor-build-client-fixed2 --version
 curl https://install.meteor.com | /bin/sh
 export PATH=$HOME/.meteor:$PATH
 meteor npm install
-meteor-build-client-fixed ../../docs/_book/viewer -u $ROOT_URL --path './'
+meteor-build-client-fixed2 ../../docs/_book/viewer -u $ROOT_URL --path './' --legacy


### PR DESCRIPTION
… and supporting legacy browsers.

Fix: StandaloneViewer client build doesn't work on Legacy/IE11 browser #333