### PR TITLE
including skip configuration if the push comes from external PR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,8 @@ jobs:
   include:
     - stage: build production docker image
       before_script:
+        - set -e
+        - if [ -z "${DOCKER_PASS}" ]; then echo "Build triggered by external PR. Skipping build production docker image stage" && exit 0; fi    
         - export REPO=ohif/viewer
         - export COMMIT=${TRAVIS_COMMIT::8}
         - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
@@ -49,6 +51,8 @@ jobs:
 
     - stage: build development docker image
       before_script:
+        - set -e
+        - if [ -z "${DOCKER_PASS}" ]; then echo "Build triggered by external PR. Skipping build production docker image stage" && exit 0; fi    
         - export REPO=ohif/viewer-dev
         - export COMMIT=${TRAVIS_COMMIT::8}
         - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)


### PR DESCRIPTION
### What
There is an open issue https://github.com/OHIF/Viewers/issues/340 which is related to when someone does a fork and then open a PR, Travis ignores the encrypted environment variables and breaks the build.

In order to solve that issue, it was added a condition where if the DOCKER_PASS is null it skips the "build development docker image" and "build production docker image" stages.

### Why
"Encrypted environment variables are not available to pull requests from forks due to the security risk of exposing such information to unknown code."