### PR TITLE
adding style to fix viewport maximization

### DIFF
--- a/Packages-react/extensions/ohif-dicom-microscopy-extension/src/DicomMicroscopyViewport.js
+++ b/Packages-react/extensions/ohif-dicom-microscopy-extension/src/DicomMicroscopyViewport.js
@@ -73,7 +73,7 @@ class DicomMicroscopyViewport extends Component {
         {this.state.error ? (
           <h2>{JSON.stringify(this.state.error)}</h2>
         ) : (
-          <div ref={this.container} />
+          <div style={style} ref={this.container} />
         )}
       </div>
     );


### PR DESCRIPTION
### What
Refs in React provides a way to access the React elements (or DOM nodes) created in the render() method. DicomMicroscopyViewport makes use of this strategy to render the container.
`<div ref={this.container} />`
### Why
There is an issue which is that the viewport is not maximizing.