### PR TITLE
Strict versioning for `react-viewerbase`

### DIFF
--- a/Packages-react/ohif-viewer/package.json
+++ b/Packages-react/ohif-viewer/package.json
@@ -121,7 +121,7 @@
     "react-resize-detector": "^3.4.0",
     "react-router": "^4.3.1",
     "react-router-dom": "^4.3.1",
-    "react-viewerbase": "^0.2.11",
+    "react-viewerbase": "0.2.11",
     "react-vtkjs-viewport": "^0.0.7",
     "redux": "^4.0.1",
     "redux-oidc": "^3.1.0"


### PR DESCRIPTION
I couldn't determine if the most recent lock-files have an effective dependency on a more recent version. This may need to be bumped `v0.2.17` if you encounter issues.