### PR TITLE
docs(netlify.toml): Fix Netlify URL path issues for deploy previews

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -15,6 +15,11 @@
 
 # COMMENT: This a rule for Single Page Applications
 [[redirects]]
+  from = "/demo/*"
+  to = "/demo/index.html"
+  status = 200
+
+[[redirects]]
   from = "/*"
   to = "/index.html"
   status = 200


### PR DESCRIPTION
@dlwire, this should fix your Netlify direct link issues.