### PR TITLE
fix(DragNDrop): add new library to handle drag and drop for mobile devices

### DIFF
--- a/src/connectedComponents/FlexboxLayout.css
+++ b/src/connectedComponents/FlexboxLayout.css
@@ -10,8 +10,6 @@
 
 .sidebar-menu {
   height: 100%;
-  /* required transformation to make inner fixed elements relative to this one*/
-  transform: scale(1);
   transition: var(--sidebar-transition);
 }
 


### PR DESCRIPTION
Removed `transform` that was affecting the drag and drop position in the study browser area.