### PR TITLE
docs(netlify): Add Netlify badge to top of docs page

### DIFF
--- a/docs/latest/README.md
+++ b/docs/latest/README.md
@@ -1,4 +1,14 @@
-##### Looking for a Deploy Preview? - <a onclick="function redirect() { window.location.href='/demo/'; } redirect();">Deploy Preview for Viewer</a>
+<div class='row'>
+	<div class='column' style='text-align: right; padding: 0 20px'>
+		<strong>Looking for a Deploy Preview?</strong>
+		<a onclick="function redirect() { window.location.href='/demo/'; } redirect();">Deploy Preview for Viewer</a>
+	</div>
+	<div class='column' style='text-align: left; padding: 0 20px'>
+		<a href="https://www.netlify.com">
+		  <img src="https://www.netlify.com/img/global/badges/netlify-color-bg.svg"/>
+		</a>
+	</div>
+</div>
 
 > ATTENTION! You are looking at the docs for the `React` version of the OHIF
 > Viewer. If you're looking for the `Meteor` version's documentation (now

--- a/docs/latest/package.json
+++ b/docs/latest/package.json
@@ -35,7 +35,7 @@
     "gitbook-plugin-ga": "^2.0.0",
     "gitbook-plugin-github": "^3.0.0",
     "gitbook-plugin-sitemap": "^1.2.0",
-    "gitbook-plugin-theme-cornerstone": "^1.1.2",
+    "gitbook-plugin-theme-cornerstone": "^1.1.4",
     "gitbook-plugin-versions": "^2.1.4"
   },
   "devDependencies": {


### PR DESCRIPTION
We are now on the free open source plan of Netlify, so we need to display the badge prominently on our homepage according to their guidelines. 

Looks like this:
<img width="876" alt="Screenshot 2019-06-26 at 11 48 30" src="https://user-images.githubusercontent.com/607793/60170257-6305de00-9808-11e9-8085-e3906cb2fe5d.png">
