### PR TITLE
fix(docker-google-cloud): Update docker build process for simpler GCP usage

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 # Output
 dist/
+build/
 
 # Dependencies
 node_modules/
@@ -7,6 +8,7 @@ node_modules/
 # Root
 README.md
 Dockerfile
+dockerfile
 
 # Misc. Config
 .git
@@ -14,3 +16,8 @@ Dockerfile
 .gitignore
 .vscode
 .circleci
+
+# Unnecessary things to pull into container
+extensions
+docs
+cypress

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,22 +27,34 @@ FROM node:11.2.0-slim as builder
 RUN mkdir /usr/src/app
 WORKDIR /usr/src/app
 
-ENV PATH /usr/src/app/node_modules/.bin:$PATH
-ENV GENERATE_SOURCEMAP=false
-
 COPY package.json /usr/src/app/package.json
 COPY yarn.lock /usr/src/app/yarn.lock
 
-ADD . /usr/src/app/
+# Run the install before copying the rest of the files
 RUN yarn install
+
+ENV PATH /usr/src/app/node_modules/.bin:$PATH
+ENV GENERATE_SOURCEMAP=false
+ENV REACT_APP_CONFIG=config/default.js
+
+# White list instead of copying the whole directory
+COPY src /usr/src/app/src
+COPY public /usr/src/app/public
+COPY .babelrc /usr/src/app/.babelrc
+COPY .eslintrc /usr/src/app/.eslintrc
+
 RUN yarn run build:web
 
 # Stage 2: Bundle the built application into a Docker container
 # which runs Nginx using Alpine Linux
 FROM nginx:1.15.5-alpine
+RUN apk add --no-cache bash
 RUN rm -rf /etc/nginx/conf.d
 COPY docker/Viewer-v2.x /etc/nginx/conf.d
+COPY docker/Viewer-v2.x/entrypoint.sh /usr/src/
+RUN chmod 777 /usr/src/entrypoint.sh
 COPY --from=builder /usr/src/app/build /usr/share/nginx/html
 EXPOSE 80
 EXPOSE 443
+ENTRYPOINT ["/usr/src/entrypoint.sh"]
 CMD ["nginx", "-g", "daemon off;"]

--- a/docker/Viewer-v2.x/entrypoint.sh
+++ b/docker/Viewer-v2.x/entrypoint.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# If CLIENT_ID is specified, use the google.js configuration with the modified ID
+if [ ! -z "$CLIENT_ID" ]
+  then
+  	echo "Google Cloud Healthcare $CLIENT_ID has been provided: "
+  	echo $CLIENT_ID
+  	echo "Updating config..."
+
+  	# - Use SED to replace the CLIENT_ID that is currently in public/config/google.js
+	sed -i -e "s/YOURCLIENTID.apps.googleusercontent.com/$CLIENT_ID/g" /usr/share/nginx/html/config/google.js
+
+	# - Copy public/config/google.js to overwrite public/config/default.js
+	cp /usr/share/nginx/html/config/google.js /usr/share/nginx/html/config/default.js
+fi
+
+echo "Starting Nginx to serve the OHIF Viewer..."
+
+exec "$@"

--- a/docs/latest/connecting-to-image-archives/google-cloud-healthcare.md
+++ b/docs/latest/connecting-to-image-archives/google-cloud-healthcare.md
@@ -1,11 +1,5 @@
 # Google Cloud Healthcare
 
-> ATTENTION: The original documentation for this integration lives in the legacy
-> `version 1` Meteor documentation. You can
-> [find it here](/history/v1/connecting-to-image-archives/google-cloud-healthcare.html).
-> These docs will mirror the Meteor documentation until our `React`
-> implementation has been updated to work with Google Cloud Healthcare.
-
 > The [Google Cloud Healthcare API](https://cloud.google.com/healthcare/) is a
 > powerful option for storing medical imaging data in the cloud.
 
@@ -16,10 +10,7 @@ store their data in the cloud. It offers an
 [almost-entirely complete DICOMWeb API](https://cloud.google.com/healthcare/docs/dicom)
 which requires tokens generated via the
 [OAuth 2.0 Sign In flow](https://developers.google.com/identity/sign-in/web/sign-in).
-Images can even be transcoded on the fly if this is desired. The Cloud
-Healthcare API is a very attractive option because it allows us to avoid
-deploying the Meteor server entirely. We can just deploy OHIF as a client-only
-static site application.
+Images can even be transcoded on the fly if this is desired.
 
 ## Setup a Google Cloud Healthcare Project
 
@@ -55,70 +46,26 @@ static site application.
 
 ## Run the viewer with your OAuth Client ID
 
-1. Open the `config/oidc-googleCloud.json` file and change `YOURCLIENTID` to
+1. Open the `config/google.js` file and change `YOURCLIENTID` to
    your Client ID value.
-1. Run the OHIF Viewer using the oidc-googleCloud.json configuration file
+1. Run the OHIF Viewer using the config/google.js configuration file
 
 ```bash
 cd OHIFViewer
-METEOR_PACKAGE_DIRS="../Packages" meteor npm install
-METEOR_PACKAGE_DIRS="../Packages" meteor --settings ../config/oidc-googleCloud.json
+yarn install
+REACT_APP_CONFIG=config/google.js yarn run dev
 ```
 
 ## Running via Docker
 
-OHIF is also providing a Docker container which can connect to Google Cloud
-Healthcare with a Client ID which is provided at runtime. This is a very simple
-method to get up and running. Internally, the container is running
-[Nginx](https://nginx.org/) to serve the
-[Standalone Viewer](../standalone-viewer/usage.md).
+The OHIF Viewer Docker container can be connected to Google Cloud
+Healthcare by providing a Client ID at runtime. This is a very simple
+method to get up and running.
 
 1. Install Docker (https://www.docker.com/)
 1. Run the Docker container, providing a Client ID as an environment variable.
    Client IDs look like `xyz.apps.googleusercontent.com`.
 
 ```bash
-docker run --env CLIENT_ID=$CLIENT_ID --publish 3000:80 ohif/viewer-google-cloud:latest
-```
-
-## Building the ohif/viewer-google-cloud Docker Image
-
-The
-[ohif/viewer-google-cloud](https://cloud.docker.com/u/ohif/repository/docker/ohif/viewer-google-cloud)
-Docker image is built as follows. The Dockerfile and nginx.conf are in the
-`/dockersupport/viewer-google-cloud` folder.
-
-1. [Install Meteor](https://www.meteor.com/install)
-1. Clone the repository
-
-```bash
-git clone https://github.com/OHIF/Viewers.git
-cd Viewers
-```
-
-1. Install meteor-build-client-fixed2 so you can build the Standalone Viewer
-
-```bash
-npm install -g meteor-build-client-fixed2
-```
-
-1. Build the Standalone client-only OHIF Viewer
-
-```bash
-cd OHIFViewer/
-METEOR_PACKAGE_DIRS="../Packages" meteor npm install
-METEOR_PACKAGE_DIRS="../Packages" meteor-build-client-fixed2 ../dockersupport/viewer-google-cloud/build -s ../config/oidc.json
-```
-
-1. Build the Docker image
-
-```bash
-cd ../dockersupport/viewer-google-cloud
-docker build -t ohif/viewer-google-cloud .
-```
-
-1. Run the Docker image using an OAuth Client ID
-
-```bash
-docker run --env CLIENT_ID={$someID}.apps.googleusercontent.com --publish 3000:80 ohif/viewer-google-cloud
+docker run --env CLIENT_ID=$CLIENT_ID --publish 3000:80 ohif/viewer:latest
 ```

--- a/public/config/google.js
+++ b/public/config/google.js
@@ -12,7 +12,7 @@ window.config = {
       // ~ REQUIRED
       // Authorization Server URL
       authority: 'https://accounts.google.com',
-      client_id: '99926187585-6nli1cbsf1774f575vj9ti0j7h6ru711.apps.googleusercontent.com', //'YOURCLIENTID.apps.googleusercontent.com',
+      client_id: 'YOURCLIENTID.apps.googleusercontent.com',
       redirect_uri: 'http://localhost:5000/callback', // `OHIFStandaloneViewer.js`
       response_type: 'id_token token',
       scope: 'email profile openid https://www.googleapis.com/auth/cloudplatformprojects.readonly https://www.googleapis.com/auth/cloud-healthcare', // email profile openid


### PR DESCRIPTION
fix(docker-google-cloud): Update docker build process to allow Google Cloud CLIENT_ID to be passed in at runtime, update docs.