### PR TITLE
fix(Viewer): Removes fixed modality and get the one returned from ohif-core

### DIFF
--- a/src/connectedComponents/Viewer.js
+++ b/src/connectedComponents/Viewer.js
@@ -344,7 +344,7 @@ const _mapStudiesToThumbnails = function(studies) {
       if (displaySet.images && displaySet.images.length) {
         imageId = displaySet.images[0].getImageId();
       } else {
-        altImageText = 'SR';
+        altImageText = displaySet.modality;
       }
 
       return {

--- a/src/connectedComponents/Viewer.js
+++ b/src/connectedComponents/Viewer.js
@@ -344,7 +344,7 @@ const _mapStudiesToThumbnails = function(studies) {
       if (displaySet.images && displaySet.images.length) {
         imageId = displaySet.images[0].getImageId();
       } else {
-        altImageText = displaySet.modality;
+        altImageText = displaySet.modality ? displaySet.modality : 'UN';
       }
 
       return {


### PR DESCRIPTION
Instead of using a default modality information for display set, start getting these from ohif-core display set