### PR TITLE
add ArrowAnnotate as an available tool

### DIFF
--- a/src/setupTools.js
+++ b/src/setupTools.js
@@ -219,7 +219,6 @@ export default function setupTools(store) {
     { name: 'StackScrollMultiTouch' },
     {
       name: 'ArrowAnnotate',
-      mouseButtonMasks: [1],
       props: {
         configuration: {
           getMeasurementLocationCallback: toolLabellingFlowCallback,

--- a/src/setupTools.js
+++ b/src/setupTools.js
@@ -217,6 +217,15 @@ export default function setupTools(store) {
     { name: 'ZoomTouchPinch' },
     { name: 'StackScrollMouseWheel' },
     { name: 'StackScrollMultiTouch' },
+    {
+      name: 'ArrowAnnotate',
+      mouseButtonMasks: [1],
+      props: {
+        configuration: {
+          getMeasurementLocationCallback: toolLabellingFlowCallback,
+        },
+      },
+    },
   ];
 
   const onRightClick = getOnRightClickCallback(store);


### PR DESCRIPTION
Adding the ArrowAnnotate tool to the list of supported tools.

We could also add this to the toolbar easily enough but here we go for now.

https://github.com/trustsitka/sitka/issues/3403