### PR TITLE
straw man for cancelling the active draw

### DIFF
--- a/extensions/ohif-cornerstone-extension/src/commandsModule.js
+++ b/extensions/ohif-cornerstone-extension/src/commandsModule.js
@@ -91,59 +91,30 @@ const actions = {
     console.warn('updateDisplaySet: ', direction);
   },
   clearAnnotations: ({ viewports }) => {
-    const element = _getActiveViewportEnabledElement(
-      viewports.viewportSpecificData,
-      viewports.activeViewportIndex
-    );
-    if (!element) {
-      return;
-    }
+    const enabledElement = _getEnabledElement(viewports);
+    const enabledElementToolState = _getElementToolState(enabledElement);
 
-    const enabledElement = cornerstone.getEnabledElement(element);
-    if (!enabledElement || !enabledElement.image) {
-      return;
-    }
+    Object.entries(enabledElementToolState)
+      .forEach(([toolType, toolState]) => {
+        const { data } = toolState;
 
-    const {
-      toolState,
-    } = cornerstoneTools.globalImageIdSpecificToolStateManager;
-    if (
-      !toolState ||
-      toolState.hasOwnProperty(enabledElement.image.imageId) === false
-    ) {
-      return;
-    }
-
-    const imageIdToolState = toolState[enabledElement.image.imageId];
-
-    const measurementsToRemove = [];
-
-    Object.keys(imageIdToolState).forEach(toolType => {
-      const { data } = imageIdToolState[toolType];
-
-      data.forEach(measurementData => {
-        const { _id, lesionNamingNumber, measurementNumber } = measurementData;
-        if (!_id) {
-          return;
-        }
-
-        measurementsToRemove.push({
-          toolType,
-          _id,
-          lesionNamingNumber,
-          measurementNumber,
-        });
+        data
+          .filter(({ _id }) => _id)
+          .forEach(data => _removeMeasurementData(toolType, data));
       });
-    });
+  },
+  cancelActiveDraw: ({ viewports }) => {
+    const enabledElement = _getEnabledElement(viewports);
+    const enabledElementToolState = _getElementToolState(enabledElement);
 
-    measurementsToRemove.forEach(measurementData => {
-      OHIF.measurements.MeasurementHandlers.onRemoved({
-        detail: {
-          toolType: measurementData.toolType,
-          measurementData,
-        },
+    Object.entries(enabledElementToolState)
+      .forEach(([toolType, toolState]) => {
+        const { data } = toolState;
+
+        data
+          .filter(({ _id, active }) => _id && active)
+          .forEach(data => _removeMeasurementData(toolType, data));
       });
-    });
   },
 };
 
@@ -217,6 +188,11 @@ const definitions = {
     storeContexts: [],
     options: {},
   },
+  cancelActiveDraw: {
+    commandFn: actions.cancelActiveDraw,
+    storeContexts: ['viewports'],
+    options: {},
+  }
 };
 
 /**
@@ -226,6 +202,50 @@ const definitions = {
 function _getActiveViewportEnabledElement(viewports, activeIndex) {
   const activeViewport = viewports[activeIndex] || {};
   return activeViewport.dom;
+}
+
+function _getEnabledElement(viewports, activeIndex) {
+  const element = _getActiveViewportEnabledElement(
+    viewports.viewportSpecificData,
+    viewports.activeViewportIndex
+  );
+  if (!element) {
+    return null;
+  }
+
+  const enabledElement = cornerstone.getEnabledElement(element);
+  if (!enabledElement || !enabledElement.image) {
+    return null;
+  }
+
+  return enabledElement;
+}
+
+function _getElementToolState(element) {
+  const { toolState } = cornerstoneTools.globalImageIdSpecificToolStateManager;
+  const { imageId } = element.image;
+
+  if (toolState && toolState.hasOwnProperty(imageId)) {
+    return toolState[imageId];
+  }
+
+  return null;
+}
+
+function _removeMeasurementData(toolType, data) {
+  const { _id, active, lesionNamingNumber, measurementNumber } = data;
+
+  OHIF.measurements.MeasurementHandlers.onRemoved({
+    detail: {
+      toolType,
+      measurementData: {
+        _id,
+        active,
+        lesionNamingNumber,
+        measurementNumber,
+      }
+    },
+  });
 }
 
 export default {


### PR DESCRIPTION
Just wanted to start some discussion here. This is an action and command that cancel the active draw.  I've done some testing and noticed a couple of things:
* Deleting all the active data doesn't stop the draw as mentioned in slack - this doesn't seem to cause any exceptions, just seems to swallow the next mouse click and then start drawing again
* This also deletes the data from the tool under the mouse on hover - apparently those data points are marked as active as well

That said, it seems like both `clearAnnotations` and `cancelActiveDraw` deal heavily in the details of `cornerstoneTools`. I'd like to suggest that we push both of those in to `cornerstoneTools`.

It'll be really helpful for us to have support for cancelling the active draw so it is probable something we'll be able to do and contribute back if there's interest.

Perhaps something like the `clearToolState` here: https://github.com/cornerstonejs/cornerstoneTools/blob/7d67e2a944c8fcd29eae58fdb6935eeaff8516f2/src/stateManagement/toolState.js#L116

https://github.com/trustsitka/sitka/issues/3417