### PR TITLE
Issue 3403 escape cancel

### DIFF
--- a/extensions/ohif-cornerstone-extension/src/commandsModule.js
+++ b/extensions/ohif-cornerstone-extension/src/commandsModule.js
@@ -91,59 +91,30 @@ const actions = {
     console.warn('updateDisplaySet: ', direction);
   },
   clearAnnotations: ({ viewports }) => {
-    const element = _getActiveViewportEnabledElement(
-      viewports.viewportSpecificData,
-      viewports.activeViewportIndex
-    );
-    if (!element) {
-      return;
-    }
+    const enabledElement = _getEnabledElement(viewports);
+    const enabledElementToolState = _getElementToolState(enabledElement);
 
-    const enabledElement = cornerstone.getEnabledElement(element);
-    if (!enabledElement || !enabledElement.image) {
-      return;
-    }
+    Object.entries(enabledElementToolState)
+      .forEach(([toolType, toolState]) => {
+        const { data } = toolState;
 
-    const {
-      toolState,
-    } = cornerstoneTools.globalImageIdSpecificToolStateManager;
-    if (
-      !toolState ||
-      toolState.hasOwnProperty(enabledElement.image.imageId) === false
-    ) {
-      return;
-    }
-
-    const imageIdToolState = toolState[enabledElement.image.imageId];
-
-    const measurementsToRemove = [];
-
-    Object.keys(imageIdToolState).forEach(toolType => {
-      const { data } = imageIdToolState[toolType];
-
-      data.forEach(measurementData => {
-        const { _id, lesionNamingNumber, measurementNumber } = measurementData;
-        if (!_id) {
-          return;
-        }
-
-        measurementsToRemove.push({
-          toolType,
-          _id,
-          lesionNamingNumber,
-          measurementNumber,
-        });
+        data
+          .filter(({ _id }) => _id)
+          .forEach(data => _removeMeasurementData(toolType, data));
       });
-    });
+  },
+  cancelActiveDraw: ({ viewports }) => {
+    const enabledElement = _getEnabledElement(viewports);
+    const enabledElementToolState = _getElementToolState(enabledElement);
 
-    measurementsToRemove.forEach(measurementData => {
-      OHIF.measurements.MeasurementHandlers.onRemoved({
-        detail: {
-          toolType: measurementData.toolType,
-          measurementData,
-        },
+    Object.entries(enabledElementToolState)
+      .forEach(([toolType, toolState]) => {
+        const { data } = toolState;
+
+        data
+          .filter(({ _id, active }) => _id && active)
+          .forEach(data => _removeMeasurementData(toolType, data));
       });
-    });
   },
 };
 
@@ -217,6 +188,11 @@ const definitions = {
     storeContexts: [],
     options: {},
   },
+  cancelActiveDraw: {
+    commandFn: actions.cancelActiveDraw,
+    storeContexts: ['viewports'],
+    options: {},
+  }
 };
 
 /**
@@ -226,6 +202,50 @@ const definitions = {
 function _getActiveViewportEnabledElement(viewports, activeIndex) {
   const activeViewport = viewports[activeIndex] || {};
   return activeViewport.dom;
+}
+
+function _getEnabledElement(viewports, activeIndex) {
+  const element = _getActiveViewportEnabledElement(
+    viewports.viewportSpecificData,
+    viewports.activeViewportIndex
+  );
+  if (!element) {
+    return null;
+  }
+
+  const enabledElement = cornerstone.getEnabledElement(element);
+  if (!enabledElement || !enabledElement.image) {
+    return null;
+  }
+
+  return enabledElement;
+}
+
+function _getElementToolState(element) {
+  const { toolState } = cornerstoneTools.globalImageIdSpecificToolStateManager;
+  const { imageId } = element.image;
+
+  if (toolState && toolState.hasOwnProperty(imageId)) {
+    return toolState[imageId];
+  }
+
+  return null;
+}
+
+function _removeMeasurementData(toolType, data) {
+  const { _id, active, lesionNamingNumber, measurementNumber } = data;
+
+  OHIF.measurements.MeasurementHandlers.onRemoved({
+    detail: {
+      toolType,
+      measurementData: {
+        _id,
+        active,
+        lesionNamingNumber,
+        measurementNumber,
+      }
+    },
+  });
 }
 
 export default {

--- a/src/OHIFStandaloneViewer.js
+++ b/src/OHIFStandaloneViewer.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { withRouter, matchPath } from 'react-router';
 import { Route, Switch } from 'react-router-dom';
 import { NProgress } from '@tanem/react-nprogress';
-import { CSSTransition } from 'react-transition-group';
+// import { CSSTransition } from 'react-transition-group';
 import { connect } from 'react-redux';
 import { ViewerbaseDragDropContext } from 'react-viewerbase';
 // import asyncComponent from './components/AsyncComponent.js'
@@ -159,22 +159,22 @@ class OHIFStandaloneViewer extends Component {
         {!noMatchingRoutes &&
           routes.map(({ path, Component }) => (
             <Route key={path} exact path={path}>
-              {({ match }) => (
-                <CSSTransition
-                  in={match !== null}
-                  timeout={300}
-                  classNames="fade"
-                  unmountOnExit
-                  onEnter={() => {
-                    this.setState({ isLoading: true });
-                  }}
-                  onEntered={() => {
-                    this.setState({ isLoading: false });
-                  }}
-                >
-                  {match === null ? <></> : <Component match={match} />}
-                </CSSTransition>
-              )}
+              {({ match }) =>
+                // <CSSTransition
+                //   in={match !== null}
+                //   timeout={300}
+                //   classNames="fade"
+                //   unmountOnExit
+                //   onEnter={() => {
+                //     this.setState({ isLoading: true });
+                //   }}
+                //   onEntered={() => {
+                //     this.setState({ isLoading: false });
+                //   }}
+                // >
+                match === null ? <></> : <Component match={match} />
+                // </CSSTransition>
+              }
             </Route>
           ))}
         {noMatchingRoutes && <NotFound />}

--- a/src/components/Labelling/LabellingTransition.js
+++ b/src/components/Labelling/LabellingTransition.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { CSSTransition } from 'react-transition-group';
+// import { CSSTransition } from 'react-transition-group';
 
 import './LabellingTransition.css';
 
@@ -17,15 +17,15 @@ export default class LabellingTransition extends Component {
   };
   render() {
     return (
-      <CSSTransition
-        in={this.props.displayComponent}
-        appear={transitionOnAppear}
-        timeout={transitionDuration}
-        classNames={transitionClassName}
-        onExited={this.props.onTransitionExit}
-      >
-        {this.props.children}
-      </CSSTransition>
+      // <CSSTransition
+      //   in={this.props.displayComponent}
+      //   appear={transitionOnAppear}
+      //   timeout={transitionDuration}
+      //   classNames={transitionClassName}
+      //   onExited={this.props.onTransitionExit}
+      // >
+      this.props.children
+      // </CSSTransition>
     );
   }
 }


### PR DESCRIPTION
This adds the escape to cancel behavior. It's not perfect but it's better. The right way to fix this is to push clearAnnotations and cancelActiveDraw into cornerstoneTools. I've got a PR opened there to discuss https://github.com/OHIF/Viewers/pull/676

Contributes to https://github.com/trustsitka/sitka/issues/3403