### PR TITLE
fix(package.json): Bump @ohif/vtk-extension usage to fix picking-rela…

### DIFF
--- a/extensions/ohif-vtk-extension/yarn.lock
+++ b/extensions/ohif-vtk-extension/yarn.lock
@@ -5519,10 +5519,10 @@ react-viewerbase@^0.15.1:
     react-i18next "^10.11.0"
     react-with-direction "1.3.0"
 
-react-vtkjs-viewport@0.0.9:
-  version "0.0.9"
-  resolved "https://registry.yarnpkg.com/react-vtkjs-viewport/-/react-vtkjs-viewport-0.0.9.tgz#da79aa66f52dcd731bcc5abd2587cbb120a25331"
-  integrity sha512-VwRCY2DPxWMhix4v3PAtdENp3U1p+Z9nKf1Ch5+KWRKF6fWeA+B2glYKMYNpPnP4bULzVz9iwV+Zeojt3gEibA==
+react-vtkjs-viewport@0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/react-vtkjs-viewport/-/react-vtkjs-viewport-0.0.10.tgz#5a33da4703686278e5b52739cfc8c45d12fc51a2"
+  integrity sha512-UaxZrzkUxTZ8J7aDV1cLpWEINCnvefEhBC4UkHTkyLAEZ8eFx5bbKk/RvTZFZmatP5VurMPc5YDyEgvUt9/9qA==
   dependencies:
     moment "^2.24.0"
 
@@ -6974,10 +6974,10 @@ void-elements@^2.0.1:
   resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-2.0.1.tgz#c066afb582bb1cb4128d60ea92392e94d5e9dbec"
   integrity sha1-wGavtYK7HLQSjWDqkjkulNXp2+w=
 
-vtk.js@^8.11.0:
-  version "8.11.1"
-  resolved "https://registry.yarnpkg.com/vtk.js/-/vtk.js-8.11.1.tgz#cdf69705a72a2a3ce76d7442d1b3903e3de770d4"
-  integrity sha512-Y5ZCFtoMOuuJt44fyj91Gqeg9ZeCQovyoJlEHG1oUHLPehQTvq0oW09WqBcxVSdiv92x3aXYWtgZjm/s4EWw7Q==
+vtk.js@^8.13.0:
+  version "8.13.0"
+  resolved "https://registry.yarnpkg.com/vtk.js/-/vtk.js-8.13.0.tgz#d22bbe3403d86f979703506f9be83ab8e5099248"
+  integrity sha512-uoq2U0Yu2XjuKeeduuGRXlphHR6cdIvtZ5useNMJ8FobK9dpeFTT4ncoyPXx77KvwOMSueT8W+ngm/e9+FGZtA==
   dependencies:
     base64-js "1.2.1"
     blueimp-md5 "2.10.0"

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "@ohif/extension-dicom-html": "0.0.3",
     "@ohif/extension-dicom-microscopy": "0.0.9",
     "@ohif/extension-dicom-pdf": "0.0.7",
-    "@ohif/extension-vtk": "0.1.3",
+    "@ohif/extension-vtk": "0.1.4",
     "@ohif/i18n": "0.2.2",
     "@tanem/react-nprogress": "^1.1.25",
     "classnames": "^2.2.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1273,14 +1273,14 @@
     classnames "^2.2.6"
     lodash.isequal "^4.5.0"
 
-"@ohif/extension-vtk@0.1.3":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@ohif/extension-vtk/-/extension-vtk-0.1.3.tgz#21e27ef088a62ed25d5c62c871cefd0194b9c0b1"
-  integrity sha512-ZqX44/Wolhne1luAlZBTkSZ32Ox/ef3qbh87fGOLq8HAiG1Ae9or8pEfhLmz3ZBxxgW7hiQauCc4Wcu/L6B9GQ==
+"@ohif/extension-vtk@0.1.4":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@ohif/extension-vtk/-/extension-vtk-0.1.4.tgz#4ed691d0217693adef58f69ce2c57b62eb5747ed"
+  integrity sha512-K0SHpfDVMX4uBgPzMXu9Z1cQ6+A9pval6acWRERv0fBJWFAhBAinAk3R3RN/E8F8gmV4cgnIH7SLa9qibQr/Aw==
   dependencies:
     "@babel/runtime" "^7.4.5"
-    react-vtkjs-viewport "0.0.9"
-    vtk.js "^8.11.0"
+    react-vtkjs-viewport "0.0.10"
+    vtk.js "^8.13.0"
 
 "@ohif/i18n@0.2.1":
   version "0.2.1"
@@ -12719,10 +12719,10 @@ react-viewerbase@0.17.0:
     react-i18next "^10.11.0"
     react-with-direction "1.3.0"
 
-react-vtkjs-viewport@0.0.9:
-  version "0.0.9"
-  resolved "https://registry.yarnpkg.com/react-vtkjs-viewport/-/react-vtkjs-viewport-0.0.9.tgz#da79aa66f52dcd731bcc5abd2587cbb120a25331"
-  integrity sha512-VwRCY2DPxWMhix4v3PAtdENp3U1p+Z9nKf1Ch5+KWRKF6fWeA+B2glYKMYNpPnP4bULzVz9iwV+Zeojt3gEibA==
+react-vtkjs-viewport@0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/react-vtkjs-viewport/-/react-vtkjs-viewport-0.0.10.tgz#5a33da4703686278e5b52739cfc8c45d12fc51a2"
+  integrity sha512-UaxZrzkUxTZ8J7aDV1cLpWEINCnvefEhBC4UkHTkyLAEZ8eFx5bbKk/RvTZFZmatP5VurMPc5YDyEgvUt9/9qA==
   dependencies:
     moment "^2.24.0"
 
@@ -15600,7 +15600,7 @@ void-elements@^2.0.1:
   resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-2.0.1.tgz#c066afb582bb1cb4128d60ea92392e94d5e9dbec"
   integrity sha1-wGavtYK7HLQSjWDqkjkulNXp2+w=
 
-vtk.js@^8.11.0:
+vtk.js@^8.13.0:
   version "8.13.0"
   resolved "https://registry.yarnpkg.com/vtk.js/-/vtk.js-8.13.0.tgz#d22bbe3403d86f979703506f9be83ab8e5099248"
   integrity sha512-uoq2U0Yu2XjuKeeduuGRXlphHR6cdIvtZ5useNMJ8FobK9dpeFTT4ncoyPXx77KvwOMSueT8W+ngm/e9+FGZtA==


### PR DESCRIPTION
…ted performance issue

This disables picking on the widget manager before attaching it to the renderer. That way, if painting is disabled the picking code is avoided. It removes a lot of unnecessary cycles during the VTK component usage.