### PR TITLE
feat(commandsModule): Add `previousImage` and `nextImage` actions and commands

### DIFF
--- a/extensions/ohif-cornerstone-extension/src/commandsModule.js
+++ b/extensions/ohif-cornerstone-extension/src/commandsModule.js
@@ -1,6 +1,7 @@
 import cornerstone from 'cornerstone-core';
 import cornerstoneTools from 'cornerstone-tools';
 import OHIF from 'ohif-core';
+const scroll = cornerstoneTools.import('util/scroll');
 
 const actions = {
   rotateViewport: ({ viewports, rotation }) => {
@@ -151,7 +152,7 @@ const actions = {
       viewports.activeViewportIndex
     );
 
-    cornerstoneTools.scroll(enabledElement, 1);
+    scroll(enabledElement, 1);
   },
   previousImage: ({ viewports }) => {
     const enabledElement = _getActiveViewportEnabledElement(
@@ -159,7 +160,7 @@ const actions = {
       viewports.activeViewportIndex
     );
 
-    cornerstoneTools.scroll(enabledElement, -1);
+    scroll(enabledElement, -1);
   }
 };
 

--- a/extensions/ohif-cornerstone-extension/src/commandsModule.js
+++ b/extensions/ohif-cornerstone-extension/src/commandsModule.js
@@ -145,6 +145,22 @@ const actions = {
       });
     });
   },
+  nextImage: ({ viewports }) => {
+    const enabledElement = _getActiveViewportEnabledElement(
+      viewports.viewportSpecificData,
+      viewports.activeViewportIndex
+    );
+
+    cornerstoneTools.scroll(enabledElement, 1);
+  },
+  previousImage: ({ viewports }) => {
+    const enabledElement = _getActiveViewportEnabledElement(
+      viewports.viewportSpecificData,
+      viewports.activeViewportIndex
+    );
+
+    cornerstoneTools.scroll(enabledElement, -1);
+  }
 };
 
 const definitions = {
@@ -198,7 +214,16 @@ const definitions = {
     storeContexts: ['viewports'],
     options: {},
   },
-  // TODO: Next/Previous image
+  nextImage: {
+    commandFn: actions.nextImage,
+    storeContexts: ['viewports'],
+    options: {},
+  },
+  previousImage: {
+    commandFn: actions.previousImage,
+    storeContexts: ['viewports'],
+    options: {},
+  },
   // TODO: First/Last image
   // Next/Previous series/DisplaySet
   nextViewportDisplaySet: {

--- a/public/config/default.js
+++ b/public/config/default.js
@@ -54,8 +54,8 @@ window.config = {
     { commandName: 'fitViewportToWindow', label: 'Zoom to Fit', keys: ['='] },
     { commandName: 'resetViewport', label: 'Reset', keys: ['space'] },
     // clearAnnotations
-    // nextImage
-    // previousImage
+		{ commandName: 'nextImage', label: 'Next Image', keys: ['up'] },
+		{ commandName: 'previousImage', label: 'Previous Image', keys: ['down'] },
     // firstImage
     // lastImage
     {

--- a/public/config/default.js
+++ b/public/config/default.js
@@ -54,8 +54,8 @@ window.config = {
     { commandName: 'fitViewportToWindow', label: 'Zoom to Fit', keys: ['='] },
     { commandName: 'resetViewport', label: 'Reset', keys: ['space'] },
     // clearAnnotations
-		{ commandName: 'nextImage', label: 'Next Image', keys: ['up'] },
-		{ commandName: 'previousImage', label: 'Previous Image', keys: ['down'] },
+    { commandName: 'nextImage', label: 'Next Image', keys: ['up'] },
+    { commandName: 'previousImage', label: 'Previous Image', keys: ['down'] },
     // firstImage
     // lastImage
     {


### PR DESCRIPTION
This change adds the keybindings for previousImage (down) and nextImage (up) to the default
configuration and adds the command and action necessary to support it. This pull request is
dependent upon https://github.com/cornerstonejs/cornerstoneTools/pull/1025 which exports the scroll
utility it uses.

Depends on https://github.com/cornerstonejs/cornerstoneTools/pull/1025

Contributes to https://github.com/trustsitka/sitka/issues/3426