### PR TITLE
fix(package.json): Resolve react/react-dom dependency conflict for embedded users

### DIFF
--- a/cypress/support/script-tag/index.html
+++ b/cypress/support/script-tag/index.html
@@ -25,6 +25,10 @@
 
   <div id="root"></div>
 
+  <!-- Load React. -->
+  <script crossorigin src="https://unpkg.com/react@16/umd/react.production.min.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@16/umd/react-dom.production.min.js"></script>
+
   <script src="/dist/index.umd.js" crossorigin></script>
   <script>
     window.config = {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,10 @@
       "path": "./node_modules/cz-conventional-changelog"
     }
   },
+  "peerDependencies": {
+    "react": "^16.8.6",
+    "react-dom": "^16.8.6"
+  },
   "dependencies": {
     "@babel/runtime": "^7.4.5",
     "@ohif/extension-cornerstone": "0.0.43",
@@ -97,8 +101,6 @@
     "ohif-core": "0.10.6",
     "oidc-client": "1.8.x",
     "prop-types": "^15.7.2",
-    "react": "^16.8.6",
-    "react-dom": "^16.8.6",
     "react-dropzone": "^10.1.5",
     "react-i18next": "^10.11.0",
     "react-redux": "^7.1.0",
@@ -144,6 +146,8 @@
     "lodash": "4.17.11",
     "lodash.clonedeep": "4.5.0",
     "prettier": "1.18.x",
+    "react": "^16.8.6",
+    "react-dom": "^16.8.6",
     "react-scripts": "^3.0.1",
     "rollup": "^1.15.5",
     "rollup-plugin-babel": "^4.3.2",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -12,6 +12,11 @@ import builtins from 'rollup-plugin-node-builtins'
 import replace from 'rollup-plugin-replace';
 import serve from 'rollup-plugin-serve'
 
+const globals = {
+  react: 'React',
+  'react-dom': 'ReactDOM',
+};
+
 const startServer = process.env.START_SERVER === 'true';
 
 export default {
@@ -24,12 +29,14 @@ export default {
       exports: 'named',
       name: 'OHIFStandaloneViewer',
       esModule: false,
+      globals,
     },
     {
       file: pkg.module,
       format: 'es',
       exports: 'named',
       sourcemap: true,
+      globals,
     },
   ],
   plugins: [


### PR DESCRIPTION
Some of the recent changes around the script-tag support for ohif/Viewers included moving `react` and `react-dom` from `peerDependencies` to `dependencies`. This caused an error for embedded consumers of the viewer because there could be multiple versions of react included. 

The error in the console points to this link: https://reactjs.org/warnings/invalid-hook-call-warning.html.

These changes are necessary to resolve the issue for embedded users and don't seem to break the standalone version either.