### PR TITLE
fix(ConnectedCornerstoneViewport): Fix definition of function map so it happens less frequently

### DIFF
--- a/extensions/ohif-cornerstone-extension/src/ConnectedCornerstoneViewport.js
+++ b/extensions/ohif-cornerstone-extension/src/ConnectedCornerstoneViewport.js
@@ -4,6 +4,21 @@ import { connect } from 'react-redux';
 import throttle from 'lodash.throttle';
 
 const { setViewportActive, setViewportSpecificData } = OHIF.redux.actions;
+const {
+  onAdded,
+  onRemoved,
+  onModified,
+} = OHIF.measurements.MeasurementHandlers;
+
+// TODO: Transition to enums for the action names so that we can ensure they stay up to date
+// everywhere they're used.
+const MEASUREMENT_ACTION_MAP = {
+  'added': onAdded,
+  'removed': onRemoved,
+  'modified': throttle(event => {
+    return onModified(event);
+  }, 300),
+}
 
 const mapStateToProps = (state, ownProps) => {
   let dataFromStore;
@@ -71,20 +86,7 @@ const mapDispatchToProps = (dispatch, ownProps) => {
     },
 
     onMeasurementsChanged: (event, action) => {
-      const {
-        onAdded,
-        onRemoved,
-        onModified,
-      } = OHIF.measurements.MeasurementHandlers;
-      const actions = {
-        added: onAdded,
-        removed: onRemoved,
-        modified: throttle(event => {
-          return onModified(event);
-        }, 300),
-      };
-
-      return actions[action](event);
+      return MEASUREMENT_ACTION_MAP[action](event);
     },
   };
 };


### PR DESCRIPTION
`onMeasurementsChanged` currently defines a function map every time it is called. This function map includes a throttle on the `modified` function which is not being used because the function is
called at most once per time it is instantiated. These changes elevate the map definition to the
file level, since what it is defining does not change based on the other executed code.

This cleans up the code a little bit, but more importantly because the `throttle` is now working as intended, the performance of the "Measurements" pane is improved.