### PR TITLE
fix: 🐛 Activating Pan and Zoom on right and middle click by def

### DIFF
--- a/platform/viewer/src/setupTools.js
+++ b/platform/viewer/src/setupTools.js
@@ -142,8 +142,8 @@ function getResetLabellingAndContextMenu(store) {
 export default function setupTools(store) {
   const toolLabellingFlowCallback = getToolLabellingFlowCallback(store);
   const availableTools = [
-    { name: 'Pan', mouseButtonMasks: [4] },
-    { name: 'Zoom', mouseButtonMasks: [2] },
+    { name: 'Pan', mouseButtonMasks: [1, 4] },
+    { name: 'Zoom', mouseButtonMasks: [1, 2] },
     { name: 'Wwwc', mouseButtonMasks: [1] },
     { name: 'Magnify' },
     { name: 'WwwcRegion' },


### PR DESCRIPTION
Issue:
- Pan and Zoom tools should be activated by default on right and middle click respectively. 

Cause: 
- `react-cornerstone-tools` will only activate tools that are left button (1) tools and also have another button mask. 

Fix: 
- Changing `mouseButtonMask` adding button 1 into mask array.