### PR TITLE
Fixed broken link to roadmap

### DIFF
--- a/.github/ISSUE_TEMPLATE/---feature-request.md
+++ b/.github/ISSUE_TEMPLATE/---feature-request.md
@@ -8,9 +8,9 @@ assignees: ''
 
 <!-- ## Awesome, do you have an idea? 😍
 
-If you have a **feature request, improvement or idea**, check [our official roadmap](https://github.com/OHIF/react-viewerbase/projects) to see if it is already planned! -->
+If you have a **feature request, improvement or idea**, check [our official roadmap](https://ohif.canny.io/) to see if it is already planned! -->
 
-<!-- ### 👉 &nbsp; [Go to Roadmap](https://github.com/OHIF/react-viewerbase/projects)
+<!-- ### 👉 &nbsp; [Go to Roadmap](https://ohif.canny.io/)
 
 If your feature request isn't there, continue with this issue and we can discuss
 it 🤟 -->


### PR DESCRIPTION
Git commit message:
"This link was broken after the monorepo update. I found the new link to https://ohif.canny.io/ by googling."

In an outstanding display of version control coverage. The template for issue reporting is in the git repo, as a reward for such a feat, enjoy this free pull request.