### PR TITLE
fix: 🐛 Fix issue on not loading gcloud

### DIFF
--- a/platform/viewer/src/App.js
+++ b/platform/viewer/src/App.js
@@ -83,7 +83,7 @@ class App extends Component {
   constructor(props) {
     super(props);
 
-    this.appConfig = props;
+    this._appConfig = props;
     const { servers, extensions, hotkeys, oidc } = props;
 
     this.initUserManager(oidc);


### PR DESCRIPTION
Fixed issue on not loading gcloud. Error on name variable declaration

### Included items
The correct name variable is _appConfig and not appConfig