### PR TITLE
fix: Stop adding empty labelmap to VTK Viewports for now. 

### DIFF
--- a/extensions/vtk/src/OHIFVTKViewport.js
+++ b/extensions/vtk/src/OHIFVTKViewport.js
@@ -233,9 +233,11 @@ class OHIFVTKViewport extends Component {
       frameIndex
     );
 
-    if (!labelmap) {
+    // TODO: Temporarily disabling this since it is not yet
+    // being used and hurts performance significantly.
+    /*if (!labelmap) {
       labelmap = createLabelMapImageData(data);
-    }
+    }*/
 
     const volumeActor = this.getOrCreateVolume(data, displaySetInstanceUid);
 


### PR DESCRIPTION
Wait until paint tools are implemented