### PR TITLE
ui fix: Made mpr more accessible from toolbar.

### DIFF
--- a/platform/viewer/src/connectedComponents/ConnectedPluginSwitch.js
+++ b/platform/viewer/src/connectedComponents/ConnectedPluginSwitch.js
@@ -38,18 +38,13 @@ const mergeProps = (propsFromState, propsFromDispatch, ownProps) => {
 
   // TODO: Do not display certain options if the current display set
   // cannot be displayed using these view types
-  const button =
-    {
-      label: "2D MPR",
-      icon: "cube",
-      onClick: () => {
+  const mpr = () => {
         commandsManager.runCommand("mpr2d");
       }
-    }
   ;
 
   return {
-    button
+    mpr
   };
 };
 

--- a/platform/viewer/src/connectedComponents/ConnectedPluginSwitch.js
+++ b/platform/viewer/src/connectedComponents/ConnectedPluginSwitch.js
@@ -38,48 +38,7 @@ const mergeProps = (propsFromState, propsFromDispatch, ownProps) => {
 
   // TODO: Do not display certain options if the current display set
   // cannot be displayed using these view types
-  const buttons = [
-    /*{
-      text: 'Acquired',
-      type: 'command',
-      icon: 'bars',
-      active: false,
-      onClick: () => {
-        console.warn('Original Acquisition');
-
-        const layoutData = setSingleLayoutData(
-          layout.viewports,
-          activeViewportIndex,
-          { plugin: 'cornerstone' }
-        );
-
-        setLayout({ viewports: layoutData });
-      },
-    },
-    {
-      text: 'Axial',
-      icon: 'cube',
-      active: false,
-      onClick: () => {
-        commandsManager.runCommand('axial');
-      },
-    },
-    {
-      text: 'Sagittal',
-      icon: 'cube',
-      active: false,
-      onClick: () => {
-        commandsManager.runCommand('sagittal');
-      },
-    },
-    {
-      text: 'Coronal',
-      icon: 'cube',
-      active: false,
-      onClick: () => {
-        commandsManager.runCommand('coronal');
-      },
-    },*/
+  const button =
     {
       label: "2D MPR",
       icon: "cube",
@@ -87,10 +46,10 @@ const mergeProps = (propsFromState, propsFromDispatch, ownProps) => {
         commandsManager.runCommand("mpr2d");
       }
     }
-  ];
+  ;
 
   return {
-    buttons
+    button
   };
 };
 

--- a/platform/viewer/src/connectedComponents/PluginSwitch.js
+++ b/platform/viewer/src/connectedComponents/PluginSwitch.js
@@ -1,11 +1,11 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { ExpandableToolMenu } from '@ohif/ui';
+import { ToolbarButton } from '@ohif/ui';
 import './PluginSwitch.css';
 
 class PluginSwitch extends Component {
   static propTypes = {
-    buttons: PropTypes.array,
+    button: PropTypes.any,
   };
 
   static defaultProps = {};
@@ -13,7 +13,9 @@ class PluginSwitch extends Component {
   render() {
     return (
       <div className="PluginSwitch">
-        <ExpandableToolMenu buttons={this.props.buttons} label={'View'} />
+        <ToolbarButton       label = "2D MPR"
+                             icon = "cube"
+                             onClick = {this.props.button.onClick} />
       </div>
     );
   }

--- a/platform/viewer/src/connectedComponents/PluginSwitch.js
+++ b/platform/viewer/src/connectedComponents/PluginSwitch.js
@@ -5,7 +5,7 @@ import './PluginSwitch.css';
 
 class PluginSwitch extends Component {
   static propTypes = {
-    button: PropTypes.any,
+    mpr: PropTypes.func,
   };
 
   static defaultProps = {};
@@ -15,7 +15,7 @@ class PluginSwitch extends Component {
       <div className="PluginSwitch">
         <ToolbarButton       label = "2D MPR"
                              icon = "cube"
-                             onClick = {this.props.button.onClick} />
+                             onClick = {this.props.mpr} />
       </div>
     );
   }


### PR DESCRIPTION
The Toolbar was showing 2 expandable buttons with an "etc..." icon, one of them had only 1 button, MPR.

This way, mpr is better accessible with fewer clicks to get to it.

Codewise, I removed some commented out code (don't worry, git will remember), and reduced the amount of state shared between 2 components to the bare minimum.