### PR TITLE
OHIF-1002 Study lazy load should be true by default

### DIFF
--- a/platform/core/src/studies/services/wado/retrieveMetadata.js
+++ b/platform/core/src/studies/services/wado/retrieveMetadata.js
@@ -469,7 +469,7 @@ async function createStudyFromSOPInstanceList(server, sopInstanceList) {
  * @returns {Object} A study descriptor object
  */
 async function RetrieveMetadata(server, studyInstanceUid) {
-  return (server.enableStudyLazyLoad
+  return (server.enableStudyLazyLoad !== false
     ? lazyLoadStudyMetadata
     : loadStudyMetadata)(server, studyInstanceUid);
 }


### PR DESCRIPTION
Simple change to make sure lazy study metadata load is enabled by default.