### PR TITLE
feat: 🎸 Only allow reconstruction of datasets that make sense

### DIFF
--- a/platform/core/src/classes/metadata/StudyMetadata.js
+++ b/platform/core/src/classes/metadata/StudyMetadata.js
@@ -621,7 +621,15 @@ const makeDisplaySet = (series, instances) => {
     imageSet.getImage(0).getRawValue('x00200013')
   );
 
-  imageSet.isReconstructable = isDisplaySetReconstructable(series, instances);
+  const isReconstructable = isDisplaySetReconstructable(series, instances);
+
+  imageSet.isReconstructable = isReconstructable.value;
+
+  if (isReconstructable.missingFrames) {
+    // TODO -> This is currently unused, but may be used for reconstructing
+    // Volumes with gaps later on.
+    imageSet.missingFrames = isReconstructable.missingFrames;
+  }
 
   return imageSet;
 };

--- a/platform/core/src/classes/metadata/StudyMetadata.js
+++ b/platform/core/src/classes/metadata/StudyMetadata.js
@@ -9,6 +9,7 @@ import { SeriesMetadata } from './SeriesMetadata';
 import { api } from 'dicomweb-client';
 // - createStacks
 import { isImage } from '../../utils/isImage';
+import isDisplaySetReconstructable from '../../utils/isDisplaySetReconstructable';
 import isLowPriorityModality from '../../utils/isLowPriorityModality';
 
 export class StudyMetadata extends Metadata {
@@ -619,6 +620,8 @@ const makeDisplaySet = (series, instances) => {
     'instanceNumber',
     imageSet.getImage(0).getRawValue('x00200013')
   );
+
+  imageSet.isReconstructable = isDisplaySetReconstructable(series, instances);
 
   return imageSet;
 };

--- a/platform/core/src/utils/isDisplaySetReconstructable.js
+++ b/platform/core/src/utils/isDisplaySetReconstructable.js
@@ -1,0 +1,106 @@
+export default function isDisplaySetReconstructable(series, instances) {
+  debugger;
+
+  // Can't reconstruct if we only have one image.
+  if (instances.length === 1) {
+    return false;
+  }
+
+  const firstImage = instances[0];
+  const firstImageRows = firstImage.getTagValue('x00280010');
+  const firstImageColumns = firstImage.getTagValue('x00280011');
+  const firstImageSamplesPerPixel = firstImage.getTagValue('x00280002');
+  // Note: No need to unpack iop, can compare string form.
+  const firstImageOrientationPatient = firstImage.getTagValue('x00200037');
+
+  // Can't reconstruct if we:
+  // -- Have a different dimensions within a displaySet.
+  // -- Have a different number of components within a displaySet.
+  // -- Have different orientations within a displaySet.
+  for (let i = 1; i < instances.length; i++) {
+    const instance = instances[i];
+    const rows = instance.getTagValue('x00280010');
+    const columns = instance.getTagValue('x00280011');
+    const samplesPerPixel = instance.getTagValue('x00280002');
+    const imageOrientationPatient = instance.getTagValue('x00200037');
+
+    if (
+      rows !== firstImageRows ||
+      columns !== firstImageColumns ||
+      samplesPerPixel !== firstImageSamplesPerPixel ||
+      imageOrientationPatient !== firstImageOrientationPatient
+    ) {
+      return false;
+    }
+  }
+
+  // Check if frame spacing is approximately equal within a tolerance.
+  // TODO: Can we really do this when missing slices are really common?
+  // - You probably still want to view the series if we have slices missing, but
+  // - its impossible to tell the difference between missing slices and a multi
+  // - slice thickness reconstruction (could check if the difference is a
+  // multiple of the first to second frame slice spacing, but that is degenerate with
+  // particular  )
+  // Slicer throws a warning and still lets you open the scan, maybe we should do the same.
+  if (instances.length > 2) {
+    const firstIpp = _getImagePositionPatient(firstImage);
+    const lastIpp = _getImagePositionPatient(instances[instances.length - 1]);
+    const averageSpacingBetweenFrames =
+      _getPerpindicularDistance(firstIpp, lastIpp) / (instances.length - 1);
+
+    let previousIpp = firstIpp;
+
+    for (let i = 1; i < instances.length; i++) {
+      const instance = instances[i];
+      const ipp = _getImagePositionPatient(instance);
+
+      const spacingBetweenFrames = _getPerpindicularDistance(ipp, previousIpp);
+
+      if (
+        !_equalWithinTolerance(
+          spacingBetweenFrames,
+          averageSpacingBetweenFrames
+        )
+      ) {
+        return false;
+      }
+
+      previousIpp = ipp;
+    }
+  }
+
+  return true;
+}
+
+const tolerance = 0.1;
+
+function _equalWithinTolerance(spacing, averageSpacing) {
+  return a < b * (1 + tolerance) && a > b * (1 - tolerance);
+  /*
+  const equalWithinTolerance =
+    a < b * (1 + tolerance) && a > b * (1 - tolerance);
+
+  if (equalWithinTolerance) {
+    return true;
+  }
+
+  const multipleOfAverageSpacing = (spacing/averageSpacing);
+
+  return;
+  */
+}
+
+function _getImagePositionPatient(instance) {
+  return instance
+    .getTagValue('x00200032')
+    .split('\\')
+    .map(element => Number(element));
+}
+
+function _getPerpindicularDistance(a, b) {
+  return Math.sqrt(
+    Math.pow(a[0] - b[0], 2) +
+      Math.pow(a[1] - b[1], 2) +
+      Math.pow(a[2] - b[2], 2)
+  );
+}

--- a/platform/viewer/src/connectedComponents/ConnectedPluginSwitch.js
+++ b/platform/viewer/src/connectedComponents/ConnectedPluginSwitch.js
@@ -35,16 +35,10 @@ const mapDispatchToProps = dispatch => {
 }*/
 
 const mergeProps = (propsFromState, propsFromDispatch, ownProps) => {
-  const {
-    activeViewportIndex,
-    viewportSpecificData,
-    activeContexts,
-  } = propsFromState;
+  const { activeViewportIndex, viewportSpecificData } = propsFromState;
   const { studies } = ownProps;
   //const { setLayout } = propsFromDispatch;
 
-  // TODO: Do not display certain options if the current display set
-  // cannot be displayed using these view types
   const mpr = () => {
     commandsManager.runCommand('mpr2d');
   };
@@ -52,7 +46,6 @@ const mergeProps = (propsFromState, propsFromDispatch, ownProps) => {
     mpr,
     activeViewportIndex,
     viewportSpecificData,
-    activeContexts,
     studies,
   };
 };

--- a/platform/viewer/src/connectedComponents/ConnectedPluginSwitch.js
+++ b/platform/viewer/src/connectedComponents/ConnectedPluginSwitch.js
@@ -1,7 +1,8 @@
-import OHIF from "@ohif/core";
-import PluginSwitch from "./PluginSwitch.js";
-import { commandsManager } from "./../App.js";
-import { connect } from "react-redux";
+import OHIF from '@ohif/core';
+import PluginSwitch from './PluginSwitch.js';
+import { commandsManager } from './../App.js';
+import { connect } from 'react-redux';
+import { getActiveContexts } from './../store/layout/selectors.js';
 
 const { setLayout } = OHIF.redux.actions;
 
@@ -11,7 +12,8 @@ const mapStateToProps = state => {
   return {
     activeViewportIndex,
     viewportSpecificData,
-    layout
+    layout,
+    activeContexts: getActiveContexts(state),
   };
 };
 
@@ -19,7 +21,7 @@ const mapDispatchToProps = dispatch => {
   return {
     setLayout: data => {
       dispatch(setLayout(data));
-    }
+    },
   };
 };
 
@@ -33,18 +35,25 @@ const mapDispatchToProps = dispatch => {
 }*/
 
 const mergeProps = (propsFromState, propsFromDispatch, ownProps) => {
-  //const { activeViewportIndex, layout } = propsFromState;
+  const {
+    activeViewportIndex,
+    viewportSpecificData,
+    activeContexts,
+  } = propsFromState;
+  const { studies } = ownProps;
   //const { setLayout } = propsFromDispatch;
 
   // TODO: Do not display certain options if the current display set
   // cannot be displayed using these view types
   const mpr = () => {
-        commandsManager.runCommand("mpr2d");
-      }
-  ;
-
+    commandsManager.runCommand('mpr2d');
+  };
   return {
-    mpr
+    mpr,
+    activeViewportIndex,
+    viewportSpecificData,
+    activeContexts,
+    studies,
   };
 };
 

--- a/platform/viewer/src/connectedComponents/PluginSwitch.js
+++ b/platform/viewer/src/connectedComponents/PluginSwitch.js
@@ -32,22 +32,15 @@ class PluginSwitch extends Component {
 }
 
 function _shouldRenderMpr2DButton() {
-  const { viewportSpecificData, activeContexts, studies } = this.props;
+  const { viewportSpecificData, studies, activeViewportIndex } = this.props;
 
   if (!viewportSpecificData[0]) {
-    return false;
+    return;
   }
 
-  // Can only construct data which is displayed in these types of viewports.
-  const appropriateViewport =
-    activeContexts.includes('ACTIVE_VIEWPORT::CORNERSTONE') ||
-    activeContexts.includes('ACTIVE_VIEWPORT::VTK');
-
-  if (!appropriateViewport) {
-    return false;
-  }
-
-  const { displaySetInstanceUid, studyInstanceUid } = viewportSpecificData[0];
+  const { displaySetInstanceUid, studyInstanceUid } = viewportSpecificData[
+    activeViewportIndex
+  ];
 
   const displaySet = _getDisplaySet(
     studies,
@@ -55,10 +48,8 @@ function _shouldRenderMpr2DButton() {
     displaySetInstanceUid
   );
 
-  debugger;
-
   if (!displaySet) {
-    return false;
+    return;
   }
 
   return displaySet.isReconstructable;

--- a/platform/viewer/src/connectedComponents/PluginSwitch.js
+++ b/platform/viewer/src/connectedComponents/PluginSwitch.js
@@ -6,19 +6,78 @@ import './PluginSwitch.css';
 class PluginSwitch extends Component {
   static propTypes = {
     mpr: PropTypes.func,
+    activeContexts: PropTypes.arrayOf(PropTypes.string).isRequired,
+    activeViewportIndex: PropTypes.number,
+    viewportSpecificData: PropTypes.object,
+    studies: PropTypes.array,
   };
 
   static defaultProps = {};
 
   render() {
     return (
-      <div className="PluginSwitch">
-        <ToolbarButton       label = "2D MPR"
-                             icon = "cube"
-                             onClick = {this.props.mpr} />
-      </div>
+      <>
+        {_shouldRenderMpr2DButton.call(this) && (
+          <div className="PluginSwitch">
+            <ToolbarButton
+              label="2D MPR"
+              icon="cube"
+              onClick={this.props.mpr}
+            />
+          </div>
+        )}
+      </>
     );
   }
+}
+
+function _shouldRenderMpr2DButton() {
+  const { viewportSpecificData, activeContexts, studies } = this.props;
+
+  if (!viewportSpecificData[0]) {
+    return false;
+  }
+
+  // Can only construct data which is displayed in these types of viewports.
+  const appropriateViewport =
+    activeContexts.includes('ACTIVE_VIEWPORT::CORNERSTONE') ||
+    activeContexts.includes('ACTIVE_VIEWPORT::VTK');
+
+  if (!appropriateViewport) {
+    return false;
+  }
+
+  const { displaySetInstanceUid, studyInstanceUid } = viewportSpecificData[0];
+
+  const displaySet = _getDisplaySet(
+    studies,
+    studyInstanceUid,
+    displaySetInstanceUid
+  );
+
+  debugger;
+
+  if (!displaySet) {
+    return false;
+  }
+
+  return displaySet.isReconstructable;
+}
+
+function _getDisplaySet(studies, studyInstanceUid, displaySetInstanceUid) {
+  const study = studies.find(
+    study => study.studyInstanceUid === studyInstanceUid
+  );
+
+  if (!study) {
+    return;
+  }
+
+  const displaySet = study.displaySets.find(set => {
+    return set.displaySetInstanceUid === displaySetInstanceUid;
+  });
+
+  return displaySet;
 }
 
 export default PluginSwitch;

--- a/platform/viewer/src/connectedComponents/ToolbarRow.js
+++ b/platform/viewer/src/connectedComponents/ToolbarRow.js
@@ -25,6 +25,7 @@ class ToolbarRow extends Component {
     selectedRightSidePanel: PropTypes.string.isRequired,
     handleSidePanelChange: PropTypes.func,
     activeContexts: PropTypes.arrayOf(PropTypes.string).isRequired,
+    studies: PropTypes.array,
   };
 
   constructor(props) {
@@ -128,7 +129,7 @@ class ToolbarRow extends Component {
           </div>
           {buttonComponents}
           <ConnectedLayoutButton />
-          <ConnectedPluginSwitch />
+          <ConnectedPluginSwitch studies={this.props.studies} />
           <div
             className="pull-right m-t-1 rm-x-1"
             style={{ marginLeft: 'auto' }}
@@ -228,7 +229,6 @@ function _getButtonComponents(toolbarButtons, activeButtons) {
     return _getDefaultButtonComponent.call(_this, button, activeButtons);
   });
 }
-
 
 /**
  * A handy way for us to handle different button types. IE. firing commands for

--- a/platform/viewer/src/connectedComponents/Viewer.js
+++ b/platform/viewer/src/connectedComponents/Viewer.js
@@ -279,6 +279,7 @@ class Viewer extends Component {
 
             this.setState(updatedState);
           }}
+          studies={this.props.studies}
         />
 
         {/*<ConnectedStudyLoadingMonitor studies={this.props.studies} />*/}


### PR DESCRIPTION
Regarding #561 :

Only allow reconstruction of datasets that can be 3D volumes:
- Not SR/PDF/etc, not a microscopy slide.
- Has more than one frame.
- Has the same dimmensions on each frame.
- Has the same number of components (monochrome/RGB) on each frame.
- Has parallel frames.
- Has equal spacing between frames, however if it looks like a slice is simply missing, still allow 3D reconstruction.
