### PR TITLE
ci: Set cache key to only use yarn.lock checksum

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -295,7 +295,7 @@ workflows:
           store_artifacts: false
           working_directory: platform/viewer
           build: yarn run build:e2e
-          start: yarn run test:e2e:dist
+          start: yarn run test:e2e:serve
           wait-on: 'http://localhost:3000'
           cache-key: 'yarn-packages-{{ checksum "yarn.lock" }}'
           no-workspace: true # Don't persist workspace
@@ -342,7 +342,7 @@ workflows:
           store_artifacts: true
           working_directory: platform/viewer
           build: yarn run build:e2e
-          start: yarn run test:e2e:dist
+          start: yarn run test:e2e:serve
           wait-on: 'http://localhost:3000'
           cache-key: 'yarn-packages-{{ checksum "yarn.lock" }}'
           no-workspace: true # Don't persist workspace

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,6 +81,12 @@ unit_tests_main: &unit_tests_main
       file: '/home/circleci/repo/platform/core/coverage/reports'
       flags: 'core'
 
+persist_to_workspace: &persist_to_workspace
+  # Persist :+1:
+  - persist_to_workspace:
+      root: ~/repo
+      paths: .
+
 jobs:
   UNIT_TESTS:
     <<: *defaults
@@ -91,11 +97,7 @@ jobs:
     <<: *defaults
     steps:
       <<: *unit_tests_main
-
-      # Persist :+1:
-      - persist_to_workspace:
-          root: ~/repo
-          paths: .
+      <<: *persist_to_workspace
 
   NPM_PUBLISH:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,9 @@ jobs:
       - restore_cache:
           name: Restore Yarn and Cypress Package Cache
           keys:
+            # when lock file changes, use increasingly general patterns to restore cache
             - yarn-packages-{{ checksum "yarn.lock" }}
+            - yarn-packages-
       - run:
           name: Install Dependencies
           command: yarn install --frozen-lockfile

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,10 +35,7 @@ jobs:
       - restore_cache:
           name: Restore Yarn and Cypress Package Cache
           keys:
-            # when lock file changes, use increasingly general patterns to restore cache
-            - yarn-packages-v1-{{ .Branch }}-{{ checksum "yarn.lock" }}
-            - yarn-packages-v1-{{ .Branch }}-
-            - yarn-packages-v1-
+            - yarn-packages-{{ checksum "yarn.lock" }}
       - run:
           name: Install Dependencies
           command: yarn install --frozen-lockfile
@@ -46,7 +43,7 @@ jobs:
           name: Save Yarn Package Cache
           paths:
             - ~/.cache ## Cache yarn and Cypress
-          key: yarn-packages-v1-{{ .Branch }}-{{ checksum "yarn.lock" }}
+          key: yarn-packages-{{ checksum "yarn.lock" }}
       # Persist :+1:
       - persist_to_workspace:
           root: ~/repo
@@ -239,7 +236,7 @@ workflows:
           build: yarn run build:e2e
           start: yarn run test:e2e:dist
           wait-on: 'http://localhost:3000'
-          cache-key: 'yarn-packages-v1-{{ .Branch }}-{{ checksum "yarn.lock" }}'
+          cache-key: 'yarn-packages-{{ checksum "yarn.lock" }}'
           no-workspace: true # Don't persist workspace
           post-steps:
             - store_artifacts:
@@ -258,7 +255,7 @@ workflows:
           build: yarn run build:package
           start: yarn run test:e2e:dist
           wait-on: 'http://localhost:3000'
-          cache-key: 'yarn-packages-v1-{{ .Branch }}-{{ checksum "yarn.lock" }}'
+          cache-key: 'yarn-packages-{{ checksum "yarn.lock" }}'
           no-workspace: true # Don't persist workspace
           post-steps:
             - store_artifacts:
@@ -289,7 +286,7 @@ workflows:
           build: yarn run build:e2e
           start: yarn run test:e2e:dist
           wait-on: 'http://localhost:3000'
-          cache-key: 'yarn-packages-v1-{{ .Branch }}-{{ checksum "yarn.lock" }}'
+          cache-key: 'yarn-packages-{{ checksum "yarn.lock" }}'
           no-workspace: true # Don't persist workspace
           post-steps:
             - store_artifacts:
@@ -310,7 +307,7 @@ workflows:
           build: yarn run build:package
           start: yarn run test:e2e:dist
           wait-on: 'http://localhost:3000'
-          cache-key: 'yarn-packages-v1-{{ .Branch }}-{{ checksum "yarn.lock" }}'
+          cache-key: 'yarn-packages-{{ checksum "yarn.lock" }}'
           no-workspace: true # Don't persist workspace
           post-steps:
             - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -307,7 +307,7 @@ workflows:
           store_artifacts: false
           working_directory: platform/viewer
           build: yarn run build:package
-          start: yarn run test:e2e:dist
+          start: yarn run test:e2e:serve
           wait-on: 'http://localhost:3000'
           cache-key: 'yarn-packages-{{ checksum "yarn.lock" }}'
           no-workspace: true # Don't persist workspace

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,73 +22,75 @@ defaults: &defaults
         TERM: xterm # Enable colors in term
   working_directory: ~/repo
 
-jobs:
-  CHECKOUT:
-    <<: *defaults
-    steps:
-      # Enable yarn workspaces
-      - run: yarn config set workspaces-experimental true
-      # Checkout code and ALL Git Tags
-      - checkout:
-          post:
-            - git fetch --all
-      - restore_cache:
-          name: Restore Yarn and Cypress Package Cache
-          keys:
-            # when lock file changes, use increasingly general patterns to restore cache
-            - yarn-packages-{{ checksum "yarn.lock" }}
-            - yarn-packages-
-      - run:
-          name: Install Dependencies
-          command: yarn install --frozen-lockfile
-      - save_cache:
-          name: Save Yarn Package Cache
-          paths:
-            - ~/.cache ## Cache yarn and Cypress
-          key: yarn-packages-{{ checksum "yarn.lock" }}
-      # Persist :+1:
-      - persist_to_workspace:
-          root: ~/repo
-          paths: .
+unit_tests_main: &unit_tests_main
+  # Enable yarn workspaces
+  - run: yarn config set workspaces-experimental true
 
+  # Checkout code and ALL Git Tags
+  - checkout:
+      post:
+        - git fetch --all
+
+  - restore_cache:
+      name: Restore Yarn and Cypress Package Cache
+      keys:
+        # when lock file changes, use increasingly general patterns to restore cache
+        - yarn-packages-{{ checksum "yarn.lock" }}
+        - yarn-packages-
+
+  - run:
+      name: Install Dependencies
+      command: yarn install --frozen-lockfile
+
+  - save_cache:
+      name: Save Yarn Package Cache
+      paths:
+        - ~/.cache ## Cache yarn and Cypress
+      key: yarn-packages-{{ checksum "yarn.lock" }}
+
+  # RUN TESTS
+  - run:
+      name: 'JavaScript Test Suite'
+      command: yarn run test:unit:ci
+
+  # PLATFORM/VIEWER
+  - run:
+      name: 'VIEWER: Combine report output'
+      command: |
+        viewerCov="/home/circleci/repo/platform/viewer/coverage"
+        touch "${viewerCov}/reports"
+        cat "${viewerCov}/clover.xml" >> "${viewerCov}/reports"
+        echo "\<<\<<\<< EOF" >> "${viewerCov}/reports"
+        cat "${viewerCov}/lcov.info" >>"${viewerCov}/reports"
+        echo "\<<\<<\<< EOF" >> "${viewerCov}/reports"
+  - codecov/upload:
+      file: '/home/circleci/repo/platform/viewer/coverage/reports'
+      flags: 'viewer'
+
+  # PLATFORM/CORE
+  - run:
+      name: 'CORE: Combine report output'
+      command: |
+        coreCov="/home/circleci/repo/platform/core/coverage"
+        touch "${coreCov}/reports"
+        cat "${coreCov}/clover.xml" >> "${coreCov}/reports"
+        echo "\<<\<<\<< EOF" >> "${coreCov}/reports"
+        cat "${coreCov}/lcov.info" >> "${coreCov}/reports"
+        echo "\<<\<<\<< EOF" >> "${coreCov}/reports"
+  - codecov/upload:
+      file: '/home/circleci/repo/platform/core/coverage/reports'
+      flags: 'core'
+
+jobs:
   UNIT_TESTS:
     <<: *defaults
     steps:
-      - attach_workspace:
-          at: ~/repo
+      <<: *unit_tests_main
 
-      # RUN TESTS
-      - run:
-          name: 'JavaScript Test Suite'
-          command: yarn run test:unit:ci
-
-      # PLATFORM/VIEWER
-      - run:
-          name: 'VIEWER: Combine report output'
-          command: |
-            viewerCov="/home/circleci/repo/platform/viewer/coverage"
-            touch "${viewerCov}/reports"
-            cat "${viewerCov}/clover.xml" >> "${viewerCov}/reports"
-            echo "\<<\<<\<< EOF" >> "${viewerCov}/reports"
-            cat "${viewerCov}/lcov.info" >>"${viewerCov}/reports"
-            echo "\<<\<<\<< EOF" >> "${viewerCov}/reports"
-      - codecov/upload:
-          file: '/home/circleci/repo/platform/viewer/coverage/reports'
-          flags: 'viewer'
-
-      # PLATFORM/CORE
-      - run:
-          name: 'CORE: Combine report output'
-          command: |
-            coreCov="/home/circleci/repo/platform/core/coverage"
-            touch "${coreCov}/reports"
-            cat "${coreCov}/clover.xml" >> "${coreCov}/reports"
-            echo "\<<\<<\<< EOF" >> "${coreCov}/reports"
-            cat "${coreCov}/lcov.info" >> "${coreCov}/reports"
-            echo "\<<\<<\<< EOF" >> "${coreCov}/reports"
-      - codecov/upload:
-          file: '/home/circleci/repo/platform/core/coverage/reports'
-          flags: 'core'
+  UNIT_TESTS_PERSIST_WORKSPACE:
+    <<: *defaults
+    steps:
+      <<: *unit_tests_main
 
       # Persist :+1:
       - persist_to_workspace:
@@ -216,16 +218,13 @@ workflows:
   # PULL REQUESTS
   PR_CHECKS:
     jobs:
-      - CHECKOUT:
+      - UNIT_TESTS:
           filters:
             branches:
               ignore:
                 - master
                 - feature/*
                 - hotfix/*
-      - UNIT_TESTS:
-          requires:
-            - CHECKOUT
       # E2E: PWA
       - cypress/run:
           name: 'E2E: PWA'
@@ -255,7 +254,7 @@ workflows:
           store_artifacts: false
           working_directory: platform/viewer
           build: yarn run build:package
-          start: yarn run test:e2e:dist
+          start: yarn run test:e2e:serve
           wait-on: 'http://localhost:3000'
           cache-key: 'yarn-packages-{{ checksum "yarn.lock" }}'
           no-workspace: true # Don't persist workspace
@@ -268,13 +267,10 @@ workflows:
   # MERGE TO MASTER
   RELEASE:
     jobs:
-      - CHECKOUT:
+      - UNIT_TESTS_PERSIST_WORKSPACE:
           filters:
             branches:
               only: master
-      - UNIT_TESTS:
-          requires:
-            - CHECKOUT
       # E2E: PWA + Persist
       - cypress/run:
           name: 'E2E: PWA'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,11 @@ defaults: &defaults
         TERM: xterm # Enable colors in term
   working_directory: ~/repo
 
+# Persist :+1:
+persist_to_workspace: &persist_to_workspace
+  root: ~/repo
+  paths: .
+
 unit_tests_main: &unit_tests_main
   # Enable yarn workspaces
   - run: yarn config set workspaces-experimental true
@@ -80,12 +85,6 @@ unit_tests_main: &unit_tests_main
   - codecov/upload:
       file: '/home/circleci/repo/platform/core/coverage/reports'
       flags: 'core'
-
-persist_to_workspace: &persist_to_workspace
-  # Persist :+1:
-  - persist_to_workspace:
-      root: ~/repo
-      paths: .
 
 jobs:
   UNIT_TESTS:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,81 +22,133 @@ defaults: &defaults
         TERM: xterm # Enable colors in term
   working_directory: ~/repo
 
-# Persist :+1:
-persist_to_workspace: &persist_to_workspace
-  root: ~/repo
-  paths: .
-
-unit_tests_main: &unit_tests_main
-  # Enable yarn workspaces
-  - run: yarn config set workspaces-experimental true
-
-  # Checkout code and ALL Git Tags
-  - checkout:
-      post:
-        - git fetch --all
-
-  - restore_cache:
-      name: Restore Yarn and Cypress Package Cache
-      keys:
-        # when lock file changes, use increasingly general patterns to restore cache
-        - yarn-packages-{{ checksum "yarn.lock" }}
-        - yarn-packages-
-
-  - run:
-      name: Install Dependencies
-      command: yarn install --frozen-lockfile
-
-  - save_cache:
-      name: Save Yarn Package Cache
-      paths:
-        - ~/.cache ## Cache yarn and Cypress
-      key: yarn-packages-{{ checksum "yarn.lock" }}
-
-  # RUN TESTS
-  - run:
-      name: 'JavaScript Test Suite'
-      command: yarn run test:unit:ci
-
-  # PLATFORM/VIEWER
-  - run:
-      name: 'VIEWER: Combine report output'
-      command: |
-        viewerCov="/home/circleci/repo/platform/viewer/coverage"
-        touch "${viewerCov}/reports"
-        cat "${viewerCov}/clover.xml" >> "${viewerCov}/reports"
-        echo "\<<\<<\<< EOF" >> "${viewerCov}/reports"
-        cat "${viewerCov}/lcov.info" >>"${viewerCov}/reports"
-        echo "\<<\<<\<< EOF" >> "${viewerCov}/reports"
-  - codecov/upload:
-      file: '/home/circleci/repo/platform/viewer/coverage/reports'
-      flags: 'viewer'
-
-  # PLATFORM/CORE
-  - run:
-      name: 'CORE: Combine report output'
-      command: |
-        coreCov="/home/circleci/repo/platform/core/coverage"
-        touch "${coreCov}/reports"
-        cat "${coreCov}/clover.xml" >> "${coreCov}/reports"
-        echo "\<<\<<\<< EOF" >> "${coreCov}/reports"
-        cat "${coreCov}/lcov.info" >> "${coreCov}/reports"
-        echo "\<<\<<\<< EOF" >> "${coreCov}/reports"
-  - codecov/upload:
-      file: '/home/circleci/repo/platform/core/coverage/reports'
-      flags: 'core'
-
 jobs:
   UNIT_TESTS:
     <<: *defaults
     steps:
-      <<: *unit_tests_main
+      # Enable yarn workspaces
+      - run: yarn config set workspaces-experimental true
+
+      # Checkout code and ALL Git Tags
+      - checkout:
+          post:
+            - git fetch --all
+
+      - restore_cache:
+          name: Restore Yarn and Cypress Package Cache
+          keys:
+            # when lock file changes, use increasingly general patterns to restore cache
+            - yarn-packages-{{ checksum "yarn.lock" }}
+            - yarn-packages-
+
+      - run:
+          name: Install Dependencies
+          command: yarn install --frozen-lockfile
+
+      - save_cache:
+          name: Save Yarn Package Cache
+          paths:
+            - ~/.cache ## Cache yarn and Cypress
+          key: yarn-packages-{{ checksum "yarn.lock" }}
+
+      # RUN TESTS
+      - run:
+          name: 'JavaScript Test Suite'
+          command: yarn run test:unit:ci
+
+      # PLATFORM/VIEWER
+      - run:
+          name: 'VIEWER: Combine report output'
+          command: |
+            viewerCov="/home/circleci/repo/platform/viewer/coverage"
+            touch "${viewerCov}/reports"
+            cat "${viewerCov}/clover.xml" >> "${viewerCov}/reports"
+            echo "\<<\<<\<< EOF" >> "${viewerCov}/reports"
+            cat "${viewerCov}/lcov.info" >>"${viewerCov}/reports"
+            echo "\<<\<<\<< EOF" >> "${viewerCov}/reports"
+      - codecov/upload:
+          file: '/home/circleci/repo/platform/viewer/coverage/reports'
+          flags: 'viewer'
+
+      # PLATFORM/CORE
+      - run:
+          name: 'CORE: Combine report output'
+          command: |
+            coreCov="/home/circleci/repo/platform/core/coverage"
+            touch "${coreCov}/reports"
+            cat "${coreCov}/clover.xml" >> "${coreCov}/reports"
+            echo "\<<\<<\<< EOF" >> "${coreCov}/reports"
+            cat "${coreCov}/lcov.info" >> "${coreCov}/reports"
+            echo "\<<\<<\<< EOF" >> "${coreCov}/reports"
+      - codecov/upload:
+          file: '/home/circleci/repo/platform/core/coverage/reports'
+          flags: 'core'
 
   UNIT_TESTS_PERSIST_WORKSPACE:
     <<: *defaults
     steps:
-      <<: *unit_tests_main
-      <<: *persist_to_workspace
+      # Enable yarn workspaces
+      - run: yarn config set workspaces-experimental true
+
+      # Checkout code and ALL Git Tags
+      - checkout:
+          post:
+            - git fetch --all
+
+      - restore_cache:
+          name: Restore Yarn and Cypress Package Cache
+          keys:
+            # when lock file changes, use increasingly general patterns to restore cache
+            - yarn-packages-{{ checksum "yarn.lock" }}
+            - yarn-packages-
+
+      - run:
+          name: Install Dependencies
+          command: yarn install --frozen-lockfile
+
+      - save_cache:
+          name: Save Yarn Package Cache
+          paths:
+            - ~/.cache ## Cache yarn and Cypress
+          key: yarn-packages-{{ checksum "yarn.lock" }}
+
+      # RUN TESTS
+      - run:
+          name: 'JavaScript Test Suite'
+          command: yarn run test:unit:ci
+
+      # PLATFORM/VIEWER
+      - run:
+          name: 'VIEWER: Combine report output'
+          command: |
+            viewerCov="/home/circleci/repo/platform/viewer/coverage"
+            touch "${viewerCov}/reports"
+            cat "${viewerCov}/clover.xml" >> "${viewerCov}/reports"
+            echo "\<<\<<\<< EOF" >> "${viewerCov}/reports"
+            cat "${viewerCov}/lcov.info" >>"${viewerCov}/reports"
+            echo "\<<\<<\<< EOF" >> "${viewerCov}/reports"
+      - codecov/upload:
+          file: '/home/circleci/repo/platform/viewer/coverage/reports'
+          flags: 'viewer'
+
+      # PLATFORM/CORE
+      - run:
+          name: 'CORE: Combine report output'
+          command: |
+            coreCov="/home/circleci/repo/platform/core/coverage"
+            touch "${coreCov}/reports"
+            cat "${coreCov}/clover.xml" >> "${coreCov}/reports"
+            echo "\<<\<<\<< EOF" >> "${coreCov}/reports"
+            cat "${coreCov}/lcov.info" >> "${coreCov}/reports"
+            echo "\<<\<<\<< EOF" >> "${coreCov}/reports"
+      - codecov/upload:
+          file: '/home/circleci/repo/platform/core/coverage/reports'
+          flags: 'core'
+      
+      # Persist :+1:
+      - persist_to_workspace: &persist_to_workspace
+          root: ~/repo
+          paths: .
 
   NPM_PUBLISH:
     <<: *defaults
@@ -293,7 +345,7 @@ workflows:
             - store_test_results:
                 path: cypress/results
           requires:
-            - UNIT_TESTS
+            - UNIT_TESTS_PERSIST_WORKSPACE
       # E2E: script-tag
       - cypress/run:
           name: 'E2E: Script Tag'
@@ -314,7 +366,7 @@ workflows:
             - store_test_results:
                 path: cypress/results
           requires:
-            - UNIT_TESTS
+            - UNIT_TESTS_PERSIST_WORKSPACE
       # Update NPM
       - NPM_PUBLISH:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ orbs:
 
 defaults: &defaults
   docker:
-    - image: circleci/node:10.16.0
+    - image: circleci/node:12.9.1
       environment:
         TERM: xterm # Enable colors in term
   working_directory: ~/repo
@@ -26,6 +26,9 @@ jobs:
   UNIT_TESTS:
     <<: *defaults
     steps:
+      # Update yarn
+      - run: rm -rf ~/.yarn && npm i -g yarn && yarn -v
+
       # Enable yarn workspaces
       - run: yarn config set workspaces-experimental true
 
@@ -87,6 +90,9 @@ jobs:
   UNIT_TESTS_PERSIST_WORKSPACE:
     <<: *defaults
     steps:
+      # Update yarn
+      - run: rm -rf ~/.yarn && npm i -g yarn && yarn -v
+
       # Enable yarn workspaces
       - run: yarn config set workspaces-experimental true
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,8 @@ jobs:
     <<: *defaults
     steps:
       # Update yarn
-      - run: rm -rf ~/.yarn && npm i -g yarn && yarn -v
+      - run: yarn -v
+      #- run: rm -rf ~/.yarn && npm i -g yarn && yarn -v
 
       # Enable yarn workspaces
       - run: yarn config set workspaces-experimental true
@@ -91,7 +92,7 @@ jobs:
     <<: *defaults
     steps:
       # Update yarn
-      - run: rm -rf ~/.yarn && npm i -g yarn && yarn -v
+      #- run: rm -rf ~/.yarn && npm i -g yarn && yarn -v
 
       # Enable yarn workspaces
       - run: yarn config set workspaces-experimental true

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "test:unit:ci": "lerna run test:unit:ci --parallel --stream",
     "test:e2e": "lerna run test:e2e --stream",
     "test:e2e:dist": "lerna run test:e2e:dist --stream",
+    "test:e2e:serve": "lerna run test:e2e:serve --stream",
     "see-changed": "lerna changed",
     "docs:publish": "chmod +x ./build-and-publish-docs.sh && ./build-and-publish-docs.sh",
     "release": "yarn run lerna:version && yarn run lerna:publish",


### PR DESCRIPTION
We make a lot of changes but don't touch the lockfile on every PR. I don't think we need to include the branch name in the cache key. I'm checking this because the initial Checkout step in the CI process is taking 6 minutes to restore and then reupload the cache, which seems crazy: https://circleci.com/workflow-run/3938d5fd-3c82-4ff1-957e-6a04dd577df7