### PR TITLE
Reliably show SR (structured report) series

### DIFF
--- a/platform/core/src/classes/metadata/StudyMetadata.js
+++ b/platform/core/src/classes/metadata/StudyMetadata.js
@@ -121,7 +121,7 @@ export class StudyMetadata extends Metadata {
       if (displaySet) {
         displaySet.sopClassModule = true;
         displaySets.push(displaySet);
-        return;
+        return displaySets;
       }
     }
 


### PR DESCRIPTION
Before this fix, SR series for a study show up sometimes, other times they cannot be seen in the left panel of the viewer.

The documentation for the _createDisplaySetsForSeries function says that it should return the display sets, however there is one case where it doesn't do that. This fixes the case so that it returns the display sets.