### PR TITLE
ci: Skip copying URL to clipboard on headless CI servers

### DIFF
--- a/platform/viewer/package.json
+++ b/platform/viewer/package.json
@@ -29,7 +29,7 @@
     "test:e2e": "cypress open",
     "test:e2e:ci": "cypress run",
     "test:e2e:dist": "start-server-and-test test:e2e:serve http://localhost:3000 test:e2e:ci",
-    "test:e2e:serve": "serve -l 3000 -s dist",
+    "test:e2e:serve": "serve -n -l 3000 -s dist",
     "test:unit": "jest --watchAll",
     "test:unit:ci": "jest --ci --runInBand --collectCoverage",
     "prepublishOnly": "yarn run build:package",


### PR DESCRIPTION
The build is throwing weird errors on the Start command