### PR TITLE
Improvement on VTK beforeEach hook

### DIFF
--- a/platform/viewer/cypress/integration/pwa/OHIFExtensionVTK.spec.js
+++ b/platform/viewer/cypress/integration/pwa/OHIFExtensionVTK.spec.js
@@ -17,7 +17,11 @@ describe('OHIF VTK Extension', () => {
     cy.get('.PluginSwitch > .toolbar-button')
       .as('twodmprBtn')
       .should('be.visible')
-      .click();
+      .then(btn => {
+        if (!btn.text().includes('Exit')) {
+          btn.click();
+        }
+      });
 
     cy.initVTKToolsAliases();
     cy.wait(1000);


### PR DESCRIPTION
I just added a small improvement to avoid opening/closing the VTK menu before each test. Now, cypress will only click on the `VTK button` to open the toolbar. If the toolbar is already open, it won't click again.