### PR TITLE
fix: 🐛 Desc of meas.table not being updated on properly

### DIFF
--- a/platform/viewer/src/appExtensions/MeasurementsPanel/ConnectedMeasurementTable.js
+++ b/platform/viewer/src/appExtensions/MeasurementsPanel/ConnectedMeasurementTable.js
@@ -28,16 +28,12 @@ function getAllTools() {
   return tools;
 }
 
-function getMeasurementText(measurementData) {
-  const { location, description } = measurementData;
-  let text = '...';
-  if (location) {
-    text = location;
-    if (description) {
-      text += `(${description})`;
-    }
-  }
-  return text;
+function getMeasurementText(measurementData = {}) {
+  const defaultText = '...';
+  const { location = '', description = '' } = measurementData;
+  const result = location + (description ? `(${description})` : '');
+
+  return result || defaultText;
 }
 
 function getDataForEachMeasurementNumber(


### PR DESCRIPTION
Is not possible to add Measurement Description if Relabel was not
previously selected

### Included items
- On description measurement table item, set default text to '...' or a combination of label and description

### Closes
 #1013 