### PR TITLE
fix: study list translations

### DIFF
--- a/platform/ui/src/components/languageSwitcher/LanguageSwitcher.js
+++ b/platform/ui/src/components/languageSwitcher/LanguageSwitcher.js
@@ -27,6 +27,9 @@ const LanguageSwitcher = () => {
     setCurrentLanguage(language);
 
     i18n.init({
+      react: {
+        useSuspense: false,
+      },
       fallbackLng: language,
       lng: language,
     });

--- a/platform/ui/src/components/languageSwitcher/LanguageSwitcher.js
+++ b/platform/ui/src/components/languageSwitcher/LanguageSwitcher.js
@@ -27,9 +27,6 @@ const LanguageSwitcher = () => {
     setCurrentLanguage(language);
 
     i18n.init({
-      react: {
-        useSuspense: false,
-      },
       fallbackLng: language,
       lng: language,
     });

--- a/platform/ui/src/components/studyList/StudyList.js
+++ b/platform/ui/src/components/studyList/StudyList.js
@@ -113,82 +113,80 @@ function StudyList(props) {
     .map(field => field.size)
     .reduce((prev, next) => prev + next);
 
-  return (
-    ready && (
-      <table className="table table--striped table--hoverable">
-        <colgroup>
-          {tableMeta.map((field, i) => {
-            const size = field.size;
-            const percentWidth = (size / totalSize) * 100.0;
+  return ready ? (
+    <table className="table table--striped table--hoverable">
+      <colgroup>
+        {tableMeta.map((field, i) => {
+          const size = field.size;
+          const percentWidth = (size / totalSize) * 100.0;
 
-            return <col key={i} style={{ width: `${percentWidth}%` }} />;
-          })}
-        </colgroup>
-        <thead className="table-head">
-          <tr className="filters">
-            <TableSearchFilter
-              meta={tableMeta}
-              values={filterValues}
-              onSort={handleSort}
-              onValueChange={handleFilterChange}
-              sortFieldName={sort.fieldName}
-              sortDirection={sort.direction}
-              studyListDateFilterNumDays={studyListDateFilterNumDays}
-            />
+          return <col key={i} style={{ width: `${percentWidth}%` }} />;
+        })}
+      </colgroup>
+      <thead className="table-head">
+        <tr className="filters">
+          <TableSearchFilter
+            meta={tableMeta}
+            values={filterValues}
+            onSort={handleSort}
+            onValueChange={handleFilterChange}
+            sortFieldName={sort.fieldName}
+            sortDirection={sort.direction}
+            studyListDateFilterNumDays={studyListDateFilterNumDays}
+          />
+        </tr>
+      </thead>
+      <tbody className="table-body" data-cy="study-list-results">
+        {/* I'm not in love with this approach, but it's the quickest way for now
+         *
+         * - Display different content based on loading, empty, results state
+         *
+         * This is not ideal because it create a jump in focus. For loading especially,
+         * We should keep our current results visible while we load the new ones.
+         */}
+        {/* LOADING */}
+        {isLoading && (
+          <tr className="no-hover">
+            <td colSpan={tableMeta.length}>
+              <StudyListLoadingText />
+            </td>
           </tr>
-        </thead>
-        <tbody className="table-body" data-cy="study-list-results">
-          {/* I'm not in love with this approach, but it's the quickest way for now
-           *
-           * - Display different content based on loading, empty, results state
-           *
-           * This is not ideal because it create a jump in focus. For loading especially,
-           * We should keep our current results visible while we load the new ones.
-           */}
-          {/* LOADING */}
-          {isLoading && (
-            <tr className="no-hover">
-              <td colSpan={tableMeta.length}>
-                <StudyListLoadingText />
-              </td>
-            </tr>
-          )}
-          {!isLoading && hasError && (
-            <tr className="no-hover">
-              <td colSpan={tableMeta.length}>
-                <div className="notFound">
-                  {t('There was an error fetching studies')}
-                </div>
-              </td>
-            </tr>
-          )}
-          {/* EMPTY */}
-          {!isLoading && !studies.length && (
-            <tr className="no-hover">
-              <td colSpan={tableMeta.length}>
-                <div className="notFound">{t('No matching results')}</div>
-              </td>
-            </tr>
-          )}
-          {!isLoading &&
-            studies.map((study, index) => (
-              <TableRow
-                key={`${study.studyInstanceUid}-${index}`}
-                onClick={studyInstanceUid => handleSelectItem(studyInstanceUid)}
-                accessionNumber={study.accessionNumber || ''}
-                modalities={study.modalities}
-                patientId={study.patientId || ''}
-                patientName={study.patientName || ''}
-                studyDate={study.studyDate}
-                studyDescription={study.studyDescription || ''}
-                studyInstanceUid={study.studyInstanceUid}
-                t={t}
-              />
-            ))}
-        </tbody>
-      </table>
-    )
-  );
+        )}
+        {!isLoading && hasError && (
+          <tr className="no-hover">
+            <td colSpan={tableMeta.length}>
+              <div className="notFound">
+                {t('There was an error fetching studies')}
+              </div>
+            </td>
+          </tr>
+        )}
+        {/* EMPTY */}
+        {!isLoading && !studies.length && (
+          <tr className="no-hover">
+            <td colSpan={tableMeta.length}>
+              <div className="notFound">{t('No matching results')}</div>
+            </td>
+          </tr>
+        )}
+        {!isLoading &&
+          studies.map((study, index) => (
+            <TableRow
+              key={`${study.studyInstanceUid}-${index}`}
+              onClick={studyInstanceUid => handleSelectItem(studyInstanceUid)}
+              accessionNumber={study.accessionNumber || ''}
+              modalities={study.modalities}
+              patientId={study.patientId || ''}
+              patientName={study.patientName || ''}
+              studyDate={study.studyDate}
+              studyDescription={study.studyDescription || ''}
+              studyInstanceUid={study.studyInstanceUid}
+              t={t}
+            />
+          ))}
+      </tbody>
+    </table>
+  ) : null;
 }
 
 StudyList.propTypes = {

--- a/platform/ui/src/components/studyList/StudyList.js
+++ b/platform/ui/src/components/studyList/StudyList.js
@@ -30,7 +30,9 @@ function StudyList(props) {
     //
     studyListDateFilterNumDays,
   } = props;
-  const [t] = useTranslation('StudyList');
+  const { t, i18n, ready } = useTranslation('StudyList', {
+    useSuspense: false,
+  });
 
   const largeTableMeta = [
     {
@@ -112,78 +114,80 @@ function StudyList(props) {
     .reduce((prev, next) => prev + next);
 
   return (
-    <table className="table table--striped table--hoverable">
-      <colgroup>
-        {tableMeta.map((field, i) => {
-          const size = field.size;
-          const percentWidth = (size / totalSize) * 100.0;
+    ready && (
+      <table className="table table--striped table--hoverable">
+        <colgroup>
+          {tableMeta.map((field, i) => {
+            const size = field.size;
+            const percentWidth = (size / totalSize) * 100.0;
 
-          return <col key={i} style={{ width: `${percentWidth}%` }} />;
-        })}
-      </colgroup>
-      <thead className="table-head">
-        <tr className="filters">
-          <TableSearchFilter
-            meta={tableMeta}
-            values={filterValues}
-            onSort={handleSort}
-            onValueChange={handleFilterChange}
-            sortFieldName={sort.fieldName}
-            sortDirection={sort.direction}
-            studyListDateFilterNumDays={studyListDateFilterNumDays}
-          />
-        </tr>
-      </thead>
-      <tbody className="table-body" data-cy="study-list-results">
-        {/* I'm not in love with this approach, but it's the quickest way for now
-         *
-         * - Display different content based on loading, empty, results state
-         *
-         * This is not ideal because it create a jump in focus. For loading especially,
-         * We should keep our current results visible while we load the new ones.
-         */}
-        {/* LOADING */}
-        {isLoading && (
-          <tr className="no-hover">
-            <td colSpan={tableMeta.length}>
-              <StudyListLoadingText />
-            </td>
-          </tr>
-        )}
-        {!isLoading && hasError && (
-          <tr className="no-hover">
-            <td colSpan={tableMeta.length}>
-              <div className="notFound">
-                {t('There was an error fetching studies')}
-              </div>
-            </td>
-          </tr>
-        )}
-        {/* EMPTY */}
-        {!isLoading && !studies.length && (
-          <tr className="no-hover">
-            <td colSpan={tableMeta.length}>
-              <div className="notFound">{t('No matching results')}</div>
-            </td>
-          </tr>
-        )}
-        {!isLoading &&
-          studies.map((study, index) => (
-            <TableRow
-              key={`${study.studyInstanceUid}-${index}`}
-              onClick={studyInstanceUid => handleSelectItem(studyInstanceUid)}
-              accessionNumber={study.accessionNumber || ''}
-              modalities={study.modalities}
-              patientId={study.patientId || ''}
-              patientName={study.patientName || ''}
-              studyDate={study.studyDate}
-              studyDescription={study.studyDescription || ''}
-              studyInstanceUid={study.studyInstanceUid}
-              t={t}
+            return <col key={i} style={{ width: `${percentWidth}%` }} />;
+          })}
+        </colgroup>
+        <thead className="table-head">
+          <tr className="filters">
+            <TableSearchFilter
+              meta={tableMeta}
+              values={filterValues}
+              onSort={handleSort}
+              onValueChange={handleFilterChange}
+              sortFieldName={sort.fieldName}
+              sortDirection={sort.direction}
+              studyListDateFilterNumDays={studyListDateFilterNumDays}
             />
-          ))}
-      </tbody>
-    </table>
+          </tr>
+        </thead>
+        <tbody className="table-body" data-cy="study-list-results">
+          {/* I'm not in love with this approach, but it's the quickest way for now
+           *
+           * - Display different content based on loading, empty, results state
+           *
+           * This is not ideal because it create a jump in focus. For loading especially,
+           * We should keep our current results visible while we load the new ones.
+           */}
+          {/* LOADING */}
+          {isLoading && (
+            <tr className="no-hover">
+              <td colSpan={tableMeta.length}>
+                <StudyListLoadingText />
+              </td>
+            </tr>
+          )}
+          {!isLoading && hasError && (
+            <tr className="no-hover">
+              <td colSpan={tableMeta.length}>
+                <div className="notFound">
+                  {t('There was an error fetching studies')}
+                </div>
+              </td>
+            </tr>
+          )}
+          {/* EMPTY */}
+          {!isLoading && !studies.length && (
+            <tr className="no-hover">
+              <td colSpan={tableMeta.length}>
+                <div className="notFound">{t('No matching results')}</div>
+              </td>
+            </tr>
+          )}
+          {!isLoading &&
+            studies.map((study, index) => (
+              <TableRow
+                key={`${study.studyInstanceUid}-${index}`}
+                onClick={studyInstanceUid => handleSelectItem(studyInstanceUid)}
+                accessionNumber={study.accessionNumber || ''}
+                modalities={study.modalities}
+                patientId={study.patientId || ''}
+                patientName={study.patientName || ''}
+                studyDate={study.studyDate}
+                studyDescription={study.studyDescription || ''}
+                studyInstanceUid={study.studyInstanceUid}
+                t={t}
+              />
+            ))}
+        </tbody>
+      </table>
+    )
   );
 }
 

--- a/platform/ui/src/components/studyList/StudyList.js
+++ b/platform/ui/src/components/studyList/StudyList.js
@@ -30,9 +30,7 @@ function StudyList(props) {
     //
     studyListDateFilterNumDays,
   } = props;
-  const { t, i18n, ready } = useTranslation('StudyList', {
-    useSuspense: false,
-  });
+  const { t, i18n } = useTranslation('StudyList');
 
   const largeTableMeta = [
     {

--- a/platform/ui/src/components/studyList/StudyList.js
+++ b/platform/ui/src/components/studyList/StudyList.js
@@ -7,7 +7,7 @@ import useMedia from '../../hooks/useMedia.js';
 import PropTypes from 'prop-types';
 import ColorHash from './internal/color-hash.js';
 import { StudyListLoadingText } from './StudyListLoadingText.js';
-import { withTranslation } from '../../utils/LanguageProvider';
+import { useTranslation } from 'react-i18next';
 
 const colorHash = new ColorHash();
 
@@ -27,10 +27,10 @@ function StudyList(props) {
     filterValues,
     onFilterChange: handleFilterChange,
     onSelectItem: handleSelectItem,
-    t,
     //
     studyListDateFilterNumDays,
   } = props;
+  const [t] = useTranslation('StudyList');
 
   const largeTableMeta = [
     {
@@ -73,13 +73,13 @@ function StudyList(props) {
 
   const mediumTableMeta = [
     {
-      displayText: 'Patient / MRN',
+      displayText: `${t('Patient')} / ${t('MRN')}`,
       fieldName: 'patientNameOrId',
       inputType: 'text',
       size: 250,
     },
     {
-      displayText: 'Description',
+      displayText: t('Description'),
       fieldName: 'accessionOrModalityOrDescription',
       inputType: 'text',
       size: 350,
@@ -94,7 +94,7 @@ function StudyList(props) {
 
   const smallTableMeta = [
     {
-      displayText: 'Search',
+      displayText: t('Search'),
       fieldName: 'allFields',
       inputType: 'text',
       size: 100,
@@ -393,5 +393,4 @@ TableRow.defaultProps = {
   isHighlighted: false,
 };
 
-const connectedComponent = withTranslation('StudyList')(StudyList);
-export { connectedComponent as StudyList };
+export { StudyList };

--- a/platform/ui/src/components/studyList/TableSearchFilter.js
+++ b/platform/ui/src/components/studyList/TableSearchFilter.js
@@ -6,8 +6,6 @@ import CustomDateRangePicker from './CustomDateRangePicker.js';
 import { Icon } from './../../elements/Icon';
 import { useTranslation } from 'react-i18next';
 
-
-
 function TableSearchFilter(props) {
   const {
     meta,
@@ -17,10 +15,10 @@ function TableSearchFilter(props) {
     sortFieldName,
     sortDirection,
     // TODO: Rename
-    studyListDateFilterNumDays
+    studyListDateFilterNumDays,
   } = props;
   const [focusedInput, setFocusedInput] = useState(null);
-  const [t] = useTranslation(); // 'Common'?
+  const [t] = useTranslation('Common');
 
   const sortIcons = ['sort', 'sort-up', 'sort-down'];
   const sortIconForSortField =
@@ -29,7 +27,10 @@ function TableSearchFilter(props) {
   const today = moment();
   const lastWeek = moment().subtract(7, 'day');
   const lastMonth = moment().subtract(1, 'month');
-  const defaultStartDate = moment().subtract(studyListDateFilterNumDays, 'days');
+  const defaultStartDate = moment().subtract(
+    studyListDateFilterNumDays,
+    'days'
+  );
   const defaultEndDate = today;
   const studyDatePresets = [
     {

--- a/platform/ui/src/components/studyList/TableSearchFilter.js
+++ b/platform/ui/src/components/studyList/TableSearchFilter.js
@@ -18,9 +18,7 @@ function TableSearchFilter(props) {
     studyListDateFilterNumDays,
   } = props;
   const [focusedInput, setFocusedInput] = useState(null);
-  const { t, i18n, ready } = useTranslation('Common', {
-    useSuspense: false,
-  });
+  const { t, i18n } = useTranslation('Common');
 
   console.log('TABLE SEARCH FILTER:', i18n, ready);
 

--- a/platform/ui/src/components/studyList/TableSearchFilter.js
+++ b/platform/ui/src/components/studyList/TableSearchFilter.js
@@ -52,59 +52,58 @@ function TableSearchFilter(props) {
     },
   ];
 
-  return (
-    ready &&
-    meta.map((field, i) => {
-      const { displayText, fieldName, inputType } = field;
-      const isSortField = sortFieldName === fieldName;
-      const sortIcon = isSortField ? sortIconForSortField : sortIcons[0];
+  return ready
+    ? meta.map((field, i) => {
+        const { displayText, fieldName, inputType } = field;
+        const isSortField = sortFieldName === fieldName;
+        const sortIcon = isSortField ? sortIconForSortField : sortIcons[0];
 
-      return (
-        <th key={`${fieldName}-${i}`}>
-          <label
-            htmlFor={`filter-${fieldName}`}
-            onClick={() => onSort(fieldName)}
-          >
-            {`${displayText} `}
-            <Icon name={sortIcon} style={{ fontSize: '12px' }} />
-          </label>
-          {inputType === 'text' && (
-            <input
-              type="text"
-              id={`filter-${fieldName}`}
-              className="form-control studylist-search"
-              value={values[fieldName]}
-              onChange={e => onValueChange(fieldName, e.target.value)}
-            />
-          )}
-          {inputType === 'date-range' && (
-            // https://github.com/airbnb/react-dates
-            <CustomDateRangePicker
-              // Required
-              startDate={studyListDateFilterNumDays ? defaultStartDate : null}
-              startDateId="start-date"
-              endDate={studyListDateFilterNumDays ? defaultEndDate : null}
-              endDateId="end-date"
-              // TODO: We need a dynamic way to determine which fields values to update
-              onDatesChange={({ startDate, endDate, preset = false }) => {
-                onValueChange('studyDateTo', startDate);
-                onValueChange('studyDateFrom', endDate);
-              }}
-              focusedInput={focusedInput}
-              onFocusChange={updatedVal => setFocusedInput(updatedVal)}
-              // Optional
-              numberOfMonths={1} // For med and small screens? 2 for large?
-              showClearDates={true}
-              anchorDirection="left"
-              presets={studyDatePresets}
-              hideKeyboardShortcutsPanel={true}
-              isOutsideRange={day => !isInclusivelyBeforeDay(day, moment())}
-            />
-          )}
-        </th>
-      );
-    })
-  );
+        return (
+          <th key={`${fieldName}-${i}`}>
+            <label
+              htmlFor={`filter-${fieldName}`}
+              onClick={() => onSort(fieldName)}
+            >
+              {`${displayText} `}
+              <Icon name={sortIcon} style={{ fontSize: '12px' }} />
+            </label>
+            {inputType === 'text' && (
+              <input
+                type="text"
+                id={`filter-${fieldName}`}
+                className="form-control studylist-search"
+                value={values[fieldName]}
+                onChange={e => onValueChange(fieldName, e.target.value)}
+              />
+            )}
+            {inputType === 'date-range' && (
+              // https://github.com/airbnb/react-dates
+              <CustomDateRangePicker
+                // Required
+                startDate={studyListDateFilterNumDays ? defaultStartDate : null}
+                startDateId="start-date"
+                endDate={studyListDateFilterNumDays ? defaultEndDate : null}
+                endDateId="end-date"
+                // TODO: We need a dynamic way to determine which fields values to update
+                onDatesChange={({ startDate, endDate, preset = false }) => {
+                  onValueChange('studyDateTo', startDate);
+                  onValueChange('studyDateFrom', endDate);
+                }}
+                focusedInput={focusedInput}
+                onFocusChange={updatedVal => setFocusedInput(updatedVal)}
+                // Optional
+                numberOfMonths={1} // For med and small screens? 2 for large?
+                showClearDates={true}
+                anchorDirection="left"
+                presets={studyDatePresets}
+                hideKeyboardShortcutsPanel={true}
+                isOutsideRange={day => !isInclusivelyBeforeDay(day, moment())}
+              />
+            )}
+          </th>
+        );
+      })
+    : null;
 }
 
 TableSearchFilter.propTypes = {

--- a/platform/ui/src/components/studyList/TableSearchFilter.js
+++ b/platform/ui/src/components/studyList/TableSearchFilter.js
@@ -22,6 +22,8 @@ function TableSearchFilter(props) {
     useSuspense: false,
   });
 
+  console.log('TABLE SEARCH FILTER:', i18n, ready);
+
   const sortIcons = ['sort', 'sort-up', 'sort-down'];
   const sortIconForSortField =
     sortDirection === 'asc' ? sortIcons[1] : sortIcons[2];

--- a/platform/ui/src/components/studyList/TableSearchFilter.js
+++ b/platform/ui/src/components/studyList/TableSearchFilter.js
@@ -18,7 +18,9 @@ function TableSearchFilter(props) {
     studyListDateFilterNumDays,
   } = props;
   const [focusedInput, setFocusedInput] = useState(null);
-  const [t] = useTranslation('Common');
+  const { t, i18n, ready } = useTranslation('Common', {
+    useSuspense: false,
+  });
 
   const sortIcons = ['sort', 'sort-up', 'sort-down'];
   const sortIconForSortField =
@@ -50,56 +52,59 @@ function TableSearchFilter(props) {
     },
   ];
 
-  return meta.map((field, i) => {
-    const { displayText, fieldName, inputType } = field;
-    const isSortField = sortFieldName === fieldName;
-    const sortIcon = isSortField ? sortIconForSortField : sortIcons[0];
+  return (
+    ready &&
+    meta.map((field, i) => {
+      const { displayText, fieldName, inputType } = field;
+      const isSortField = sortFieldName === fieldName;
+      const sortIcon = isSortField ? sortIconForSortField : sortIcons[0];
 
-    return (
-      <th key={`${fieldName}-${i}`}>
-        <label
-          htmlFor={`filter-${fieldName}`}
-          onClick={() => onSort(fieldName)}
-        >
-          {`${displayText} `}
-          <Icon name={sortIcon} style={{ fontSize: '12px' }} />
-        </label>
-        {inputType === 'text' && (
-          <input
-            type="text"
-            id={`filter-${fieldName}`}
-            className="form-control studylist-search"
-            value={values[fieldName]}
-            onChange={e => onValueChange(fieldName, e.target.value)}
-          />
-        )}
-        {inputType === 'date-range' && (
-          // https://github.com/airbnb/react-dates
-          <CustomDateRangePicker
-            // Required
-            startDate={studyListDateFilterNumDays ? defaultStartDate : null}
-            startDateId="start-date"
-            endDate={studyListDateFilterNumDays ? defaultEndDate : null}
-            endDateId="end-date"
-            // TODO: We need a dynamic way to determine which fields values to update
-            onDatesChange={({ startDate, endDate, preset = false }) => {
-              onValueChange('studyDateTo', startDate);
-              onValueChange('studyDateFrom', endDate);
-            }}
-            focusedInput={focusedInput}
-            onFocusChange={updatedVal => setFocusedInput(updatedVal)}
-            // Optional
-            numberOfMonths={1} // For med and small screens? 2 for large?
-            showClearDates={true}
-            anchorDirection="left"
-            presets={studyDatePresets}
-            hideKeyboardShortcutsPanel={true}
-            isOutsideRange={day => !isInclusivelyBeforeDay(day, moment())}
-          />
-        )}
-      </th>
-    );
-  });
+      return (
+        <th key={`${fieldName}-${i}`}>
+          <label
+            htmlFor={`filter-${fieldName}`}
+            onClick={() => onSort(fieldName)}
+          >
+            {`${displayText} `}
+            <Icon name={sortIcon} style={{ fontSize: '12px' }} />
+          </label>
+          {inputType === 'text' && (
+            <input
+              type="text"
+              id={`filter-${fieldName}`}
+              className="form-control studylist-search"
+              value={values[fieldName]}
+              onChange={e => onValueChange(fieldName, e.target.value)}
+            />
+          )}
+          {inputType === 'date-range' && (
+            // https://github.com/airbnb/react-dates
+            <CustomDateRangePicker
+              // Required
+              startDate={studyListDateFilterNumDays ? defaultStartDate : null}
+              startDateId="start-date"
+              endDate={studyListDateFilterNumDays ? defaultEndDate : null}
+              endDateId="end-date"
+              // TODO: We need a dynamic way to determine which fields values to update
+              onDatesChange={({ startDate, endDate, preset = false }) => {
+                onValueChange('studyDateTo', startDate);
+                onValueChange('studyDateFrom', endDate);
+              }}
+              focusedInput={focusedInput}
+              onFocusChange={updatedVal => setFocusedInput(updatedVal)}
+              // Optional
+              numberOfMonths={1} // For med and small screens? 2 for large?
+              showClearDates={true}
+              anchorDirection="left"
+              presets={studyDatePresets}
+              hideKeyboardShortcutsPanel={true}
+              isOutsideRange={day => !isInclusivelyBeforeDay(day, moment())}
+            />
+          )}
+        </th>
+      );
+    })
+  );
 }
 
 TableSearchFilter.propTypes = {


### PR DESCRIPTION
1. Translations are working locally, but they pull from static files that are synced manually from `locize`.
2. Hosted solution displays `key` names instead of translated text.
  - When we use `useTranslation`, we're not guaranteed that our translated text is available
  - `Locize` is enabled, so we fetch translations from its API
  - We're not using suspense, so we need to wait for the `useTranslation` hook's `ready` state

![image](https://user-images.githubusercontent.com/5797588/67885738-80341b80-fb1e-11e9-86ec-e7172b229749.png)
