### PR TITLE
e2e: set right viewport when layout is decreased

### DIFF
--- a/platform/viewer/cypress/integration/common/OHIFCornerstoneToolbar.spec.js
+++ b/platform/viewer/cypress/integration/common/OHIFCornerstoneToolbar.spec.js
@@ -393,6 +393,20 @@ describe('OHIF Cornerstone Toolbar', () => {
     });
   });
 
+  it('checks if the available viewport was set to active when layout is decreased', () => {
+    cy.setLayout(3, 3);
+
+    // activate the ninth viewport
+    cy.get('[data-cy=viewport-container-8]')
+      .click()
+      .should('have.class', 'active');
+
+    cy.setLayout(1, 1);
+
+    // first viewport should be active
+    cy.get('[data-cy=viewport-container-0]').should('have.class', 'active');
+  });
+
   it('checks if Clear tool will delete all measurements added in the viewport', () => {
     //Add measurements in the viewport
     cy.addLengthMeasurement();

--- a/platform/viewer/src/components/ViewportGrid/ViewportPane.js
+++ b/platform/viewer/src/components/ViewportGrid/ViewportPane.js
@@ -35,6 +35,7 @@ const ViewportPane = function(props) {
         propClassName
       )}
       ref={drop}
+      data-cy={`viewport-container-${viewportIndex}`}
     >
       {children}
     </div>


### PR DESCRIPTION
I've checked that #1077 is not a bug anymore -- when the layout changes to a lower number than the last active viewport, the first viewport is set as active automatically.

I've created this test to assert that the right viewport is being set to active when the layout changes.

---

Closes #1077