### PR TITLE
Fix for modalities search result

### DIFF
--- a/platform/viewer/cypress/integration/common/OHIFStudyList.spec.js
+++ b/platform/viewer/cypress/integration/common/OHIFStudyList.spec.js
@@ -1,3 +1,5 @@
+//We are keeping the hardcoded results values for the study list tests
+//this is intended to be running in a controled docker environment with test data.
 describe('OHIF Study List', function() {
   context('Desktop resolution', function() {
     beforeEach(function() {
@@ -41,7 +43,7 @@ describe('OHIF Study List', function() {
       //Wait result list to be displayed
       cy.waitStudyList();
       cy.get('@searchResult').should($list => {
-        expect($list.length).to.be.eq(17);
+        expect($list.length).to.be.eq(18);
         expect($list).to.contain('MR');
       });
     });
@@ -130,7 +132,7 @@ describe('OHIF Study List', function() {
       //Wait result list to be displayed
       cy.waitStudyList();
       cy.get('@searchResult').should($list => {
-        expect($list.length).to.be.eq(17);
+        expect($list.length).to.be.eq(18);
         expect($list).to.contain('MR');
       });
     });


### PR DESCRIPTION
The `MR` modality amount of studies was increased and since we are using hardcoded values for search result comparison, those constants needed to be updated.