### PR TITLE
ci: optional visual test step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -367,6 +367,31 @@ workflows:
           requires:
             - UNIT_TESTS
 
+  PR_OPTIONAL_VISUAL_TESTS:
+    jobs:
+      - AWAIT_APPROVAL:
+          type: approval
+      # Update hub.docker.org
+      - cypress/run:
+          name: 'E2E: PWA'
+          executor: cypress/browsers-chrome76
+          pre-steps:
+            - run: 'rm -rf ~/.yarn && npm i -g yarn && yarn -v && yarn global
+                add wait-on' # Use yarn latest
+          yarn: true
+          store_artifacts: false
+          working_directory: platform/viewer
+          build: npx cross-env QUICK_BUILD=true yarn run build
+          # start server --> verify running --> percy + chrome + cypress
+          command: yarn run test:e2e:dist
+          cache-key: 'yarn-packages-{{ checksum "yarn.lock" }}'
+          no-workspace: true # Don't persist workspace
+          post-steps:
+            - store_artifacts:
+                path: platform/viewer/cypress/screenshots
+          requires:
+            - AWAIT_APPROVAL
+
   PR_OPTIONAL_DOCKER_PUBLISH:
     jobs:
       # https://circleci.com/docs/2.0/workflows/#holding-a-workflow-for-a-manual-approval

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -373,7 +373,7 @@ workflows:
           type: approval
       # Update hub.docker.org
       - cypress/run:
-          name: 'E2E: PWA'
+          name: 'Generate Percy Snapshots'
           executor: cypress/browsers-chrome76
           pre-steps:
             - run: 'rm -rf ~/.yarn && npm i -g yarn && yarn -v && yarn global


### PR DESCRIPTION
1. `PR_OPTIONAL_VISUAL_TESTS`
2. Manual approval

![image](https://user-images.githubusercontent.com/5797588/70589533-f015d700-1b9d-11ea-82a9-5aa112f0d8e9.png)

3. Cypress E2E tests run with a custom command that enables `percy.io` executor
4. Captured snapshots are called out in output:

![image](https://user-images.githubusercontent.com/5797588/70589597-15a2e080-1b9e-11ea-9c53-e5863bea3a27.png)

5. New status check appears for `percy`

![image](https://user-images.githubusercontent.com/5797588/70589637-2fdcbe80-1b9e-11ea-9ce6-e4e153fcb62a.png)

6. Wait for comparison to process:

![image](https://user-images.githubusercontent.com/5797588/70589793-a8437f80-1b9e-11ea-8e8c-6cea1d06d87b.png)

## Comparisons

### New Snapshots:

![image](https://user-images.githubusercontent.com/5797588/70590011-5818ed00-1b9f-11ea-9945-b0d06002c165.png)

### In Different Browsers:

![image](https://user-images.githubusercontent.com/5797588/70590028-649d4580-1b9f-11ea-9eb2-2049955d7299.png)

### In Different Dimensions:

![image](https://user-images.githubusercontent.com/5797588/70590046-7b439c80-1b9f-11ea-9ae0-d52a958606d2.png)

### Visual Diffs w/ Changes Highlighted:

![image](https://user-images.githubusercontent.com/5797588/70590093-a1693c80-1b9f-11ea-9d52-aa14f57ef2b1.png)

### Visual Diffs w/o Changes Highlighted:

![image](https://user-images.githubusercontent.com/5797588/70590125-ba71ed80-1b9f-11ea-9181-af67ccea4157.png)


## Final notes

### Quota

⚠️ We need to be careful about how much we test if we're going to stay under our quota.

Number of screenshots: 20
Checks at different dimensions: `375px` and `1280px` (2)
Number of browsers to test in: Chrome + FireFox (2)

20 * 2 * 2 = `80 screenshots`

### Expiration

We're limited to 30-days of history. Any important visual notes should be screen captured and shared on GitHub issues to preserve a reference. Images are archived in CircleCI as well. I'm unsure of for what duration.

### "Trusted Branch"

Can only be initiated from a trusted branch (ie. off of `upstream`) or else percy's keys will not be available. This is the same limitation we have for npm, github, etc. tokens/keys.


### PR Checklist

- [x] Brief description of changes
- [x] Links to any relevant issues
- [x] Required status checks are passing
- [x] User cases if changes impact the user's experience
- [x] `@mention` a maintainer to request a review

<!--
  Links
  -->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
