### PR TITLE
fix: allow empty values for dimensions

### DIFF
--- a/platform/ui/src/components/content/viewportDownloadForm/ViewportDownloadForm.js
+++ b/platform/ui/src/components/content/viewportDownloadForm/ViewportDownloadForm.js
@@ -46,20 +46,20 @@ const ViewportDownloadForm = ({
 
   const [viewportElement, setViewportElement] = useState();
   const [viewportElementDimensions, setViewportElementDimensions] = useState({
-    width: minimumSize,
-    height: minimumSize,
+    width: defaultSize,
+    height: defaultSize,
   });
 
   const [downloadCanvas, setDownloadCanvas] = useState({
     ref: createRef(),
-    width: minimumSize,
-    height: minimumSize,
+    width: defaultSize,
+    height: defaultSize,
   });
 
   const [viewportPreview, setViewportPreview] = useState({
     src: null,
-    width: minimumSize,
-    height: minimumSize,
+    width: defaultSize,
+    height: defaultSize,
   });
 
   // Cornerstone's `enable/disable`
@@ -289,6 +289,7 @@ ViewportDownloadForm.propTypes = {
   toggleAnnotations: PropTypes.func.isRequired,
   loadImage: PropTypes.func.isRequired,
   downloadBlob: PropTypes.func.isRequired,
+  /** A default width & height, between the minimum and maximum size */
   defaultSize: PropTypes.number.isRequired,
   minimumSize: PropTypes.number.isRequired,
   maximumSize: PropTypes.number.isRequired,

--- a/platform/ui/src/components/content/viewportDownloadForm/ViewportDownloadForm.js
+++ b/platform/ui/src/components/content/viewportDownloadForm/ViewportDownloadForm.js
@@ -37,19 +37,18 @@ const ViewportDownloadForm = ({
   const [filename, setFilename] = useState(DEFAULT_FILENAME);
   const [fileType, setFileType] = useState('jpg');
 
-  const [height, setHeight] = useState(defaultSize);
-  const [width, setWidth] = useState(defaultSize);
+  const [dimensions, setDimensions] = useState({
+    width: defaultSize,
+    height: defaultSize,
+  });
 
   const [showAnnotations, setShowAnnotations] = useState(true);
 
-  const [keepAspect, setKeepAspect] = useState(true);
-  const [lastImage, setLastImage] = useState();
-
   const [viewportElement, setViewportElement] = useState();
-  const [viewportElementHeight, setViewportElementHeight] = useState(
-    minimumSize
-  );
-  const [viewportElementWidth, setViewportElementWidth] = useState(minimumSize);
+  const [viewportElementDimensions, setViewportElementDimensions] = useState({
+    width: minimumSize,
+    height: minimumSize,
+  });
 
   const [downloadCanvas, setDownloadCanvas] = useState({
     ref: createRef(),
@@ -63,37 +62,21 @@ const ViewportDownloadForm = ({
     height: minimumSize,
   });
 
+  // Cornerstone's `enable/disable`
   useEffect(() => {
     enableViewport(viewportElement);
 
     return () => {
       disableViewport(viewportElement);
-
-      setHeight(defaultSize);
-      setWidth(defaultSize);
     };
-  }, [defaultSize, disableViewport, enableViewport, viewportElement]);
+  }, [disableViewport, enableViewport, viewportElement]);
 
   useEffect(() => {
+    const { width, height } = viewportElementDimensions;
     const validSize = value => (value >= minimumSize ? value : minimumSize);
     const loadAndUpdateViewports = async () => {
-      const {
-        image,
-        width: scaledWidth,
-        height: scaledHeight,
-      } = await loadImage(activeViewport, viewportElement, width, height);
-      setLastImage(image);
-
+      await loadImage(activeViewport, viewportElement, width, height);
       toggleAnnotations(showAnnotations, viewportElement);
-
-      setViewportElementHeight(validSize(scaledHeight));
-      setViewportElementWidth(validSize(scaledWidth));
-
-      setDownloadCanvas(state => ({
-        ...state,
-        height: validSize(scaledHeight),
-        width: validSize(scaledWidth),
-      }));
 
       const {
         dataUrl,
@@ -118,8 +101,6 @@ const ViewportDownloadForm = ({
     activeViewport,
     viewportElement,
     showAnnotations,
-    height,
-    width,
     loadImage,
     toggleAnnotations,
     updateViewportPreview,
@@ -127,54 +108,41 @@ const ViewportDownloadForm = ({
     downloadCanvas.ref,
     minimumSize,
     maximumSize,
+    viewportElementDimensions,
   ]);
 
-  const onHeightChange = event => {
-    const newHeight = Math.min(event.target.value, maximumSize);
-    setHeight(newHeight);
+  /**
+   * @param {object} event - Input change event
+   * @param {string} dimension - "height" | "width"
+   */
+  const onDimensionsChange = (event, dimension) => {
+    const sanitizedTargetValue = event.target.value.replace(/\D/, '');
+    const isEmpty = sanitizedTargetValue === '';
+    const updatedDimension = isEmpty
+      ? ''
+      : Math.min(sanitizedTargetValue, maximumSize);
 
-    setViewportElementHeight(newHeight);
-
-    setDownloadCanvas(state => ({
-      ...state,
-      height: newHeight,
-    }));
-
-    if (keepAspect) {
-      const multiplier = newHeight / lastImage.height;
-      const newWidth = Math.round(lastImage.width * multiplier);
-
-      setWidth(newWidth);
-      setViewportElementWidth(newWidth);
-
-      setDownloadCanvas(state => ({
-        ...state,
-        width: newWidth,
-      }));
+    if (updatedDimension === dimensions.width) {
+      return;
     }
-  };
 
-  const onWidthChange = event => {
-    const newWidth = Math.min(event.target.value, maximumSize);
-    setWidth(newWidth);
+    // In current code, keepAspect is always `true`
+    // And we always start w/ a square width/height
+    setDimensions({
+      width: updatedDimension,
+      height: updatedDimension,
+    });
 
-    setViewportElementWidth(newWidth);
-
-    setDownloadCanvas(state => ({
-      ...state,
-      width: newWidth,
-    }));
-
-    if (keepAspect) {
-      const multiplier = newWidth / lastImage.width;
-      const newHeight = Math.round(lastImage.height * multiplier);
-
-      setHeight(newHeight);
-      setViewportElementHeight(newHeight);
-
+    // Only update if value is non-empty
+    if (!isEmpty) {
+      setViewportElementDimensions({
+        height: updatedDimension,
+        width: updatedDimension,
+      });
       setDownloadCanvas(state => ({
         ...state,
-        height: newHeight,
+        height: updatedDimension,
+        width: updatedDimension,
       }));
     }
   };
@@ -200,24 +168,18 @@ const ViewportDownloadForm = ({
         <div className="col">
           <div className="width">
             <TextInput
-              type="number"
               data-cy="image-width"
-              min={minimumSize}
-              max={maximumSize}
-              value={width}
+              value={dimensions.width}
               label={t('Image width (px)')}
-              onChange={onWidthChange}
+              onChange={evt => onDimensionsChange(evt, 'height')}
             />
           </div>
           <div className="height">
             <TextInput
-              type="number"
               data-cy="image-height"
-              min={minimumSize}
-              max={maximumSize}
-              value={height}
+              value={dimensions.height}
               label={t('Image height (px)')}
-              onChange={onHeightChange}
+              onChange={evt => onDimensionsChange(evt, 'width')}
             />
           </div>
         </div>
@@ -263,8 +225,8 @@ const ViewportDownloadForm = ({
 
       <div
         style={{
-          height: viewportElementHeight,
-          width: viewportElementWidth,
+          height: viewportElementDimensions.height,
+          width: viewportElementDimensions.width,
           position: 'absolute',
           left: '9999px',
         }}


### PR DESCRIPTION
We triggered two failing tests when we upgraded our version of Cypress. This PR attempts to address one of those failures. It allows for the `width` and `height` input fields to be empty.

Previously, they were `number` fields, and always had to have a value of at least `0`.

I tried not to stray too far from the task at hand, but I did consolidate a few things.

### User Cases:

- As a user, I expect to be able to clear an input field before I begin typing
  - Bad: `526` --> clear field --> `0` --> type "300" --> new value is `0300`
  - Good: `526` --> clear field --> "" --> type "300" --> new value is `300`
- As a developer, I want my tests to pass ^_^

### Notes:

- Will likely conflict with: https://github.com/OHIF/Viewers/pull/1235
  - This PR attempts to address other UX issues/bugs
- Related PR: https://github.com/OHIF/Viewers/pull/1293#issuecomment-565259817

### PR Checklist

- [x] Brief description of changes
- [x] Links to any relevant issues
- [x] Required status checks are passing
  - The failures associated with this change appear to be resolved
- [x] User cases if changes impact the user's experience
- [x] `@mention` a maintainer to request a review

<!--
  Links
  -->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
