### PR TITLE
fix: 🐛 #1124 Click on measurement should always move the viewport to its imageId

### DIFF
--- a/extensions/cornerstone/package.json
+++ b/extensions/cornerstone/package.json
@@ -50,6 +50,6 @@
     "lodash.merge": "^4.6.2",
     "lodash.throttle": "^4.1.1",
     "query-string": "^6.8.3",
-    "react-cornerstone-viewport": "2.x.x"
+    "react-cornerstone-viewport": "^2.x.x"
   }
 }

--- a/extensions/cornerstone/src/OHIFCornerstoneViewport.js
+++ b/extensions/cornerstone/src/OHIFCornerstoneViewport.js
@@ -212,6 +212,15 @@ class OHIFCornerstoneViewport extends Component {
     });
   }
 
+  onNewImage(newImageData) {
+    const { sopInstanceUid } = newImageData;
+    if (sopInstanceUid) {
+      this.setViewportSpecificData({
+        sopInstanceUid,
+      });
+    }
+  }
+
   componentDidMount() {
     this.setStateFromProps();
   }
@@ -267,6 +276,7 @@ class OHIFCornerstoneViewport extends Component {
           viewportIndex={viewportIndex}
           imageIds={imageIds}
           imageIdIndex={currentImageIdIndex}
+          onNewImage={this.onNewImage}
           // ~~ Connected (From REDUX)
           // frameRate={frameRate}
           // isPlaying={false}

--- a/extensions/cornerstone/src/OHIFCornerstoneViewport.js
+++ b/extensions/cornerstone/src/OHIFCornerstoneViewport.js
@@ -212,41 +212,22 @@ class OHIFCornerstoneViewport extends Component {
     });
   }
 
-  getImageIdIndexChanged(sopInstanceUid) {
-    if (!sopInstanceUid) return false;
-
-    const { imageIds, currentImageIdIndex } = this.state.viewportData.stack;
-    const imageId = imageIds[currentImageIdIndex];
-    const sopCommonModule = cornerstone.metaData.get(
-      'sopCommonModule',
-      imageId
-    );
-
-    if (!sopCommonModule) {
-      return;
-    }
-
-    return sopCommonModule.sopInstanceUID !== sopInstanceUid;
-  }
-
   componentDidMount() {
     this.setStateFromProps();
   }
 
-  componentDidUpdate(prevProps, prevState) {
+  componentDidUpdate(prevProps) {
     const { displaySet } = this.props.viewportData;
     const prevDisplaySet = prevProps.viewportData.displaySet;
 
     const displaySetInstanceUidChanged = displaySet.displaySetInstanceUid !== prevDisplaySet.displaySetInstanceUid;
     const sopInstanceUidChanged = displaySet.sopInstanceUid !== prevDisplaySet.sopInstanceUid;
     const frameIndexChanged = displaySet.frameIndex !== prevDisplaySet.frameIndex;
-    const imageIdIndexChanged = this.getImageIdIndexChanged(displaySet.sopInstanceUid);
 
     if (
       displaySetInstanceUidChanged ||
       sopInstanceUidChanged ||
-      frameIndexChanged ||
-      imageIdIndexChanged
+      frameIndexChanged
     ) {
       this.setStateFromProps();
     }

--- a/extensions/cornerstone/src/OHIFCornerstoneViewport.js
+++ b/extensions/cornerstone/src/OHIFCornerstoneViewport.js
@@ -212,19 +212,46 @@ class OHIFCornerstoneViewport extends Component {
     });
   }
 
+  setImageIdIndex(imageIdIndex) {
+    this.setState(state => {
+      state.viewportData.stack.currentImageIdIndex = imageIdIndex;
+      return state;
+    });
+  }
+
+  getImageIdIndexChanged(sopInstanceUid) {
+    const { imageIds, currentImageIdIndex } = this.state.viewportData.stack;
+    const imageId = imageIds[currentImageIdIndex];
+    const sopCommonModule = cornerstone.metaData.get(
+      'sopCommonModule',
+      imageId
+    );
+
+    if (!sopCommonModule) {
+      return;
+    }
+
+    return sopCommonModule.sopInstanceUID !== sopInstanceUid;
+  }
+
   componentDidMount() {
     this.setStateFromProps();
   }
 
-  componentDidUpdate(prevProps) {
-    const { studies, displaySet } = this.props.viewportData;
+  componentDidUpdate(prevProps, prevState) {
+    const { displaySet } = this.props.viewportData;
     const prevDisplaySet = prevProps.viewportData.displaySet;
 
+    const displaySetInstanceUidChanged = displaySet.displaySetInstanceUid !== prevDisplaySet.displaySetInstanceUid;
+    const sopInstanceUidChanged = displaySet.sopInstanceUid !== prevDisplaySet.sopInstanceUid;
+    const frameIndexChanged = displaySet.frameIndex !== prevDisplaySet.frameIndex;
+    const imageIdIndexChanged = this.getImageIdIndexChanged(displaySet.sopInstanceUid);
+
     if (
-      displaySet.displaySetInstanceUid !==
-        prevDisplaySet.displaySetInstanceUid ||
-      displaySet.sopInstanceUid !== prevDisplaySet.sopInstanceUid ||
-      displaySet.frameIndex !== prevDisplaySet.frameIndex
+      displaySetInstanceUidChanged ||
+      sopInstanceUidChanged ||
+      frameIndexChanged ||
+      imageIdIndexChanged
     ) {
       this.setStateFromProps();
     }
@@ -264,6 +291,7 @@ class OHIFCornerstoneViewport extends Component {
           viewportIndex={viewportIndex}
           imageIds={imageIds}
           imageIdIndex={currentImageIdIndex}
+          updateImageIdIndex={this.setImageIdIndex.bind(this)}
           // ~~ Connected (From REDUX)
           // frameRate={frameRate}
           // isPlaying={false}

--- a/extensions/cornerstone/src/OHIFCornerstoneViewport.js
+++ b/extensions/cornerstone/src/OHIFCornerstoneViewport.js
@@ -212,14 +212,9 @@ class OHIFCornerstoneViewport extends Component {
     });
   }
 
-  setImageIdIndex(imageIdIndex) {
-    this.setState(state => {
-      state.viewportData.stack.currentImageIdIndex = imageIdIndex;
-      return state;
-    });
-  }
-
   getImageIdIndexChanged(sopInstanceUid) {
+    if (!sopInstanceUid) return false;
+
     const { imageIds, currentImageIdIndex } = this.state.viewportData.stack;
     const imageId = imageIds[currentImageIdIndex];
     const sopCommonModule = cornerstone.metaData.get(
@@ -291,7 +286,6 @@ class OHIFCornerstoneViewport extends Component {
           viewportIndex={viewportIndex}
           imageIds={imageIds}
           imageIdIndex={currentImageIdIndex}
-          updateImageIdIndex={this.setImageIdIndex.bind(this)}
           // ~~ Connected (From REDUX)
           // frameRate={frameRate}
           // isPlaying={false}

--- a/platform/core/src/redux/reducers/viewports.js
+++ b/platform/core/src/redux/reducers/viewports.js
@@ -97,11 +97,6 @@ const viewports = (state = DEFAULT_STATE, action) => {
         action.viewportSpecificData
       );
 
-      // Make sure if we do not change the sopInstanceUid we don't keep the old one stored
-      if (!action.viewportSpecificData.sopInstanceUid) {
-        delete viewportSpecificData[action.viewportIndex].sopInstanceUid;
-      }
-
       if (action.viewportSpecificData && action.viewportSpecificData.plugin) {
         layout.viewports[action.viewportIndex].plugin =
           action.viewportSpecificData.plugin;

--- a/platform/core/src/redux/reducers/viewports.js
+++ b/platform/core/src/redux/reducers/viewports.js
@@ -97,6 +97,11 @@ const viewports = (state = DEFAULT_STATE, action) => {
         action.viewportSpecificData
       );
 
+      // Make sure if we do not change the sopInstanceUid we don't keep the old one stored
+      if (!action.viewportSpecificData.sopInstanceUid) {
+        delete viewportSpecificData[action.viewportIndex].sopInstanceUid;
+      }
+
       if (action.viewportSpecificData && action.viewportSpecificData.plugin) {
         layout.viewports[action.viewportIndex].plugin =
           action.viewportSpecificData.plugin;

--- a/yarn.lock
+++ b/yarn.lock
@@ -15842,10 +15842,10 @@ react-codemirror2@^6.0.0:
   resolved "https://registry.yarnpkg.com/react-codemirror2/-/react-codemirror2-6.0.0.tgz#180065df57a64026026cde569a9708fdf7656525"
   integrity sha512-D7y9qZ05FbUh9blqECaJMdDwKluQiO3A9xB+fssd5jKM7YAXucRuEOlX32mJQumUvHUkHRHqXIPBjm6g0FW0Ag==
 
-react-cornerstone-viewport@2.x.x:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/react-cornerstone-viewport/-/react-cornerstone-viewport-2.1.0.tgz#1f353e3b0a57c45add70e5040b819290d9f55f4b"
-  integrity sha512-HahonGn2ZSud/yMSClWL3YDlh74hE46OMyTeTI7i80EWYPXO1eKeHajwyFvfl2wWXycuotpyhUlwIfQY1h4jRw==
+react-cornerstone-viewport@^2.x.x:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/react-cornerstone-viewport/-/react-cornerstone-viewport-2.3.0.tgz#0200b1755cc98110ee6884fa04d90917e3056386"
+  integrity sha512-6jVyAgWWhFOYbf0HjT7ZE4pfXCdUGZB5qcyFidCjx0iFr1q+EL6E2q0PUqORQNhAVr3XvMTMQynHl9wMEc2NAQ==
   dependencies:
     classnames "^2.2.6"
     date-fns "^2.2.1"


### PR DESCRIPTION
### Changes
- We update redux state of `viewportSpecificData` with viewport's current `sopInstanceUid`

### User cases
As an user, I should be able to follow the steps bellow with success:
- Create any annotation supported by measurement table (e.g. length)
- Click in the measurement item in the table
- Scroll to another image after the viewport move to clicked measurement's image
- Select the same measurement item in the table
- Viewport should scroll to the measurement's image again

Closes: #1124 

<!--
  Links
  -->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
