### PR TITLE
fix: 🐛 Fix drag-n-drop of local files into OHIF

### DIFF
--- a/platform/ui/src/contextProviders/DialogProvider.js
+++ b/platform/ui/src/contextProviders/DialogProvider.js
@@ -152,6 +152,7 @@ const DialogProvider = ({ children, service }) => {
         onStart,
         onStop,
         onDrag,
+        showOverlay,
       } = dialog;
 
       let position =
@@ -160,7 +161,7 @@ const DialogProvider = ({ children, service }) => {
         position = centerPositions.find(position => position.id === id);
       }
 
-      return (
+      const dragableItem = () => (
         <Draggable
           key={id}
           disabled={!isDraggable}
@@ -217,6 +218,16 @@ const DialogProvider = ({ children, service }) => {
           </div>
         </Draggable>
       );
+
+      return (
+        showOverlay ? (
+          <div className="Overlay" key={id}>
+            {dragableItem()}
+          </div>
+        ) : (
+            dragableItem()
+          )
+      );
     });
 
   /**
@@ -238,13 +249,11 @@ const DialogProvider = ({ children, service }) => {
 
   return (
     <DialogContext.Provider value={{ create, dismiss, dismissAll, isEmpty }}>
-      <div className="DraggableArea">
-        {dialogs.some(dialog => dialog.showOverlay) ? (
-          <div className="Overlay active">{renderDialogs()}</div>
-        ) : (
-          renderDialogs()
-        )}
-      </div>
+      {!isEmpty() &&
+        <div className="DraggableArea">
+          {renderDialogs()}
+        </div>
+      }
       {children}
     </DialogContext.Provider>
   );

--- a/platform/ui/src/contextProviders/DialogProvider.styl
+++ b/platform/ui/src/contextProviders/DialogProvider.styl
@@ -6,17 +6,16 @@
   div
     cursor: grabbing !important
 
-.DraggableArea, .Overlay
+.DraggableArea
   width: 100%
   height: 100%
   position: absolute
-
-.Overlay.active
-  position: fixed
-  z-index: 999
-  left: 0
-  top: 0
-  width: 100%
-  height: 100%
-  overflow: auto
-  background: rgba(0,0,0,.1)
+  .Overlay
+    position: fixed
+    z-index: 999
+    left: 0
+    top: 0
+    width: 100%
+    height: 100%
+    overflow: auto
+    background: rgba(0,0,0,.1)


### PR DESCRIPTION
### Changes
- DialogProvider will only add the draggable area if there is any dialog to be shown
- DialogProvider will add one Overlay for each Overlay found, this way user can only interact with 1 overlay at time. 

### User cases
As an user
- I should be able to drag and drop any dicom file or folder into `/local` and get the standaloneViewer to open the study
- I should be able to see dialogs across the viewer working properly (e.g. ArrowAnnotation dialog, Relabel dialog, cine dialog)

Closes: #1307

### PR Checklist

- [x] Brief description of changes
- [x] Links to any relevant issues
- [ ] Required status checks are passing
- [x] User cases if changes impact the user's experience
- [x] `@mention` a maintainer to request a review

<!--
  Links
  -->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
