### PR TITLE
fix: 🐛 Metadata is being mistakenly purged

### DIFF
--- a/platform/viewer/src/connectedComponents/ViewerRetrieveStudyData.js
+++ b/platform/viewer/src/connectedComponents/ViewerRetrieveStudyData.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useContext } from 'react';
 import { metadata, studies, utils, log } from '@ohif/core';
+import usePrevious from '../customHooks/usePrevious';
 
 import ConnectedViewer from './ConnectedViewer.js';
 import PropTypes from 'prop-types';
@@ -128,9 +129,9 @@ const _addSeriesToStudy = (studyMetadata, series) => {
 const _updateMetaDataManager = (study, studyMetadata, series) => {
   updateMetaDataManager(study, series);
 
-  const { studyInstanceUID } = study;
+  const { studyInstanceUid } = study;
 
-  if (!studyMetadataManager.get(studyInstanceUID)) {
+  if (!studyMetadataManager.get(studyInstanceUid)) {
     studyMetadataManager.add(studyMetadata);
   }
 };
@@ -314,9 +315,15 @@ function ViewerRetrieveStudyData({
     }
   };
 
+  const prevStudyInstanceUids = usePrevious(studyInstanceUids);
+
   useEffect(() => {
-    studyMetadataManager.purge();
-    purgeCancellablePromises();
+    const hasStudyInstanceUidsChanged = !(prevStudyInstanceUids && prevStudyInstanceUids.every(e => studyInstanceUids.includes(e)));
+
+    if (hasStudyInstanceUidsChanged) {
+      studyMetadataManager.purge();
+      purgeCancellablePromises();
+    }
   }, [studyInstanceUids]);
 
   useEffect(() => {


### PR DESCRIPTION
### Description
StudyMetadata is being mistakenly purged once we load a study into the viewer and blocking the 2D MPR button component to check if the current study/series is reconstructable.

### User cases
As an user: 
- I should be able to open a study twice in a row* and be able to see the 2D MPR button everytime it is required.

It should fix the issue number 1 reported on #1326 :

> Issue 1: 2D MPR button is not displayed if user clicks on Study List and selects the same Patient
> When user is viewing a Patient series that is reconstructable the 2D MPR button will be displayed as expected. But if user decides to click on Study List link and then selects the same Patient, the 2d MPR button will not be displayed anymore. If user reloads the page, the button will be displayed again.
> 
> Although I tested this in incognito mode, it looks like something related to cache. (not sure though)
> 
> **Steps to Reproduce:**
> 
> - Search and select Patient Name: Juno
> - Drag-n-drop 3rd thumbnail into the viewport
> - Verify that button 2D MPR is displayed as expected
> - Click on link Study list
> - Search and select Patient Name: Juno
> - Drag-n-drop 3rd thumbnail into the viewport
>  -Verify that button 2D MPR is not displayed 


Closes: #1326 (Issue #1) 

