### PR TITLE
Custom Healthcare API endpoint

### DIFF
--- a/.docker/Viewer-v2.x/entrypoint.sh
+++ b/.docker/Viewer-v2.x/entrypoint.sh
@@ -1,29 +1,29 @@
 #!/bin/bash
 
-# If CLIENT_ID is specified, use the google.js configuration with the modified ID
-if [ -n "$CLIENT_ID" ]
-  then
-  	echo "Google Cloud Healthcare $CLIENT_ID has been provided: "
-  	echo "$CLIENT_ID"
-  	echo "Updating config..."
-
-  	# - Use SED to replace the CLIENT_ID that is currently in google.js
-	  sed -i -e "s/YOURCLIENTID.apps.googleusercontent.com/$CLIENT_ID/g" /usr/share/nginx/html/google.js
-fi
-
-# If HEALTHCARE_API_ENDPOINT is specified, use the google.js configuration with the modified endpoint
-if [ -n "$HEALTHCARE_API_ENDPOINT" ]
-  then
-  	echo "Google Cloud Healthcare $HEALTHCARE_API_ENDPOINT has been provided: "
-  	echo "$HEALTHCARE_API_ENDPOINT"
-  	echo "Updating config..."
-
-  	# - Use SED to replace the HEALTHCARE_API_ENDPOINT that is currently in google.js
-	  sed -i -e "s/https:\/\/healthcare.googleapis.com\/v1beta1/$HEALTHCARE_API_ENDPOINT/g" /usr/share/nginx/html/google.js
-fi
-
 if [ -n "$CLIENT_ID" ] || [ -n "$HEALTHCARE_API_ENDPOINT" ]
   then
+    # If CLIENT_ID is specified, use the google.js configuration with the modified ID
+    if [ -n "$CLIENT_ID" ]
+      then
+  	    echo "Google Cloud Healthcare \$CLIENT_ID has been provided: "
+  	    echo "$CLIENT_ID"
+  	    echo "Updating config..."
+
+  	    # - Use SED to replace the CLIENT_ID that is currently in google.js
+	      sed -i -e "s/YOURCLIENTID.apps.googleusercontent.com/$CLIENT_ID/g" /usr/share/nginx/html/google.js
+	  fi
+
+    # If HEALTHCARE_API_ENDPOINT is specified, use the google.js configuration with the modified endpoint
+    if [ -n "$HEALTHCARE_API_ENDPOINT" ]
+      then
+        echo "Google Cloud Healthcare \$HEALTHCARE_API_ENDPOINT has been provided: "
+        echo "$HEALTHCARE_API_ENDPOINT"
+        echo "Updating config..."
+
+        # - Use SED to replace the HEALTHCARE_API_ENDPOINT that is currently in google.js
+        sed -i -e "s+https://healthcare.googleapis.com/v1beta1+$HEALTHCARE_API_ENDPOINT+g" /usr/share/nginx/html/google.js
+    fi
+
 	  # - Copy google.js to overwrite app-config.js
 	  cp /usr/share/nginx/html/google.js /usr/share/nginx/html/app-config.js
 fi

--- a/.docker/Viewer-v2.x/entrypoint.sh
+++ b/.docker/Viewer-v2.x/entrypoint.sh
@@ -1,17 +1,31 @@
 #!/bin/bash
 
 # If CLIENT_ID is specified, use the google.js configuration with the modified ID
-if [ ! -z "$CLIENT_ID" ]
+if [ -n "$CLIENT_ID" ]
   then
   	echo "Google Cloud Healthcare $CLIENT_ID has been provided: "
-  	echo $CLIENT_ID
+  	echo "$CLIENT_ID"
   	echo "Updating config..."
 
   	# - Use SED to replace the CLIENT_ID that is currently in google.js
-	sed -i -e "s/YOURCLIENTID.apps.googleusercontent.com/$CLIENT_ID/g" /usr/share/nginx/html/google.js
+	  sed -i -e "s/YOURCLIENTID.apps.googleusercontent.com/$CLIENT_ID/g" /usr/share/nginx/html/google.js
+fi
 
-	# - Copy google.js to overwrite app-config.js
-	cp /usr/share/nginx/html/google.js /usr/share/nginx/html/app-config.js
+# If HEALTHCARE_API_ENDPOINT is specified, use the google.js configuration with the modified endpoint
+if [ -n "$HEALTHCARE_API_ENDPOINT" ]
+  then
+  	echo "Google Cloud Healthcare $HEALTHCARE_API_ENDPOINT has been provided: "
+  	echo "$HEALTHCARE_API_ENDPOINT"
+  	echo "Updating config..."
+
+  	# - Use SED to replace the HEALTHCARE_API_ENDPOINT that is currently in google.js
+	  sed -i -e "s/https:\/\/healthcare.googleapis.com\/v1beta1/$HEALTHCARE_API_ENDPOINT/g" /usr/share/nginx/html/google.js
+fi
+
+if [ -n "$CLIENT_ID" ] || [ -n "$HEALTHCARE_API_ENDPOINT" ]
+  then
+	  # - Copy google.js to overwrite app-config.js
+	  cp /usr/share/nginx/html/google.js /usr/share/nginx/html/app-config.js
 fi
 
 echo "Starting Nginx to serve the OHIF Viewer..."

--- a/platform/viewer/public/config/google.js
+++ b/platform/viewer/public/config/google.js
@@ -2,6 +2,7 @@ window.config = {
   routerBasename: '/',
   whiteLabelling: {},
   enableGoogleCloudAdapter: true,
+  healthcareApiEndpoint: 'https://healthcare.googleapis.com/v1beta1',
   servers: {
     // This is an array, but we'll only use the first entry for now
     dicomWeb: [],

--- a/platform/viewer/src/customHooks/useServer.js
+++ b/platform/viewer/src/customHooks/useServer.js
@@ -18,6 +18,7 @@ const getActiveServer = servers => {
 const getServers = (appConfig, project, location, dataset, dicomStore) => {
   let servers = [];
   if (appConfig.enableGoogleCloudAdapter) {
+    GoogleCloudApi.urlBase = appConfig.healthcareApiEndpoint;
     const pathUrl = GoogleCloudApi.getUrlBaseDicomWeb(
       project,
       location,

--- a/platform/viewer/src/googleCloud/api/GoogleCloudApi.js
+++ b/platform/viewer/src/googleCloud/api/GoogleCloudApi.js
@@ -15,7 +15,11 @@ class GoogleCloudApi {
   }
 
   get urlBase() {
-    return window.config.healthcareApiEndpoint || 'https://healthcare.googleapis.com/v1beta1';
+    return this.healthcareApiEndpoint || 'https://healthcare.googleapis.com/v1beta1';
+  }
+
+  set urlBase(url) {
+    this.healthcareApiEndpoint = url;
   }
 
   get urlBaseProject() {

--- a/platform/viewer/src/googleCloud/api/GoogleCloudApi.js
+++ b/platform/viewer/src/googleCloud/api/GoogleCloudApi.js
@@ -15,7 +15,7 @@ class GoogleCloudApi {
   }
 
   get urlBase() {
-    return `https://healthcare.googleapis.com/v1beta1`;
+    return window.config.healthcareApiEndpoint;
   }
 
   get urlBaseProject() {

--- a/platform/viewer/src/googleCloud/api/GoogleCloudApi.js
+++ b/platform/viewer/src/googleCloud/api/GoogleCloudApi.js
@@ -15,7 +15,7 @@ class GoogleCloudApi {
   }
 
   get urlBase() {
-    return window.config.healthcareApiEndpoint;
+    return window.config.healthcareApiEndpoint || 'https://healthcare.googleapis.com/v1beta1';
   }
 
   get urlBaseProject() {


### PR DESCRIPTION
Faster data access times for performance critical applications (i.e. primary radiologist reads) is requested by Google and it involves usage of cache that can sit transparently in front of the Cloud Healthcare API.
Currently OHIF does not allow to configure custom Cloud Healthcare API endpoint (hardcoded endpoint is https://healthcare.googleapis.com/v1beta1), so it makes impossible to use caching server.
This change adds such feature.