### PR TITLE
Add palette color cache object back to core (fix #1350)

### DIFF
--- a/platform/viewer/src/lib/localFileLoaders/dicomFileLoader.js
+++ b/platform/viewer/src/lib/localFileLoaders/dicomFileLoader.js
@@ -19,7 +19,7 @@ const DICOMFileLoader = new (class extends FileLoader {
         dicomData.meta
       );
     } catch (e) {
-      console.log('Error on getting dicom file dataset. It defaults to empty');
+      console.error('Error reading dicom file', e);
     }
     // Set imageId on dataset to be consumed later on
     dataset.imageId = imageId;


### PR DESCRIPTION
We previously had a palette color cache object which stored retrieve palette color lookup tables. This was accidentally removed during the switch to the monorepo, which caused some images to stop displaying (#1350).