### PR TITLE
Removing dependency ffmpeg-installer

### DIFF
--- a/platform/viewer/package.json
+++ b/platform/viewer/package.json
@@ -45,7 +45,6 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.5.5",
-    "@ffmpeg-installer/ffmpeg": "1.0.20",
     "@ohif/core": "^2.3.4",
     "@ohif/extension-cornerstone": "^2.2.1",
     "@ohif/extension-dicom-html": "^1.1.0",


### PR DESCRIPTION
The dependency `ffmpeg-installer` was added in order to fix one of failures that we were having on CircleCI related to the videos recorded by Percy during visual regression tests.

But since we are not recording the execution of the tests anymore, there's no point in keeping this dependency on the project's package list. 

### PR Checklist

- [x] Brief description of changes
- [x] Links to any relevant issues
- [x] Required status checks are passing
- [x] User cases if changes impact the user's experience
- [x] `@mention` a maintainer to request a review

<!--
  Links
  -->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
