### PR TITLE
Add DICOM Group 6xxx Overlay Plane rendering

### DIFF
--- a/extensions/cornerstone/package.json
+++ b/extensions/cornerstone/package.json
@@ -32,7 +32,7 @@
     "@ohif/ui": "^0.50.0",
     "cornerstone-core": "^2.2.8",
     "cornerstone-math": "^0.1.8",
-    "cornerstone-tools": "^4.9.0",
+    "cornerstone-tools": "^4.12.0",
     "cornerstone-wado-image-loader": "^3.0.0",
     "dcmjs": "^0.8.2",
     "dicom-parser": "^1.8.3",

--- a/extensions/cornerstone/src/init.js
+++ b/extensions/cornerstone/src/init.js
@@ -98,6 +98,7 @@ export default function init({ servicesManager, configuration }) {
       csTools.MagnifyTool,
       csTools.StackScrollTool,
       csTools.StackScrollMouseWheelTool,
+      csTools.OverlayTool,
     ],
   };
 
@@ -179,4 +180,5 @@ export default function init({ servicesManager, configuration }) {
   csTools.setToolActive('StackScrollMouseWheel', {}); // TODO: Empty options should not be required
   csTools.setToolActive('PanMultiTouch', { pointers: 2 }); // TODO: Better error if no options
   csTools.setToolActive('ZoomTouchPinch', {});
+  csTools.setToolEnabled('Overlay', {});
 }

--- a/extensions/vtk/package.json
+++ b/extensions/vtk/package.json
@@ -54,7 +54,7 @@
   "devDependencies": {
     "@ohif/core": "^2.3.4",
     "@ohif/ui": "^1.1.8",
-    "cornerstone-tools": "^4.9.0",
+    "cornerstone-tools": "^4.12.0",
     "cornerstone-wado-image-loader": "^3.0.0",
     "dicom-parser": "^1.8.3",
     "gh-pages": "^2.0.1",

--- a/platform/core/package.json
+++ b/platform/core/package.json
@@ -32,7 +32,7 @@
   },
   "peerDependencies": {
     "cornerstone-core": "^2.2.8",
-    "cornerstone-tools": "^4.9.0",
+    "cornerstone-tools": "^4.12.0",
     "cornerstone-wado-image-loader": "^3.0.0",
     "dicom-parser": "^1.8.3"
   },

--- a/platform/viewer/package.json
+++ b/platform/viewer/package.json
@@ -58,7 +58,7 @@
     "core-js": "^3.2.1",
     "cornerstone-core": "^2.2.8",
     "cornerstone-math": "^0.1.8",
-    "cornerstone-tools": "^4.9.0",
+    "cornerstone-tools": "^4.12.0",
     "cornerstone-wado-image-loader": "^3.0.0",
     "dcmjs": "^0.8.2",
     "dicom-parser": "^1.8.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5962,10 +5962,10 @@ cornerstone-math@^0.1.8:
   resolved "https://registry.yarnpkg.com/cornerstone-math/-/cornerstone-math-0.1.8.tgz#68ab1f9e4fdcd7c5cb23a0d2eb4263f9f894f1c5"
   integrity sha512-x7NEQHBtVG7j1yeyj/aRoKTpXv1Vh2/H9zNLMyqYJDtJkNng8C4Q8M3CgZ1qer0Yr7eVq2x+Ynmj6kfOm5jXKw==
 
-cornerstone-tools@^4.9.0:
-  version "4.9.0"
-  resolved "https://registry.yarnpkg.com/cornerstone-tools/-/cornerstone-tools-4.9.0.tgz#8b68603c32aceb84baf860f4dd0d36ac176e8b75"
-  integrity sha512-6yHzXm4qn7VuHMRiaV/oS3khdMidtTho6P1OIYICqZ2pmorsH8jN8LvNgqz+Ky9Nf+wvrvi7ul8ZzcD1sJTkWA==
+cornerstone-tools@^4.12.0:
+  version "4.12.0"
+  resolved "https://registry.yarnpkg.com/cornerstone-tools/-/cornerstone-tools-4.12.0.tgz#1adfdac3e1569ca3227e656e2b24ffe8db1fc545"
+  integrity sha512-4ecWbIrufF2Pj04XopcZU95A0iSJUAFa7vZiCVVh/okI6fNIaRe3OkyG5ZZ/7GYIzNfVAQ4TK+yY6UOA3bXTdQ==
   dependencies:
     "@babel/runtime" "7.1.2"
     cornerstone-math "0.1.7"


### PR DESCRIPTION
Once the latest cornerstone-tools is published we can update package.json and merge this. It adds DICOM Group 6xxx overlay rendering to the viewer, which people have been asking for for a long time.