### PR TITLE
fix: Switch MetadataProvider imagePlane to imagePlaneModule

### DIFF
--- a/platform/core/src/classes/MetadataProvider.js
+++ b/platform/core/src/classes/MetadataProvider.js
@@ -75,7 +75,7 @@ class MetadataProvider {
 
     // If there is sufficient information, populate
     // the imagePlane object for easier use in the Viewer
-    metadata.imagePlane = this.getImagePlane(instanceMetadata);
+    metadata.imagePlaneModule = this.getImagePlane(instanceMetadata);
 
     // Add the metadata to the imageId lookup object
     this.metadataLookup.set(imageId, metadata);
@@ -256,8 +256,8 @@ class MetadataProvider {
       );
     }
 
-    imageMetadata.imagePlane =
-      imageMetadata.imagePlane || this.getImagePlane(imageMetadata.instance);
+    imageMetadata.imagePlaneModule =
+      imageMetadata.imagePlaneModule || this.getImagePlane(imageMetadata.instance);
   }
 
   /**


### PR DESCRIPTION
We used to use `imagePlane` in the metadata provider, but it was switched to `imagePlaneModule` some time ago. 

Right now if we are using WADO-URI to obtain image data, the imageId which is generated does not match the imageId that the metadata provider is using for the data which was obtained from the initial WADO-RS RetrieveMetadata request. We will want to change this later somehow, so that requests for metadata are not tied to the method of ingestion.

For now this fixes some issues (e.g. clicking MPR button before a stack has loaded) when the imagePlaneModule metadata is not available for all instances yet (i.e. when you are using WADO-URI).