### PR TITLE
Fix issues with isDisplaySetReconstructable when we have empty tags

### DIFF
--- a/platform/core/src/studies/services/wado/retrieveMetadataLoader.js
+++ b/platform/core/src/studies/services/wado/retrieveMetadataLoader.js
@@ -46,7 +46,7 @@ export default class RetrieveMetadataLoader {
     }
 
     if (loaders.next().done && !result) {
-      throw 'cant find data';
+      throw new Error('RetrieveMetadataLoader failed');
     }
 
     return result;

--- a/platform/core/src/utils/isDisplaySetReconstructable.js
+++ b/platform/core/src/utils/isDisplaySetReconstructable.js
@@ -67,6 +67,12 @@ function processSingleframe(instances) {
   if (instances.length > 2) {
     const firstIpp = _getImagePositionPatient(firstImage);
     const lastIpp = _getImagePositionPatient(instances[instances.length - 1]);
+
+    // We can't reconstruct if we are missing imagePositionPatient values
+    if (!firstIpp || !lastIpp) {
+      return { value: false };
+    }
+
     const averageSpacingBetweenFrames =
       _getPerpendicularDistance(firstIpp, lastIpp) / (instances.length - 1);
 
@@ -136,8 +142,13 @@ function _getSpacingIssue(spacing, averageSpacing) {
 }
 
 function _getImagePositionPatient(instance) {
-  return instance
-    .getTagValue('x00200032')
+  const tagValue = instance
+    .getTagValue('x00200032');
+  if (!tagValue) {
+    return;
+  }
+
+  return tagValue
     .split('\\')
     .map(element => Number(element));
 }

--- a/platform/viewer/src/connectedComponents/ViewerRetrieveStudyData.js
+++ b/platform/viewer/src/connectedComponents/ViewerRetrieveStudyData.js
@@ -253,6 +253,7 @@ function ViewerRetrieveStudyData({
           .catch(error => {
             if (error && !error.isCanceled) {
               setError(true);
+              log.error(error);
             }
           });
 
@@ -290,11 +291,13 @@ function ViewerRetrieveStudyData({
         .catch(error => {
           if (error && !error.isCanceled) {
             setError(true);
+            log.error(error);
           }
         });
     } catch (error) {
       if (error) {
         setError(true);
+        log.error(error);
       }
     }
   };


### PR DESCRIPTION
This addresses the issues brought up in #1280 and very slightly improves the horrible error handling we have which made this issue hard to debug.
