### PR TITLE
fix: prevent the native context menu from appearing when right-clicking on a measurement or angle (https://github.com/OHIF/Viewers/issues/1406)

### DIFF
--- a/platform/ui/src/components/contextMenu/ContextMenu.js
+++ b/platform/ui/src/components/contextMenu/ContextMenu.js
@@ -1,11 +1,10 @@
-import React from 'react';
 import PropTypes from 'prop-types';
-
+import React from 'react';
 import './ContextMenu.css';
 
 const ContextMenu = ({ items, onClick }) => {
   return (
-    <div className="ContextMenu">
+    <div className="ContextMenu" onContextMenu={e => e.preventDefault()}>
       <ul>
         {items.map((item, index) => (
           <li key={index}>

--- a/platform/viewer/src/connectedComponents/ToolContextMenu.js
+++ b/platform/viewer/src/connectedComponents/ToolContextMenu.js
@@ -1,8 +1,7 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import { commandsManager } from './../App.js';
-
 import { ContextMenu } from '@ohif/ui';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { commandsManager } from './../App.js';
 
 const toolTypes = [
   'Angle',
@@ -94,7 +93,7 @@ const ToolContextMenu = ({
 
   return (
     <div className="ToolContextMenu">
-      <ContextMenu items={dropdownItems} onClick={onClickHandler} />;
+      <ContextMenu items={dropdownItems} onClick={onClickHandler} />
     </div>
   );
 };


### PR DESCRIPTION
Hi.
This PR prevents the native context menu from appearing when right-clicking on a measurement or angle (https://github.com/OHIF/Viewers/issues/1406).
@dannyrb, can you review, please?

### PR Checklist

- [x] Brief description of changes
- [x] Links to any relevant issues
- [ ] Required status checks are passing
- [x] User cases if changes impact the user's experience
- [x] `@mention` a maintainer to request a review

<!--
  Links
  -->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
