### PR TITLE
feat: Add new eslint rule: props-no-spreading

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,6 +14,9 @@
       "version": "detect"
     }
   },
+  "rules": {
+    "react/jsx-props-no-spreading": "error"
+  },
   "globals": {
     "cy": true,
     "before": true,

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "dotenv": "^8.1.0",
     "eslint": "5.16.0",
     "eslint-config-prettier": "^6.4.0",
-    "eslint-config-react-app": "^4.0.1",
+    "eslint-config-react-app": "^5.2.0",
     "eslint-plugin-flowtype": "2.x",
     "eslint-plugin-import": "2.x",
     "eslint-plugin-jsx-a11y": "6.x",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5468,7 +5468,7 @@ configstore@^5.0.0:
     write-file-atomic "^3.0.0"
     xdg-basedir "^4.0.0"
 
-confusing-browser-globals@^1.0.7, confusing-browser-globals@^1.0.9:
+confusing-browser-globals@^1.0.9:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/confusing-browser-globals/-/confusing-browser-globals-1.0.9.tgz#72bc13b483c0276801681871d4898516f8f54fdd"
   integrity sha512-KbS1Y0jMtyPgIxjO7ZzMAuUpAKMt1SzCL9fsrKsX6b0zJPTaT0SiSPmewwVZg9UAO83HVIlEhZF84LIjZ0lmAw==
@@ -7348,14 +7348,7 @@ eslint-config-prettier@^6.4.0:
   dependencies:
     get-stdin "^6.0.0"
 
-eslint-config-react-app@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/eslint-config-react-app/-/eslint-config-react-app-4.0.1.tgz#23fd0fd7ea89442ef1e733f66a7207674b23c8db"
-  integrity sha512-ZsaoXUIGsK8FCi/x4lT2bZR5mMkL/Kgj+Lnw690rbvvUr/uiwgFiD8FcfAhkCycm7Xte6O5lYz4EqMx2vX7jgw==
-  dependencies:
-    confusing-browser-globals "^1.0.7"
-
-eslint-config-react-app@^5.1.0:
+eslint-config-react-app@^5.1.0, eslint-config-react-app@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/eslint-config-react-app/-/eslint-config-react-app-5.2.0.tgz#135110ba56a9e378f7acfe5f36e2ae76a2317899"
   integrity sha512-WrHjoGpKr1kLLiWDD81tme9jMM0hk5cMxasLSdyno6DdPt+IfLOrDJBVo6jN7tn4y1nzhs43TmUaZWO6Sf0blw==


### PR DESCRIPTION
## Description

Adds a new eslint rule to prevent spreading props. The main goal is to avoid as much as possible the use of props spreading like: 

```javascript
const Component = (props) => <Component {...props} />
```

 This ends up being bad for tests since we can't know exactly what props are being passed and it can make things very confusing/difficult to debug.

![image](https://user-images.githubusercontent.com/1905961/76431953-0e53c480-6391-11ea-80ea-a0290b9d6cd6.png)

--

Related: https://github.com/OHIF/Viewers/pull/1504#discussion_r390704222