### PR TITLE
feat: uiv2 docz custom page

### DIFF
--- a/platform/ui/doczrc.js
+++ b/platform/ui/doczrc.js
@@ -1,0 +1,4 @@
+export default {
+  title: '@ohif/ui',
+  menu: ['Getting Started', 'Readme', 'Components', 'Views'],
+};

--- a/platform/ui/package.json
+++ b/platform/ui/package.json
@@ -28,10 +28,12 @@
   "dependencies": {
     "classnames": "^2.2.6",
     "docz": "^2.2.0",
+    "theme-ui": "^0.2.38",
     "gatsby": "2.19.24",
     "gatsby-plugin-postcss": "^2.1.20",
     "gatsby-plugin-react-svg": "^3.0.0",
     "gatsby-plugin-sass": "^2.1.28",
+    "gatsby-theme-docz": "^2.2.0",
     "node-sass": "^4.13.1",
     "prop-types": "^15.7.2",
     "react": "16.11.0",

--- a/platform/ui/src/components/Button/Button.mdx
+++ b/platform/ui/src/components/Button/Button.mdx
@@ -22,7 +22,7 @@ import { Button } from '@ohfi/ui';
 ## Outlined Buttons
 
 <Playground>
-  <>
+  <div className="p-4">
     <Button variant="outlined" className="m-1">
       Default
     </Button>
@@ -35,13 +35,13 @@ import { Button } from '@ohfi/ui';
     <Button variant="outlined" color="white" className="m-1">
       White
     </Button>
-  </>
+  </div>
 </Playground>
 
 ## Contained Buttons
 
 <Playground>
-  <>
+  <div className="p-4">
     <Button variant="contained" className="m-1">
       Default
     </Button>
@@ -54,13 +54,13 @@ import { Button } from '@ohfi/ui';
     <Button variant="contained" color="white" className="m-1">
       White
     </Button>
-  </>
+  </div>
 </Playground>
 
 ## Text Buttons
 
 <Playground>
-  <>
+  <div className="p-4">
     <Button variant="text" className="m-1">
       Default
     </Button>
@@ -73,13 +73,13 @@ import { Button } from '@ohfi/ui';
     <Button variant="text" color="white" className="m-1">
       White
     </Button>
-  </>
+  </div>
 </Playground>
 
 ## Rounded Buttons
 
 <Playground>
-  <>
+  <div className="p-4">
     <div className="mb-2">
       <Button variant="contained" rounded="none" className="m-1">
         Non Rounded
@@ -223,13 +223,13 @@ import { Button } from '@ohfi/ui';
         Full Rounded
       </Button>
     </div>
-  </>
+  </div>
 </Playground>
 
 ## Sizes
 
 <Playground>
-  <>
+  <div className="p-4">
     <div>
       <Button variant="contained" size="small" className="m-1">
         Small
@@ -320,14 +320,13 @@ import { Button } from '@ohfi/ui';
       </Button>
     </div>
 
-</>
-
+</div>
 </Playground>
 
 ## Buttons with icons
 
 <Playground>
-  <div className="flex">
+  <div className="p-4 flex">
     <Button
       variant="contained"
       color="primary"
@@ -365,7 +364,7 @@ import { IconButton } from '@ohfi/ui';
 ```
 
 <Playground>
-  <div className="flex flex-col items-center">
+  <div className="p-4 flex flex-col items-center">
     <div className="">
       <IconButton className="m-2">
         <Icon name="settings" />
@@ -414,7 +413,7 @@ import { IconButton } from '@ohfi/ui';
 </Playground>
 
 <Playground>
-  <div>
+  <div className="p-4">
     <div className="">
       <IconButton className="m-2">
         <Icon name="settings" />

--- a/platform/ui/src/components/ButtonGroup/ButtonGroup.mdx
+++ b/platform/ui/src/components/ButtonGroup/ButtonGroup.mdx
@@ -23,7 +23,7 @@ import { ButtonGroup } from '@ohfi/ui';
 ## Basic button group
 
 <Playground>
-  <div className="flex flex-col items-center">
+  <div className="p-4 flex flex-col items-center">
     <ButtonGroup color="primary" className="m-2">
       <Button>One</Button>
       <Button>Two</Button>
@@ -45,7 +45,7 @@ import { ButtonGroup } from '@ohfi/ui';
 ## Group sizes and colorss
 
 <Playground>
-  <div className="flex flex-col items-center">
+  <div className="p-4 flex flex-col items-center">
     <ButtonGroup color="default" size="small" className="m-2">
       <Button>One</Button>
       <Button>Two</Button>
@@ -67,7 +67,7 @@ import { ButtonGroup } from '@ohfi/ui';
 ## Group orientation
 
 <Playground>
-  <div className="flex flex-row justify-center">
+  <div className="p-4 flex flex-row justify-center">
     <ButtonGroup orientation="vertical" color="primary" className="m-2">
       <Button>One</Button>
       <Button>Two</Button>
@@ -99,7 +99,7 @@ import { ButtonGroup } from '@ohfi/ui';
 ## Split Button
 
 <Playground>
-  <div className="flex flex-col items-center">
+  <div className="p-4 flex flex-col items-center">
     <ButtonGroup color="primary" className="m-2">
       <Button>Options</Button>
       <IconButton className="mr-2">

--- a/platform/ui/src/components/Icon/icon.mdx
+++ b/platform/ui/src/components/Icon/icon.mdx
@@ -13,12 +13,14 @@ import { ICONS } from './getIcon';
 ## Basic usage
 
 <Playground>
-  <Icon name="active" className="text-custom-aquaBright m-4" />
+  <div className="p-4">
+    <Icon name="active" className="text-custom-aquaBright m-4" />
+  </div>
 </Playground>
 
 ## All Icons
 
-<div className="flex flex-wrap items-center bg-black py-8">
+<div className="p-4 flex flex-wrap items-center bg-black py-8">
   {Object.keys(ICONS)
     .sort()
     .map((name, i) => {

--- a/platform/ui/src/components/Input/Input.mdx
+++ b/platform/ui/src/components/Input/Input.mdx
@@ -15,7 +15,7 @@ import Input from './';
   {() => {
     const [inputValue, setInputValue] = React.useState('');
     return (
-      <div>
+      <div className="p-4">
         <Input
           transparent
           containerClassName="mb-3"

--- a/platform/ui/src/components/Label/Label.mdx
+++ b/platform/ui/src/components/Label/Label.mdx
@@ -13,7 +13,11 @@ import Label from './';
 
 <Playground>
   {() => {
-    return <Label text="Label" />;
+    return (
+      <div className="p-4">
+        <Label text="Label" />
+      </div>
+    );
   }}
 </Playground>
 

--- a/platform/ui/src/components/Typography/Typography.mdx
+++ b/platform/ui/src/components/Typography/Typography.mdx
@@ -21,30 +21,32 @@ import { Typography } from '@ohfi/ui';
 ## Basic usage
 
 <Playground>
-  <Typography variant="h1">
-    h1. The five boxing wizards jump quickly.
-  </Typography>
-  <Typography variant="h2">
-    h2. The five boxing wizards jump quickly.
-  </Typography>
-  <Typography variant="h3">
-    h3. The five boxing wizards jump quickly.
-  </Typography>
-  <Typography variant="h4">
-    h4. The five boxing wizards jump quickly.
-  </Typography>
-  <Typography variant="h5">
-    h5. The five boxing wizards jump quickly.
-  </Typography>
-  <Typography variant="h6">
-    h6. The five boxing wizards jump quickly.
-  </Typography>
-  <Typography variant="subtitle">
-    subtitle. The five boxing wizards jump quickly.
-  </Typography>
-  <Typography variant="body">
-    body. The five boxing wizards jump quickly.
-  </Typography>
+  <div className="p-4">
+    <Typography variant="h1">
+      h1. The five boxing wizards jump quickly.
+    </Typography>
+    <Typography variant="h2">
+      h2. The five boxing wizards jump quickly.
+    </Typography>
+    <Typography variant="h3">
+      h3. The five boxing wizards jump quickly.
+    </Typography>
+    <Typography variant="h4">
+      h4. The five boxing wizards jump quickly.
+    </Typography>
+    <Typography variant="h5">
+      h5. The five boxing wizards jump quickly.
+    </Typography>
+    <Typography variant="h6">
+      h6. The five boxing wizards jump quickly.
+    </Typography>
+    <Typography variant="subtitle">
+      subtitle. The five boxing wizards jump quickly.
+    </Typography>
+    <Typography variant="body">
+      body. The five boxing wizards jump quickly.
+    </Typography>
+  </div>
 </Playground>
 
 ## Changing the HTML element
@@ -55,9 +57,11 @@ a semantic element. The style of a Typography is independent of the semantic
 element.
 
 <Playground>
-  <Typography variant="h1" component="h2">
-    This is a h2 using the h1 styles.
-  </Typography>
+  <div className="p-4">
+    <Typography variant="h1" component="h2">
+      This is a h2 using the h1 styles.
+    </Typography>
+  </div>
 </Playground>
 
 ## Properties

--- a/platform/ui/src/gatsby-theme-docz/components/Header/index.js
+++ b/platform/ui/src/gatsby-theme-docz/components/Header/index.js
@@ -1,0 +1,69 @@
+/** @jsx jsx */
+import { jsx, Box, Flex, useColorMode } from 'theme-ui';
+import { useConfig, useCurrentDoc } from 'docz';
+
+import * as styles from 'gatsby-theme-docz/src/components/Header/styles';
+import {
+  Edit,
+  Menu,
+  Sun,
+  Github,
+} from 'gatsby-theme-docz/src/components/Icons';
+import { Logo } from 'gatsby-theme-docz/src/components/Logo';
+
+export const Header = props => {
+  const { onOpen } = props;
+  const {
+    repository,
+    themeConfig: { showDarkModeSwitch, showMarkdownEditButton },
+  } = useConfig();
+  const { edit = true, ...doc } = useCurrentDoc();
+  const [colorMode, setColorMode] = useColorMode();
+
+  const toggleColorMode = () => {
+    setColorMode(colorMode === 'light' ? 'dark' : 'light');
+  };
+
+  return (
+    <div sx={styles.wrapper} data-testid="header">
+      <div sx={styles.innerContainer}>
+        <div className="flex">
+          <button className="mr-4" sx={styles.menuButton} onClick={onOpen}>
+            <Menu size={25} />
+          </button>
+          <Logo />
+        </div>
+        <Flex>
+          {repository && (
+            <Box sx={{ mr: 2 }}>
+              <a
+                href={repository}
+                sx={styles.headerButton}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Github size={15} />
+              </a>
+            </Box>
+          )}
+          {showDarkModeSwitch && (
+            <button sx={styles.headerButton} onClick={toggleColorMode}>
+              <Sun size={15} />
+            </button>
+          )}
+        </Flex>
+        {showMarkdownEditButton && edit && doc.link && (
+          <a
+            sx={styles.editButton}
+            href={doc.link}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <Edit width={14} />
+            <Box sx={{ pl: 2 }}>Edit page</Box>
+          </a>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/platform/ui/src/gatsby-theme-docz/components/Layout/index.js
+++ b/platform/ui/src/gatsby-theme-docz/components/Layout/index.js
@@ -1,0 +1,49 @@
+/** @jsx jsx */
+import { useRef, useState } from 'react';
+import { jsx, Layout as BaseLayout, Main } from 'theme-ui';
+import classnames from 'classnames';
+
+import { Header } from '../Header';
+import { Sidebar } from '../Sidebar';
+import * as styles from 'gatsby-theme-docz/src/components/Layout/styles';
+
+const getSidebarStatus = () => window.location.pathname === '/';
+
+export const Layout = ({ children }) => {
+  const [sidebarOpen, setSidebarOpen] = useState(getSidebarStatus());
+  const nav = useRef();
+
+  const handleSidebarToggle = () => {
+    setSidebarOpen(s => !s);
+  };
+
+  return (
+    <BaseLayout sx={{ '& > div': { flex: '1 1 auto' } }} data-testid="layout">
+      <Main
+        sx={styles.main}
+        className={classnames({
+          'overflow-hidden h-screen lg:overflow-auto': sidebarOpen,
+        })}
+      >
+        <Header onOpen={handleSidebarToggle} />
+        <div className={classnames('flex', {})}>
+          <Sidebar
+            ref={nav}
+            sidebarOpen={sidebarOpen}
+            onFocus={() => setSidebarOpen(true)}
+            onBlur={() => setSidebarOpen(false)}
+            onClick={() => setSidebarOpen(false)}
+          />
+          <div
+            className={classnames('py-10 w-full', {
+              'px-4 overflow-hidden lg:px-20 lg:overflow-auto ': sidebarOpen,
+              'px-4 lg:px-8': !sidebarOpen,
+            })}
+          >
+            {children}
+          </div>
+        </div>
+      </Main>
+    </BaseLayout>
+  );
+};

--- a/platform/ui/src/gatsby-theme-docz/components/Layout/index.js
+++ b/platform/ui/src/gatsby-theme-docz/components/Layout/index.js
@@ -36,7 +36,7 @@ export const Layout = ({ children }) => {
           />
           <div
             className={classnames('py-10 w-full', {
-              'px-4 overflow-hidden lg:px-20 lg:overflow-auto ': sidebarOpen,
+              'px-4 lg:px-20': sidebarOpen,
               'px-4 lg:px-8': !sidebarOpen,
             })}
           >

--- a/platform/ui/src/gatsby-theme-docz/components/Layout/index.js
+++ b/platform/ui/src/gatsby-theme-docz/components/Layout/index.js
@@ -7,7 +7,8 @@ import { Header } from '../Header';
 import { Sidebar } from '../Sidebar';
 import * as styles from 'gatsby-theme-docz/src/components/Layout/styles';
 
-const getSidebarStatus = () => window.location.pathname === '/';
+const getSidebarStatus = () =>
+  typeof window !== 'undefined' && window.location.pathname === '/';
 
 export const Layout = ({ children }) => {
   const [sidebarOpen, setSidebarOpen] = useState(getSidebarStatus());

--- a/platform/ui/src/gatsby-theme-docz/components/Sidebar/index.js
+++ b/platform/ui/src/gatsby-theme-docz/components/Sidebar/index.js
@@ -31,16 +31,21 @@ export const Sidebar = React.forwardRef((props, ref) => {
           <div className="block lg:hidden">
             <div
               onClick={() => props.onClick()}
-              className="fixed top-81px z-10 left-0 w-full h-full bg-black opacity-80"
+              className="fixed z-10 left-0 w-full h-full bg-black opacity-80"
+              style={{ top: '81px' }}
             />
           </div>
           <div
             ref={ref}
             data-testid="sidebar"
             className={classnames(
-              'min-w-250px p-8 flex-col bg-white top-0 overflow-auto z-10 border-r border-gray-400 hidden fixed top-81px left-0 bottom-0 lg:block lg:sticky lg:h-screen lg:top-0'
+              'p-8 flex-col bg-white top-0 overflow-auto z-10 border-r border-gray-400 hidden fixed left-0 bottom-0 lg:block lg:sticky lg:h-screen lg:top-0'
             )}
-            style={{ display: props.sidebarOpen ? 'block' : 'none' }}
+            style={{
+              display: props.sidebarOpen ? 'block' : 'none',
+              top: '81px',
+              minWidth: 250,
+            }}
           >
             <NavSearch
               placeholder="Type to search..."

--- a/platform/ui/src/gatsby-theme-docz/components/Sidebar/index.js
+++ b/platform/ui/src/gatsby-theme-docz/components/Sidebar/index.js
@@ -1,0 +1,74 @@
+/** @jsx jsx */
+/** @jsxFrag React.Fragment */
+import React, { useState, useRef, useEffect } from 'react';
+import classnames from 'classnames';
+
+import { jsx } from 'theme-ui';
+import { useMenus, useCurrentDoc } from 'docz';
+
+import { NavSearch } from 'gatsby-theme-docz/src/components/NavSearch';
+import { NavLink } from 'gatsby-theme-docz/src/components/NavLink';
+import { NavGroup } from 'gatsby-theme-docz/src/components/NavGroup';
+
+export const Sidebar = React.forwardRef((props, ref) => {
+  const [query, setQuery] = useState('');
+  const menus = useMenus({ query });
+  const currentDoc = useCurrentDoc();
+  const currentDocRef = useRef();
+  const handleChange = ev => {
+    setQuery(ev.target.value);
+  };
+  useEffect(() => {
+    if (ref.current && currentDocRef.current) {
+      ref.current.scrollTo(0, currentDocRef.current.offsetTop);
+    }
+  }, [ref]);
+
+  return (
+    <>
+      {props.sidebarOpen && (
+        <>
+          <div className="block lg:hidden">
+            <div
+              onClick={() => props.onClick()}
+              className="fixed top-81px z-10 left-0 w-full h-full bg-black opacity-80"
+            />
+          </div>
+          <div
+            ref={ref}
+            data-testid="sidebar"
+            className={classnames(
+              'min-w-250px p-8 flex-col bg-white top-0 overflow-auto z-10 border-r border-gray-400 hidden fixed top-81px left-0 bottom-0 lg:block lg:sticky lg:h-screen lg:top-0'
+            )}
+            style={{ display: props.sidebarOpen ? 'block' : 'none' }}
+          >
+            <NavSearch
+              placeholder="Type to search..."
+              value={query}
+              onChange={handleChange}
+            />
+            {menus &&
+              menus.map(menu => {
+                if (!menu.route)
+                  return (
+                    <NavGroup key={menu.id} item={menu} sidebarRef={ref} />
+                  );
+                if (menu.route === currentDoc.route) {
+                  return (
+                    <NavLink key={menu.id} item={menu} ref={currentDocRef}>
+                      {menu.name}
+                    </NavLink>
+                  );
+                }
+                return (
+                  <NavLink key={menu.id} item={menu}>
+                    {menu.name}
+                  </NavLink>
+                );
+              })}
+          </div>
+        </>
+      )}
+    </>
+  );
+});

--- a/platform/ui/src/gatsby-theme-docz/theme.css
+++ b/platform/ui/src/gatsby-theme-docz/theme.css
@@ -3,7 +3,6 @@
 */
 
 [data-testid='live-preview'] {
-  padding: 10px;
   background: #000;
 }
 

--- a/platform/ui/src/views/StudyList/StudyList.mdx
+++ b/platform/ui/src/views/StudyList/StudyList.mdx
@@ -1,7 +1,7 @@
 ---
 name: Study List
 menu: Views
-route: components/studyList
+route: views/studyList
 ---
 
 import { Playground, Props } from 'docz';

--- a/platform/ui/tailwind.config.js
+++ b/platform/ui/tailwind.config.js
@@ -166,6 +166,9 @@ module.exports = {
       '48': '12rem',
       '56': '14rem',
       '64': '16rem',
+      '72': '18rem',
+      '80': '20rem',
+      '250px': '250px',
     },
     backgroundColor: theme => theme('colors'),
     backgroundPosition: {
@@ -307,6 +310,7 @@ module.exports = {
     inset: {
       '0': '0',
       auto: 'auto',
+      '81px': '81px',
     },
     letterSpacing: {
       tighter: '-0.05em',
@@ -374,6 +378,7 @@ module.exports = {
       lg: '8rem',
       xl: '10rem',
       full: '100%',
+      '250px': '250px',
     },
     objectPosition: {
       bottom: 'bottom',

--- a/platform/ui/tailwind.config.js
+++ b/platform/ui/tailwind.config.js
@@ -310,7 +310,6 @@ module.exports = {
     inset: {
       '0': '0',
       auto: 'auto',
-      '81px': '81px',
     },
     letterSpacing: {
       tighter: '-0.05em',
@@ -378,7 +377,6 @@ module.exports = {
       lg: '8rem',
       xl: '10rem',
       full: '100%',
-      '250px': '250px',
     },
     objectPosition: {
       bottom: 'bottom',


### PR DESCRIPTION
## Description

Create `docz` theme/page to better showcase **`Views`**.

It was created customization of the standard `docz` theme to make a switchable menu.
The theme files were basically copied from the [original `gatsby-theme-docz` components](https://github.com/doczjs/docz/blob/v2.2.0/core/gatsby-theme-docz/src/components) and minor changes were made to accomplish our needs.

## Preview

**Menu Opened**

![image](https://user-images.githubusercontent.com/1905961/76538816-a9ff3680-645e-11ea-8a56-27fe62dd6bfa.png)

**Menu Closed**

![image](https://user-images.githubusercontent.com/1905961/76538833-aff51780-645e-11ea-9f26-fbcd8241caad.png)