### PR TITLE
fix: [measurements panel] rendering delete button when text is too wide for parent div

### DIFF
--- a/platform/ui/src/components/measurementTable/MeasurementTableItem.styl
+++ b/platform/ui/src/components/measurementTable/MeasurementTableItem.styl
@@ -25,7 +25,7 @@
 
   &.selected
     .rowActions
-      height: 35px
+      height: auto;
       visibility: visible
 
   .measurementLocation


### PR DESCRIPTION
### Changes

Fixes issue https://github.com/OHIF/Viewers/issues/1377 delete button was disappearing due to overflowing into a row new when spanish is the selected language

### Screenshots

#### English
![image](https://user-images.githubusercontent.com/6834228/76712802-b3fd8f80-6713-11ea-8ebe-aaf29a09beda.png)

#### Spanish
![image](https://user-images.githubusercontent.com/6834228/76712809-c8418c80-6713-11ea-83ae-279a2a9f542b.png)



<!--
  Links
  -->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
