### PR TITLE
feat: 🎸 Filter/promote multiple series instances

### DIFF
--- a/platform/viewer/src/connectedComponents/ViewerRetrieveStudyData.js
+++ b/platform/viewer/src/connectedComponents/ViewerRetrieveStudyData.js
@@ -14,23 +14,25 @@ const { OHIFStudyMetadata, OHIFSeriesMetadata } = metadata;
 const { retrieveStudiesMetadata, deleteStudyMetadataPromise } = studies;
 const { studyMetadataManager, makeCancelable } = utils;
 
-const _promoteToFront = (list, value, searchMethod) => {
-  let response = [...list];
-  let promoted = false;
-  const index = response.findIndex(searchMethod.bind(undefined, value));
+const _promoteToFront = (list, values, searchMethod) => {
+  let listCopy = [...list];
+  let response = [];
+  let promotedCount = 0;
 
-  if (index > 0) {
-    const first = response.splice(index, 1);
-    response = [...first, ...response];
-  }
+  const arrayValues = values.split(',');
+  arrayValues.forEach(value => {
+    const index = listCopy.findIndex(searchMethod.bind(undefined, value));
 
-  if (index >= 0) {
-    promoted = true;
-  }
+    if (index >= 0) {
+      const [itemToPromote] = listCopy.splice(index, 1);
+      response[promotedCount] = itemToPromote;
+      promotedCount++;
+    }
+  });
 
   return {
-    promoted,
-    data: response,
+    promoted: promotedCount === arrayValues.length,
+    data: [...response, ...listCopy],
   };
 };
 
@@ -90,12 +92,48 @@ const _isQueryParamApplied = (study, filters = {}, isFilterStrategy) => {
   if (!seriesInstanceUID) {
     return applied;
   }
+  const seriesInstanceUIDs = seriesInstanceUID.split(',');
+
+  let validateFilterApplied = () => {
+    const sameSize = arrayToInspect.length === seriesInstanceUIDs.length;
+    if (!sameSize) {
+      return;
+    }
+
+    return arrayToInspect.every(item =>
+      seriesInstanceUIDs.some(
+        seriesInstanceUIDStr => seriesInstanceUIDStr === item.SeriesInstanceUID
+      )
+    );
+  };
+
+  let validatePromoteApplied = () => {
+    let isValid = true;
+    for (let index = 0; index < seriesInstanceUIDs.length; index++) {
+      const seriesInstanceUIDStr = seriesInstanceUIDs[index];
+      const resultSeries = arrayToInspect[index];
+
+      if (
+        !resultSeries ||
+        resultSeries.SeriesInstanceUID !== seriesInstanceUIDStr
+      ) {
+        isValid = false;
+        break;
+      }
+    }
+    return isValid;
+  };
 
   const { series = [], displaySets = [] } = study;
-  const firstSeries = isFilterStrategy ? series[0] : displaySets[0];
+  const arrayToInspect = isFilterStrategy ? series : displaySets;
+  const validateMethod = isFilterStrategy
+    ? validateFilterApplied
+    : validatePromoteApplied;
 
-  if (!firstSeries || firstSeries.SeriesInstanceUID !== seriesInstanceUID) {
+  if (!arrayToInspect) {
     applied = false;
+  } else {
+    applied = validateMethod();
   }
 
   return applied;
@@ -221,7 +259,7 @@ function ViewerRetrieveStudyData({
     // Show message in case not promoted neither filtered but should to
     _showUserMessage(
       isQueryParamApplied,
-      'Query parameters were not applied. Using original series list for given study.',
+      'Query parameters were not totally applied. It might be using original series list for given study.',
       snackbarContext
     );
 
@@ -233,7 +271,7 @@ function ViewerRetrieveStudyData({
    * Method to process studies. It will update displaySet, studyMetadata, load remaining series, ...
    * @param {Array} studiesData Array of studies retrieved from server
    * @param {Object} [filters] - Object containing filters to be applied
-   * @param {string} [filter.seriesInstanceUID] - series instance uid to filter results against
+   * @param {string} [filters.seriesInstanceUID] - series instance uid to filter results against
    */
   const processStudies = (studiesData, filters) => {
     if (Array.isArray(studiesData) && studiesData.length > 0) {
@@ -299,7 +337,6 @@ function ViewerRetrieveStudyData({
       const filters = {};
       // Use the first, discard others
       const seriesInstanceUID = seriesInstanceUIDs && seriesInstanceUIDs[0];
-
       const retrieveParams = [server, studyInstanceUIDs];
 
       if (seriesInstanceUID) {


### PR DESCRIPTION
improve filter/promote to be applied on multiple series instances

✅ Closes: 1532

### PR Checklist

- [x] Brief description of changes
- [ ] Links to any relevant issues
- [ ] Required status checks are passing
- [ ] User cases if changes impact the user's experience
- [ ] `@mention` a maintainer to request a review

<!--
  Links
  -->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->

### Description
- Changes will improve current filter/promote feature to accept multiple series instances.

### Closes
https://github.com/OHIF/Viewers/issues/1532

### User cases
- User can filter/promote one or many series.
- Current feature is: Consider part valid part of url `viewer/1.3.6.1.4.1.25403.345050719074.3824.20170126085406.1?SeriesInstanceUID=2.25.856992923281239003733479634608709215918`
- New feature is: Consider part valid part of url `viewer/1.3.6.1.4.1.25403.345050719074.3824.20170126085406.1/?seriesInstanceUID=1.3.6.1.4.1.25403.345050719074.3824.20170126085406.2,2.25.374532628115939034791691984300357809891` and also current feature keeps the same.
I.e user can pass one or many seriesInstanceUID(separated by comma)

### Manual Test cases
- Test twice all test cases (change flag filterQueryParam to ensure both filtering and promoting are working)
- Ensure current feature is working 
- Ensure multiple series instances works (success case) (no user message must be  is displayed)
- Ensure partial solution is applied in case partial success. I.e if there are some valid seriesInstanceUID and some not valid. Ensure user message must be  is displayed.
- Ensure none is applied in case all seriesInstanceUID are invalid. Also user message must be  is displayed.


### Current state of this PR
- Draft implementation is done. Superficial manual tests were applied (same as described above). Pending to test further and validate implementation