### PR TITLE
Only permit web workers to be initialized once.

### DIFF
--- a/platform/viewer/src/utils/initWebWorkers.js
+++ b/platform/viewer/src/utils/initWebWorkers.js
@@ -1,6 +1,8 @@
 import cornerstoneWADOImageLoader from 'cornerstone-wado-image-loader';
 
-export default function initWebWorkers() {  
+let initialized = false;
+
+export default function initWebWorkers() {
   const config = {
     maxWebWorkers: Math.max(navigator.hardwareConcurrency - 1, 1),
     startWebWorkersOnDemand: true,
@@ -13,5 +15,8 @@ export default function initWebWorkers() {
     },
   };
 
-  cornerstoneWADOImageLoader.webWorkerManager.initialize(config);
+  if (!initialized) {
+    cornerstoneWADOImageLoader.webWorkerManager.initialize(config);
+    initialized = true;
+  }
 }

--- a/platform/viewer/src/utils/initWebWorkers.test.js
+++ b/platform/viewer/src/utils/initWebWorkers.test.js
@@ -10,3 +10,14 @@ describe('initWebWorkers', () => {
     ).toHaveBeenCalled();
   });
 });
+
+describe('initWebWorkers', () => {
+  it("initializes cornerstoneWADOImageLoader's web workers only once", () => {
+    initWebWorkers();
+    initWebWorkers();
+
+    expect(
+      cornerstoneWADOImageLoader.webWorkerManager.initialize
+    ).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
### Description
When embedded in a SPA, the `initWebWorkers` method should only be called once per page.

When the DOM element the viewer is attached to is rendered within a React component, the `installViewer` method may be called multiple times per page if user navigation is causing that DOM element to be created and removed multiple times.

Because of [this line of code](https://github.com/cornerstonejs/cornerstoneWADOImageLoader/blob/master/src/imageLoader/webWorkerManager.js#L153), Cornerstone will throw an exception if this is tried. Cornerstone does not export the control object such that consumers could base their logic on that, so I created my own control object.

This gets past the exception within Cornerstone, but causes the logs to be noisy as multiple other parts of the viewer are loaded multiple times, reporting warnings. However the viewer appears to be functional after a reload.

This PR is a workaround of code in Cornerstone, and handling this use case in a more permanent fashion would require multiple checks elsewhere and perhaps changes in Cornerstone code. I am unsure of side effects stemming from this change, but after my own experimentation it appears benign aside from the noisy logs. I have only tested in Chrome.

Images of the noisy logs.
![image](https://user-images.githubusercontent.com/59040827/77012346-cce88980-693b-11ea-91f2-bb7615745a63.png)
![image](https://user-images.githubusercontent.com/59040827/77012425-ebe71b80-693b-11ea-9e57-58047a2368cb.png)