### PR TITLE
feat: UI v2 EmptyStudies Component

### DIFF
--- a/platform/ui/index.js
+++ b/platform/ui/index.js
@@ -10,6 +10,7 @@ export {
   Button,
   ButtonGroup,
   DateRange,
+  EmptyStudies,
   Icon,
   IconButton,
   Select,

--- a/platform/ui/src/components/EmptyStudies/EmptyStudies.js
+++ b/platform/ui/src/components/EmptyStudies/EmptyStudies.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+import { Icon, Typography } from '@ohif/ui';
+
+const EmptyStudies = ({ className }) => {
+  return (
+    <div className={classnames('flex-col inline-flex items-center', className)}>
+      <Icon name="magnifier" className="mb-4" />
+      <Typography className="text-custom-aquaBright" variant="h5">
+        No studies available
+      </Typography>
+    </div>
+  );
+};
+
+EmptyStudies.defaultProps = {
+  className: '',
+};
+
+EmptyStudies.propTypes = {
+  className: PropTypes.string,
+};
+
+export default EmptyStudies;

--- a/platform/ui/src/components/EmptyStudies/EmptyStudies.mdx
+++ b/platform/ui/src/components/EmptyStudies/EmptyStudies.mdx
@@ -1,0 +1,30 @@
+---
+name: Empty Studies
+menu: Components
+route: components/empty-studies
+---
+
+import { Playground, Props } from 'docz';
+import EmptyStudies from './';
+
+# Empty Studies
+
+This component can be used to display a message when there are no studies.
+
+## Import
+
+```javascript
+import { EmptyStudies } from '@ohif/ui';
+```
+
+## Basic usage
+
+<Playground>
+  <div className="p-4">
+    <EmptyStudies />
+  </div>
+</Playground>
+
+## Properties
+
+<Props of={EmptyStudies} />

--- a/platform/ui/src/components/EmptyStudies/index.js
+++ b/platform/ui/src/components/EmptyStudies/index.js
@@ -1,0 +1,2 @@
+import EmptyStudies from './EmptyStudies';
+export default EmptyStudies;

--- a/platform/ui/src/components/index.js
+++ b/platform/ui/src/components/index.js
@@ -1,6 +1,7 @@
 import Button from './Button';
 import ButtonGroup from './ButtonGroup';
 import DateRange from './DateRange';
+import EmptyStudies from './EmptyStudies';
 import Icon from './Icon';
 import IconButton from './IconButton';
 import Input from './Input';
@@ -13,6 +14,7 @@ export {
   Button,
   ButtonGroup,
   DateRange,
+  EmptyStudies,
   Icon,
   IconButton,
   Input,

--- a/platform/ui/src/views/StudyList/components/StudyListTable.js
+++ b/platform/ui/src/views/StudyList/components/StudyListTable.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
 import { format } from 'date-fns';
-import { Button, Icon, Typography } from '@ohif/ui';
+import { Button, Icon, EmptyStudies } from '@ohif/ui';
 
 const getGridColClass = (filtersMeta, name) => {
   const filter = filtersMeta.find(filter => filter.name === name);
@@ -296,10 +296,7 @@ const StudyListTable = ({ studies, numOfStudies, filtersMeta }) => {
   const renderEmpty = () => {
     return (
       <div className="flex flex-col items-center justify-center pt-48">
-        <Icon name="magnifier" className="mb-4" />
-        <Typography className="text-custom-aquaBright" variant="h5">
-          No studies available
-        </Typography>
+        <EmptyStudies />
       </div>
     );
   };


### PR DESCRIPTION
**OHIF-51**

Creates an EmptyStudies component to be used in the StudyList when the study list is empty.

## Preview

![image](https://user-images.githubusercontent.com/1905961/77485087-0cffae80-6e0b-11ea-9df6-0e4e81ec8a74.png)
