### PR TITLE
Urgent: disable autoFreeze of immer, even in dev mode

### DIFF
--- a/platform/core/src/redux/reducers/viewports.js
+++ b/platform/core/src/redux/reducers/viewports.js
@@ -1,5 +1,5 @@
 import cloneDeep from 'lodash.clonedeep';
-import produce from 'immer';
+import produce, { setAutoFreeze } from 'immer';
 
 import {
   CLEAR_VIEWPORT,
@@ -10,6 +10,8 @@ import {
   SET_VIEWPORT_LAYOUT,
   SET_VIEWPORT_LAYOUT_AND_DATA,
 } from './../constants/ActionTypes.js';
+
+setAutoFreeze(false);
 
 export const DEFAULT_STATE = {
   numRows: 1,


### PR DESCRIPTION
In https://github.com/OHIF/Viewers/pull/1544, I introduced `immer` to avoid wasteful mutation of state in `viewports` reducer.

But, it turns out that `Immer automatically freezes any state trees that are modified using produce.`
https://immerjs.github.io/immer/docs/freezing

This is causing some issue - I noticed one, but there could be more.
e.g. You start `2D MPR`, then `Exit 2D MPR` and then try to start it again - it fails with an error in console.

It turns out that rule of immutability of objects in Redux state is broken in some places.
e.g. `mpr2d` command in `vtk` extension.
It grabs a `viewportSpecificData` off the Redux state, 
https://github.com/OHIF/Viewers/blob/16866a47a0e8d6b9200cb503da714a9a29773bdb/extensions/vtk/src/commandsModule.js#L222-L223

passes it to `setMPRLayout` which then mutates it 
https://github.com/OHIF/Viewers/blob/16866a47a0e8d6b9200cb503da714a9a29773bdb/extensions/vtk/src/utils/setMPRLayout.js#L25-L26

`immer` introduced `autoFreeze`ing to be able to detect violation of immutability in development mode.
But for now, we need to disable `autoFreeze` so that other developers suddenly do not find their code broken.

As PR https://github.com/OHIF/Viewers/pull/1544 that introduced this issue got released recently, I request this fix to be released ASAP.

Note that the issue affects only in development mode.