### PR TITLE
Limit concurrent series metadata requests

### DIFF
--- a/platform/core/src/classes/metadata/StudyMetadata.js
+++ b/platform/core/src/classes/metadata/StudyMetadata.js
@@ -322,11 +322,13 @@ export class StudyMetadata extends Metadata {
 
     const displaySets = this._createDisplaySetsForSeries(sopClassHandlerModules, series)
 
-    this._displaySets.forEach((displaySet, idx) => {
+    // Note: filtering in place because this._displaySets has writable: false
+    for (let i = this._displaySets.length - 1; i >= 0; i--) {
+      const displaySet = this._displaySets[i];
       if (displaySet.SeriesInstanceUID === series.getSeriesInstanceUID()) {
-        this._displaySets.splice(idx, 1);
+        this._displaySets.splice(i, 1);
       }
-    })
+    }
 
     displaySets.forEach(displaySet => {
       this.addDisplaySet(displaySet);

--- a/platform/viewer/public/config/default.js
+++ b/platform/viewer/public/config/default.js
@@ -117,4 +117,12 @@ window.config = {
     },
   ],
   cornerstoneExtensionConfig: {},
+  // Following property limits number of simultaneous series metadata requests.
+  // For http/1.x-only servers, set this to 5 or less to improve
+  //  on first meaningful display in viewer
+  // If the server is particularly slow to respond to series metadata
+  //  requests as it extracts the metadata from raw files everytime,
+  //  try setting this to even lower value
+  // Leave it undefined for no limit, sutiable for HTTP/2 enabled servers
+  // maxConcurrentMetadataRequests: 5,
 };

--- a/platform/viewer/src/connectedComponents/ViewerRetrieveStudyData.js
+++ b/platform/viewer/src/connectedComponents/ViewerRetrieveStudyData.js
@@ -168,7 +168,7 @@ function ViewerRetrieveStudyData({
   const { appConfig = {} } = useContext(AppContext);
   const {
     filterQueryParam: isFilterStrategy = false,
-    maxConcurrentMetadataRequests = 3,
+    maxConcurrentMetadataRequests,
   } = appConfig;
 
   let cancelableSeriesPromises;
@@ -265,7 +265,8 @@ function ViewerRetrieveStudyData({
       return loadNextSeries();
     };
 
-    const promises = Array(maxConcurrentMetadataRequests)
+    const concurrentRequestsAllowed = maxConcurrentMetadataRequests || studyMetadata.getSeriesCount();
+    const promises = Array(concurrentRequestsAllowed)
       .fill(null)
       .map(loadNextSeries);
     await Promise.all(promises);


### PR DESCRIPTION
Further enhancements to series loading, to be able to show first meaningful display at the earliest.

### Issue
Concurrent loading of series metadata fills the request queue with metadata requests. 
Requests for thumbnail and viewport image get queued up after all the metadata requests.
As browser limits concurrent requests to a domain to 4, the thumbnail image and viewport image fetch requests get blocked.
Ultimately, thumbnail and viewport image is displayed only after all (actually, all - 3) metadata requests are done.

This could be a long wait,  if number of series are more and especially if server is slow to responding metadata requests. (https://github.com/OHIF/Viewers/issues/1536)

### Solutions
Solution implemented is to limit the max concurrent series metadata requests to 3 so that it leaves room for more important image requests to be served.

For slow servers, like mentioned in https://github.com/OHIF/Viewers/issues/1536, one might want to further restrict the max concurrent metadata requests to just 1 so as to not send the server in spin.
A config property `maxConcurrentMetadataRequests` can be specified app config for his purpose.
