### PR TITLE
use bit-appropriate array for palette lookup tables

### DIFF
--- a/platform/core/src/utils/metadataProvider/fetchPaletteColorLookupTableData.js
+++ b/platform/core/src/utils/metadataProvider/fetchPaletteColorLookupTableData.js
@@ -115,22 +115,14 @@ function _getPaletteColor(server, paletteColorLookupTableData, lutDescriptor) {
   const numLutEntries = lutDescriptor[0];
   const bits = lutDescriptor[2];
 
-  const readUInt16 = (byteArray, position) => {
-    return byteArray[position] + byteArray[position + 1] * 256;
-  };
-
   const arrayBufferToPaletteColorLUT = arraybuffer => {
-    const byteArray = new Uint8Array(arraybuffer);
+    const byteArray = bits === 16 ?
+      new Uint16Array(arraybuffer) :
+      new Uint8Array(arraybuffer);
     const lut = [];
 
-    if (bits === 16) {
-      for (let i = 0; i < numLutEntries; i++) {
-        lut[i] = readUInt16(byteArray, i * 2);
-      }
-    } else {
-      for (let i = 0; i < numLutEntries; i++) {
-        lut[i] = byteArray[i];
-      }
+    for (let i = 0; i < numLutEntries; i++) {
+      lut[i] = byteArray[i];
     }
 
     return lut;


### PR DESCRIPTION
### PR Checklist

- [x] Brief description of changes
- [x] Links to any relevant issues
- [ ] Required status checks are passing
- [ ] User cases if changes impact the user's experience
- [x] `@mention` a maintainer to request a review

Addresses https://github.com/OHIF/Viewers/issues/1689. Instead of using a Uint8Array for all lookup table byte arrays, first check to see whether the palette colors are 8 or 16 bits, and use the appropriately sized Uint array. Thanks @swederik.

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
