### PR TITLE
feat: expose some app internals as window.app

### DIFF
--- a/platform/viewer/src/App.js
+++ b/platform/viewer/src/App.js
@@ -71,6 +71,14 @@ let extensionManager;
 // TODO[react] Use a provider when the whole tree is React
 window.store = store;
 
+window.ohif = window.ohif || {};
+window.ohif.app: {
+  commandsManager,
+  hotkeysManager,
+  servicesManager,
+  extensionManager,
+};
+
 class App extends Component {
   static propTypes = {
     config: PropTypes.oneOfType([

--- a/platform/viewer/src/App.js
+++ b/platform/viewer/src/App.js
@@ -72,7 +72,7 @@ let extensionManager;
 window.store = store;
 
 window.ohif = window.ohif || {};
-window.ohif.app: {
+window.ohif.app = {
   commandsManager,
   hotkeysManager,
   servicesManager,


### PR DESCRIPTION
This can help developers explore and access some
internal functionaltiy for debugging in the console.

For example, this command can download the currently
viewed study:

ohif.app.commandsManager.runCommand("downloadAndZip", {listOfUIDs: [window.location.href.split("/").pop()]})

TODO: collect this example and other handy functions on a wiki page

Co-authored-by: dannyrb <danny.ri.brown@gmail.com>

### PR Checklist

- [x ] Brief description of changes
- [n/a] Links to any relevant issues
- [ ] Required status checks are passing
- [n/a ] User cases if changes impact the user's experience
- [x] `@mention` a maintainer to request a review

<!--
  Links
  -->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
