### PR TITLE
fix: 🐛 [User Preferences/Hotkeys] `Previous Series` and `Next Series` are throwing Uncaught ReferenceError #1548

### DIFF
--- a/platform/viewer/src/appExtensions/GenericViewerCommands/commandsModule.js
+++ b/platform/viewer/src/appExtensions/GenericViewerCommands/commandsModule.js
@@ -1,4 +1,4 @@
-import { redux } from '@ohif/core';
+import { redux, utils } from '@ohif/core';
 import store from './../../store';
 
 const commandsModule = ({ commandsManager }) => {


### PR DESCRIPTION
Imported `utils` from `core` to `commandsModule.js`.

File is found here: 
```
/platform/viewer/src/appExtensions/GenericViewerCommands/commandsModule.js
```
Lines 36-38 are the source of the error.
```
const studyMetadata = utils.studyMetadataManager.get(
  activeViewport.StudyInstanceUID
);
```
Error is being thrown because `utils` is not defined, so the fix is to just import it.

The function that is trying to be called in `commandsModule.js` is found here: 
```
/platform/core/src/utils/studyMetadataManager.js
```
Fix for issue #1548 
### PR Checklist

- [x] Brief description of changes
- [x] Links to any relevant issues
- [x] Required status checks are passing
- [ ] User cases if changes impact the user's experience
- [x] `@mention` a maintainer to request a review

<!--
  Links
  -->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
