### PR TITLE
Feat/1767 error boundary stack trace

### DIFF
--- a/platform/ui/src/design/styles/common/button.styl
+++ b/platform/ui/src/design/styles/common/button.styl
@@ -51,3 +51,9 @@ button.close
   position: relative;
   display: inline-block;
   vertical-align: middle;
+
+.btn-sm
+  padding: .25rem .5rem;
+  font-size: .875rem;
+  line-height: 1.5;
+  border-radius: .2rem;

--- a/platform/viewer/src/components/ErrorBoundaryDialog/ErrorBoundaryDialog.css
+++ b/platform/viewer/src/components/ErrorBoundaryDialog/ErrorBoundaryDialog.css
@@ -3,8 +3,6 @@
 }
 
 .ErrorBoundaryDialogButton {
-  display: inline-flex;
-  align-items: center;
   outline: none;
 }
 
@@ -12,6 +10,7 @@
   margin-right: 5px;
   width: 10px;
   transform: rotate(-90deg);
+  vertical-align: middle;
 }
 
 .ErrorBoundaryDialogIcon.opened {

--- a/platform/viewer/src/components/ErrorBoundaryDialog/ErrorBoundaryDialog.css
+++ b/platform/viewer/src/components/ErrorBoundaryDialog/ErrorBoundaryDialog.css
@@ -1,0 +1,19 @@
+.ErrorBoundaryDialogTitle {
+  margin-top: 0;
+}
+
+.ErrorBoundaryDialogButton {
+  display: inline-flex;
+  align-items: center;
+  outline: none;
+}
+
+.ErrorBoundaryDialogIcon {
+  margin-right: 5px;
+  width: 10px;
+  transform: rotate(-90deg);
+}
+
+.ErrorBoundaryDialogIcon.opened {
+  transform: rotate(0deg);
+}

--- a/platform/viewer/src/components/ErrorBoundaryDialog/ErrorBoundaryDialog.js
+++ b/platform/viewer/src/components/ErrorBoundaryDialog/ErrorBoundaryDialog.js
@@ -1,26 +1,46 @@
-import React from 'react';
+import React, { useState } from 'react';
+import classnames from 'classnames';
 import PropTypes from 'prop-types';
-import { ErrorBoundary } from '@ohif/ui';
+import { ErrorBoundary, Icon } from '@ohif/ui';
 import { servicesManager } from './../../App';
+
+import './ErrorBoundaryDialog.css';
 
 const { UIModalService } = servicesManager.services;
 
 const ErrorBoundaryDialog = ({ context, children }) => {
   const handleOnError = (error, componentStack) => {
-    const ErrorDialog = () => (
-      <div className="ErrorFallback" role="alert">
-        <div>
-          <h3>
-            {context}: <span>{error.message}</span>
-          </h3>
+    const ErrorDialog = () => {
+      const [open, setOpen] = useState(false);
+
+      return (
+        <div className="ErrorFallback" role="alert">
+          <div className="ErrorBoundaryDialog">
+            <h3 className="ErrorBoundaryDialogTitle">
+              {context}: <span>{error.message}</span>
+            </h3>
+          </div>
+          <button
+            className="btn btn-primary btn-sm ErrorBoundaryDialogButton"
+            onClick={() => setOpen(s => !s)}
+          >
+            <Icon
+              name="chevron-down"
+              className={classnames('ErrorBoundaryDialogIcon', {
+                opened: open,
+              })}
+            />
+            Toggle stack trace
+          </button>
+
+          {open && <pre>{componentStack}</pre>}
         </div>
-        <pre>{componentStack}</pre>
-      </div>
-    );
+      );
+    };
 
     UIModalService.show({
       content: ErrorDialog,
-      title: `${context}: ${error.message}`,
+      title: `Something went wrong in ${context}`,
     });
   };
 

--- a/platform/viewer/src/components/ErrorBoundaryDialog/ErrorBoundaryDialog.js
+++ b/platform/viewer/src/components/ErrorBoundaryDialog/ErrorBoundaryDialog.js
@@ -30,7 +30,7 @@ const ErrorBoundaryDialog = ({ context, children }) => {
                 opened: open,
               })}
             />
-            Toggle stack trace
+            Stack Trace
           </button>
 
           {open && <pre>{componentStack}</pre>}


### PR DESCRIPTION
> * Move the stack trace to a collapsable menu named "stack trace", as displaying the stack trace straight away is blinding to the user, only the error message should be displayed at first.

### Preview

![image](https://user-images.githubusercontent.com/1905961/83792934-2c6c5080-a672-11ea-8db5-798fc01eba8f.png)

![image](https://user-images.githubusercontent.com/1905961/83792958-32623180-a672-11ea-949e-8de68e872c90.png)


Fixes #1767

---

### PR Checklist

- [x] Brief description of changes
- [x] Links to any relevant issues
- [ ] Required status checks are passing
- [ ] User cases if changes impact the user's experience
- [ ] `@mention` a maintainer to request a review

<!--
  Links
  -->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
