### PR TITLE
v2 - Feat/ohif 156

### DIFF
--- a/extensions/cornerstone/src/init.js
+++ b/extensions/cornerstone/src/init.js
@@ -90,6 +90,7 @@ export default function init({ servicesManager, configuration }) {
 
   /* Add extension tools configuration here. */
   const internalToolsConfig = {
+    /* TODO ArrowAnnotate input
     ArrowAnnotate: {
       configuration: {
         getTextCallback: (callback, eventDetails) =>
@@ -98,6 +99,7 @@ export default function init({ servicesManager, configuration }) {
           callInputDialog(data, eventDetails, callback),
       },
     },
+    */
   };
 
   /* Abstract tools configuration using extension configuration. */
@@ -166,27 +168,48 @@ export default function init({ servicesManager, configuration }) {
 
 const _initMeasurementService = measurementService => {
   /* Initialization */
-  const { toAnnotation, toMeasurement } = measurementServiceMappingsFactory(
-    measurementService
-  );
+  const {
+    Length,
+    Bidirectional,
+    EllipticalRoi,
+    ArrowAnnotate,
+  } = measurementServiceMappingsFactory(measurementService);
   const csToolsVer4MeasurementSource = measurementService.createSource(
     'CornerstoneTools',
     '4'
   );
 
-  /* Matching Criterias */
-  const matchingCriteria = {
-    valueType: measurementService.VALUE_TYPES.POLYLINE,
-    points: 2,
-  };
-
   /* Mappings */
   measurementService.addMapping(
     csToolsVer4MeasurementSource,
     'Length',
-    matchingCriteria,
-    toAnnotation,
-    toMeasurement
+    Length.matchingCriteria,
+    Length.toAnnotation,
+    Length.toMeasurement
+  );
+
+  measurementService.addMapping(
+    csToolsVer4MeasurementSource,
+    'Bidirectional',
+    Bidirectional.matchingCriteria,
+    Bidirectional.toAnnotation,
+    Bidirectional.toMeasurement
+  );
+
+  measurementService.addMapping(
+    csToolsVer4MeasurementSource,
+    'EllipticalRoi',
+    EllipticalRoi.matchingCriteria,
+    EllipticalRoi.toAnnotation,
+    EllipticalRoi.toMeasurement
+  );
+
+  measurementService.addMapping(
+    csToolsVer4MeasurementSource,
+    'ArrowAnnotate',
+    ArrowAnnotate.matchingCriteria,
+    ArrowAnnotate.toAnnotation,
+    ArrowAnnotate.toMeasurement
   );
 
   return csToolsVer4MeasurementSource;

--- a/extensions/cornerstone/src/utils/measurementServiceMappings/ArrowAnnotate.js
+++ b/extensions/cornerstone/src/utils/measurementServiceMappings/ArrowAnnotate.js
@@ -1,0 +1,49 @@
+import SUPPORTED_TOOLS from './constants/supportedTools';
+import getHandlesFromPoints from './utils/getHandlesFromPoints';
+import getPointsFromHandles from './utils/getPointsFromHandles';
+import getSOPInstanceAttributes from './utils/getSOPInstanceAttributes';
+
+const ArrowAnnotate = {
+  toAnnotation: (measurement, definition) => {
+    // TODO -> Implement when this is needed.
+  },
+  toMeasurement: (csToolsAnnotation, getValueTypeFromToolType) => {
+    const { element, measurementData } = csToolsAnnotation;
+    const tool =
+      csToolsAnnotation.toolType ||
+      csToolsAnnotation.toolName ||
+      measurementData.toolType;
+
+    const validToolType = toolName => SUPPORTED_TOOLS.includes(toolName);
+
+    if (!validToolType(tool)) {
+      throw new Error('Tool not supported');
+    }
+
+    const {
+      SOPInstanceUID,
+      FrameOfReferenceUID,
+      SeriesInstanceUID,
+      StudyInstanceUID,
+    } = getSOPInstanceAttributes(element);
+
+    const points = [];
+    points.push(measurementData.handles);
+
+    return {
+      id: measurementData._measurementServiceId,
+      SOPInstanceUID: SOPInstanceUID,
+      FrameOfReferenceUID,
+      referenceSeriesUID: SeriesInstanceUID,
+      referenceStudyUID: StudyInstanceUID,
+      label: measurementData.text,
+      description: measurementData.description,
+      unit: measurementData.unit,
+      text: measurementData.text,
+      type: getValueTypeFromToolType(tool),
+      points: getPointsFromHandles(measurementData.handles),
+    };
+  },
+};
+
+export default ArrowAnnotate;

--- a/extensions/cornerstone/src/utils/measurementServiceMappings/Bidirectional.js
+++ b/extensions/cornerstone/src/utils/measurementServiceMappings/Bidirectional.js
@@ -1,0 +1,50 @@
+import SUPPORTED_TOOLS from './constants/supportedTools';
+import getSOPInstanceAttributes from './utils/getSOPInstanceAttributes';
+
+const Bidirectional = {
+  toAnnotation: (measurement, definition) => {
+    // TODO -> Implement when this is needed.
+  },
+  toMeasurement: (csToolsAnnotation, getValueTypeFromToolType) => {
+    const { element, measurementData } = csToolsAnnotation;
+    const tool =
+      csToolsAnnotation.toolType ||
+      csToolsAnnotation.toolName ||
+      measurementData.toolType;
+
+    const validToolType = toolName => SUPPORTED_TOOLS.includes(toolName);
+
+    if (!validToolType(tool)) {
+      throw new Error('Tool not supported');
+    }
+
+    const {
+      SOPInstanceUID,
+      FrameOfReferenceUID,
+      SeriesInstanceUID,
+      StudyInstanceUID,
+    } = getSOPInstanceAttributes(element);
+
+    const { handles } = measurementData;
+
+    const longAxis = [handles.start, handles.end];
+    const shortAxis = [handles.perpendicularStart, handles.perpendicularEnd];
+
+    return {
+      id: measurementData._measurementServiceId,
+      SOPInstanceUID: SOPInstanceUID,
+      FrameOfReferenceUID,
+      referenceSeriesUID: SeriesInstanceUID,
+      referenceStudyUID: StudyInstanceUID,
+      label: measurementData.text,
+      description: measurementData.description,
+      unit: measurementData.unit,
+      shortestDiameter: measurementData.shortestDiameter,
+      longestDiameter: measurementData.longestDiameter,
+      type: getValueTypeFromToolType(tool),
+      points: { longAxis, shortAxis },
+    };
+  },
+};
+
+export default Bidirectional;

--- a/extensions/cornerstone/src/utils/measurementServiceMappings/Length.js
+++ b/extensions/cornerstone/src/utils/measurementServiceMappings/Length.js
@@ -1,0 +1,79 @@
+import SUPPORTED_TOOLS from './constants/supportedTools';
+import getHandlesFromPoints from './utils/getHandlesFromPoints';
+import getPointsFromHandles from './utils/getPointsFromHandles';
+import getSOPInstanceAttributes from './utils/getSOPInstanceAttributes';
+
+const Length = {
+  toAnnotation: (measurement, definition) => {
+    const {
+      id,
+      label,
+      description,
+      points,
+      unit,
+      SOPInstanceUID,
+      FrameOfReferenceUID,
+      referenceSeriesUID,
+    } = measurement;
+
+    return {
+      toolName: definition,
+      measurementData: {
+        sopInstanceUid: SOPInstanceUID,
+        frameOfReferenceUID: FrameOfReferenceUID,
+        SeriesInstanceUID: referenceSeriesUID,
+        unit,
+        text: label,
+        description,
+        handles: getHandlesFromPoints(points),
+        _measurementServiceId: id,
+      },
+    };
+  },
+
+  /**
+   * Maps cornerstone annotation event data to measurement service format.
+   *
+   * @param {Object} cornerstone Cornerstone event data
+   * @return {Measurement} Measurement instance
+   */
+  toMeasurement: (csToolsAnnotation, getValueTypeFromToolType) => {
+    const { element, measurementData } = csToolsAnnotation;
+    const tool =
+      csToolsAnnotation.toolType ||
+      csToolsAnnotation.toolName ||
+      measurementData.toolType;
+
+    const validToolType = toolName => SUPPORTED_TOOLS.includes(toolName);
+
+    if (!validToolType(tool)) {
+      throw new Error('Tool not supported');
+    }
+
+    const {
+      SOPInstanceUID,
+      FrameOfReferenceUID,
+      SeriesInstanceUID,
+      StudyInstanceUID,
+    } = getSOPInstanceAttributes(element);
+
+    const points = [];
+    points.push(measurementData.handles);
+
+    return {
+      id: measurementData._measurementServiceId,
+      SOPInstanceUID: SOPInstanceUID,
+      FrameOfReferenceUID,
+      referenceSeriesUID: SeriesInstanceUID,
+      referenceStudyUID: StudyInstanceUID,
+      label: measurementData.text,
+      description: measurementData.description,
+      unit: measurementData.unit,
+      length: measurementData.length,
+      type: getValueTypeFromToolType(tool),
+      points: getPointsFromHandles(measurementData.handles),
+    };
+  },
+};
+
+export default Length;

--- a/extensions/cornerstone/src/utils/measurementServiceMappings/constants/supportedTools.js
+++ b/extensions/cornerstone/src/utils/measurementServiceMappings/constants/supportedTools.js
@@ -1,0 +1,1 @@
+export default ['Length', 'EllipticalRoi', 'Bidirectional', 'ArrowAnnotate'];

--- a/extensions/cornerstone/src/utils/measurementServiceMappings/utils/getHandlesFromPoints.js
+++ b/extensions/cornerstone/src/utils/measurementServiceMappings/utils/getHandlesFromPoints.js
@@ -1,0 +1,5 @@
+export default function getHandlesFromPoints(points) {
+  return points
+    .map((p, i) => (i % 10 === 0 ? { start: p } : { end: p }))
+    .reduce((obj, item) => Object.assign(obj, { ...item }), {});
+}

--- a/extensions/cornerstone/src/utils/measurementServiceMappings/utils/getPointsFromHandles.js
+++ b/extensions/cornerstone/src/utils/measurementServiceMappings/utils/getPointsFromHandles.js
@@ -1,0 +1,12 @@
+export default function getPointsFromHandles(handles) {
+  let points = [];
+  Object.keys(handles).map(handle => {
+    if (['start', 'end'].includes(handle)) {
+      let point = {};
+      if (handles[handle].x) point.x = handles[handle].x;
+      if (handles[handle].y) point.y = handles[handle].y;
+      points.push(point);
+    }
+  });
+  return points;
+}

--- a/extensions/cornerstone/src/utils/measurementServiceMappings/utils/getSOPInstanceAttributes.js
+++ b/extensions/cornerstone/src/utils/measurementServiceMappings/utils/getSOPInstanceAttributes.js
@@ -1,0 +1,14 @@
+import cornerstone from 'cornerstone-core';
+
+export default function getSOPInstanceAttributes(element) {
+  const enabledElement = cornerstone.getEnabledElement(element);
+  const imageId = enabledElement.image.imageId;
+  const instance = cornerstone.metaData.get('instance', imageId);
+
+  return {
+    SOPInstanceUID: instance.SOPInstanceUID,
+    FrameOfReferenceUID: instance.FrameOfReferenceUID,
+    SeriesInstanceUID: instance.SeriesInstanceUID,
+    StudyInstanceUID: instance.StudyInstanceUID,
+  };
+}

--- a/extensions/measurement-tracking/src/panels/PanelMeasurementTableTracking/index.js
+++ b/extensions/measurement-tracking/src/panels/PanelMeasurementTableTracking/index.js
@@ -42,7 +42,7 @@ function PanelMeasurementTableTracking({ servicesManager, commandsManager }) {
         trackedSeries.includes(m.referenceSeriesUID)
     );
     const mappedMeasurements = filteredMeasurements.map((m, index) =>
-      _mapMeasurementToDisplay(m, index)
+      _mapMeasurementToDisplay(m, index, MeasurementService.VALUE_TYPES)
     );
     setDisplayMeasurements(mappedMeasurements);
     // eslint-ignore-next-line
@@ -130,7 +130,7 @@ function PanelMeasurementTableTracking({ servicesManager, commandsManager }) {
 PanelMeasurementTableTracking.propTypes = {};
 
 // TODO: This could be a MeasurementService mapper
-function _mapMeasurementToDisplay(measurement, index) {
+function _mapMeasurementToDisplay(measurement, index, types) {
   const {
     id,
     label,
@@ -153,12 +153,14 @@ function _mapMeasurementToDisplay(measurement, index) {
   return {
     id: index + 1,
     label: '(empty)', // 'Label short description',
-    displayText: _getDisplayText(
-      measurement.points,
-      PixelSpacing,
-      SeriesNumber,
-      InstanceNumber
-    ),
+    displayText:
+      _getDisplayText(
+        measurement,
+        PixelSpacing,
+        SeriesNumber,
+        InstanceNumber,
+        types
+      ) || [],
     // TODO: handle one layer down
     isActive: false, // activeMeasurementItem === i + 1,
   };
@@ -169,13 +171,21 @@ function _mapMeasurementToDisplay(measurement, index) {
  * @param {*} points
  * @param {*} pixelSpacing
  */
-function _getDisplayText(points, pixelSpacing, seriesNumber, instanceNumber) {
+function _getDisplayText(
+  measurement,
+  pixelSpacing,
+  seriesNumber,
+  instanceNumber,
+  types
+) {
   // TODO: determination of shape influences text
   // Length:  'xx.x unit (S:x, I:x)'
   // Rectangle: 'xx.x x xx.x unit (S:x, I:x)',
   // Ellipse?
   // Bidirectional?
   // Freehand?
+
+  const { type, points } = measurement;
 
   const hasPixelSpacing =
     pixelSpacing !== undefined &&
@@ -186,13 +196,37 @@ function _getDisplayText(points, pixelSpacing, seriesNumber, instanceNumber) {
     : [1, 1];
   const unit = hasPixelSpacing ? 'mm' : 'px';
 
-  const { x: x1, y: y1 } = points[0];
-  const { x: x2, y: y2 } = points[1];
-  const dx = (x2 - x1) * colPixelSpacing;
-  const dy = (y2 - y1) * rowPixelSpacing;
-  const length = _round(Math.sqrt(dx * dx + dy * dy), 1);
+  switch (type) {
+    case types.POLYLINE:
+      const { length } = measurement;
 
-  return `${length} ${unit} (S:${seriesNumber}, I:${instanceNumber})`;
+      const roundedLength = _round(length, 1);
+
+      return [
+        `${roundedLength} ${unit} (S:${seriesNumber}, I:${instanceNumber})`,
+      ];
+
+    case types.BIDIRECTIONAL:
+      const { shortestDiameter, longestDiameter } = measurement;
+
+      const roundedShortestDiameter = _round(shortestDiameter, 1);
+      const roundedLongestDiameter = _round(longestDiameter, 1);
+
+      return [
+        `l: ${roundedLongestDiameter} ${unit} (S:${seriesNumber}, I:${instanceNumber})`,
+        `s: ${roundedShortestDiameter} ${unit}`,
+      ];
+    case types.ELLIPSE:
+      const { area } = measurement;
+
+      const roundedArea = _round(area, 1);
+      return [
+        `${roundedArea} ${unit}2 (S:${seriesNumber}, I:${instanceNumber})`,
+      ];
+    case types.POINT:
+      const { text } = measurement;
+      return [`${text} (S:${seriesNumber}, I:${instanceNumber})`];
+  }
 }
 
 function _round(value, decimals) {

--- a/platform/core/src/services/MeasurementService/MeasurementService.js
+++ b/platform/core/src/services/MeasurementService/MeasurementService.js
@@ -40,6 +40,10 @@ const MEASUREMENT_SCHEMA_KEYS = [
   'type',
   'unit',
   'area', // TODO: Add concept names instead (descriptor)
+  'length',
+  'shortestDiameter',
+  'longestDiameter',
+  'text', // NOTE: There is nothing like this in SR.
   'points',
   'source',
 ];
@@ -53,6 +57,7 @@ const EVENTS = {
 const VALUE_TYPES = {
   POLYLINE: 'value_type::polyline',
   POINT: 'value_type::point',
+  BIDIRECTIONAL: 'value_type::shortAxisLongAxis', // TODO -> Discuss with Danny. => just using SCOORD values isn't enough here.
   ELLIPSE: 'value_type::ellipse',
   MULTIPOINT: 'value_type::multipoint',
   CIRCLE: 'value_type::circle',

--- a/platform/ui/src/components/MeasurementTable/MeasurementTable.jsx
+++ b/platform/ui/src/components/MeasurementTable/MeasurementTable.jsx
@@ -14,7 +14,7 @@ const MeasurementTable = ({ data, title, amount, onClick, onEdit }) => {
       </div>
       <div className="overflow-y-auto overflow-x-hidden ohif-scrollbar max-h-112">
         {!!data.length &&
-          data.map((measurementItem) => {
+          data.map(measurementItem => {
             const { id, label, displayText, isActive } = measurementItem;
             return (
               <div
@@ -45,9 +45,11 @@ const MeasurementTable = ({ data, title, amount, onClick, onEdit }) => {
                   <span className="text-base text-primary-light mb-1">
                     {label}
                   </span>
-                  <span className="pl-2 border-l border-primary-light text-base text-white">
-                    {displayText}
-                  </span>
+                  {displayText.map(line => (
+                    <span className="pl-2 border-l border-primary-light text-base text-white">
+                      {line}
+                    </span>
+                  ))}
                   <Icon
                     className={classnames(
                       'text-white w-4 absolute cursor-pointer transition duration-300',
@@ -61,7 +63,7 @@ const MeasurementTable = ({ data, title, amount, onClick, onEdit }) => {
                       right: 4,
                       transform: isActive ? '' : 'translateX(100%)',
                     }}
-                    onClick={(e) => {
+                    onClick={e => {
                       // stopPropagation needed to avoid disable the current active item
                       e.stopPropagation();
                       onEdit(id);
@@ -108,7 +110,7 @@ MeasurementTable.propTypes = {
     PropTypes.shape({
       id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
       label: PropTypes.string,
-      displayText: PropTypes.string,
+      displayText: PropTypes.arrayOf(PropTypes.string),
       isActive: PropTypes.bool,
     })
   ),


### PR DESCRIPTION
One way cornerstoneTools measurements => measurements service.

Do we need to implement the toAnnotation functions at the current time? They are unused for now, and likely not a priority until we have multiple sources of annotations (cornerstoneTools, vtk).

The originally proposed pattern of having each measurement fit to one SCOORD type doesn't gel well with SR, so we'll need to discuss @dannyrb.


I removed mathematical calculations from the UI, as these can be cashed in the measurement service representation, and shouldn't be calculated every render.