### PR TITLE
Fix README.md Quick Start Deployment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ window.config = {
 ```
 
 - Install the viewer:
-  `window.OHIFStandaloneViewer.installViewer(window.config);`
+  `window.OHIFViewer.installViewer(window.config);`
 
 This exact setup is demonstrated in this
 [CodeSandbox](https://codesandbox.io/s/viewer-script-tag-tprch) and in our


### PR DESCRIPTION
Change `window.OHIFStandaloneViewer` to `window.OHIFViewer`, since the former is undefined. 

### PR Checklist

- [ ] Brief description of changes
- [ ] Links to any relevant issues
- [ ] Required status checks are passing
- [ ] User cases if changes impact the user's experience
- [ ] `@mention` a maintainer to request a review

<!--
  Links
  -->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
