### PR TITLE
feat: v2 context menu - OHIF-193

### DIFF
--- a/extensions/cornerstone/src/init.js
+++ b/extensions/cornerstone/src/init.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import OHIF from '@ohif/core';
-import { Dialog, Input } from '@ohif/ui';
+import { Input, ContextMenuMeasurements } from '@ohif/ui';
 import cornerstone from 'cornerstone-core';
 import csTools from 'cornerstone-tools';
 import merge from 'lodash.merge';
@@ -23,6 +23,89 @@ export default function init({ servicesManager, configuration }) {
     MeasurementService,
     DisplaySetService,
   } = servicesManager.services;
+
+  const onRightClick = event => {
+    if (!UIDialogService) {
+      console.warn('Unable to show dialog; no UI Dialog Service available.');
+      return;
+    }
+
+    UIDialogService.dismiss({ id: 'context-menu' });
+    UIDialogService.create({
+      id: 'context-menu',
+      isDraggable: false,
+      preservePosition: false,
+      defaultPosition: _getDefaultPosition(event.detail),
+      content: ContextMenuMeasurements,
+      contentProps: {
+        eventData: event.detail,
+        onDelete: item => {
+          console.log('TBD: onDelete', item);
+        },
+        onClose: () => UIDialogService.dismiss({ id: 'context-menu' }),
+        onSetLabel: item => {
+          console.log('TBD: onSetLabel', item);
+        },
+        onSetDescription: item => {
+          console.log('TBD: onSetDescription', item);
+        },
+      },
+    });
+  };
+
+  const onTouchPress = event => {
+    if (!UIDialogService) {
+      console.warn('Unable to show dialog; no UI Dialog Service available.');
+      return;
+    }
+
+    UIDialogService.create({
+      eventData: event.detail,
+      content: ContextMenuMeasurements,
+      contentProps: {
+        isTouchEvent: true,
+      },
+    });
+  };
+
+  const onTouchStart = () => resetLabellingAndContextMenu();
+  const onMouseClick = () => resetLabellingAndContextMenu();
+
+  const resetLabellingAndContextMenu = () => {
+    if (!UIDialogService) {
+      console.warn('Unable to show dialog; no UI Dialog Service available.');
+      return;
+    }
+
+    UIDialogService.dismiss({ id: 'context-menu' });
+    UIDialogService.dismiss({ id: 'labelling' });
+  };
+
+  /*
+   * Because click gives us the native "mouse up", buttons will always be `0`
+   * Need to fallback to event.which;
+   *
+   */
+  const handleClick = cornerstoneMouseClickEvent => {
+    const mouseUpEvent = cornerstoneMouseClickEvent.detail.event;
+    const isRightClick = mouseUpEvent.which === 3;
+    const clickMethodHandler = isRightClick ? onRightClick : onMouseClick;
+    clickMethodHandler(cornerstoneMouseClickEvent);
+  };
+
+  function elementEnabledHandler(evt) {
+    const element = evt.detail.element;
+    element.addEventListener(csTools.EVENTS.TOUCH_PRESS, onTouchPress);
+    element.addEventListener(csTools.EVENTS.MOUSE_CLICK, handleClick);
+    element.addEventListener(csTools.EVENTS.TOUCH_START, onTouchStart);
+  }
+
+  function elementDisabledHandler(evt) {
+    const element = evt.detail.element;
+    element.removeEventListener(csTools.EVENTS.TOUCH_PRESS, onTouchPress);
+    element.removeEventListener(csTools.EVENTS.MOUSE_CLICK, handleClick);
+    element.removeEventListener(csTools.EVENTS.TOUCH_START, onTouchStart);
+  }
 
   const callInputDialog = (data, event, callback) => {
     if (UIDialogService) {
@@ -222,6 +305,15 @@ export default function init({ servicesManager, configuration }) {
   csTools.setToolActive('PanMultiTouch', { pointers: 2 }); // TODO: Better error if no options
   csTools.setToolActive('ZoomTouchPinch', {});
   csTools.setToolEnabled('Overlay', {});
+
+  cornerstone.events.addEventListener(
+    cornerstone.EVENTS.ELEMENT_ENABLED,
+    elementEnabledHandler
+  );
+  cornerstone.events.addEventListener(
+    cornerstone.EVENTS.ELEMENT_DISABLED,
+    elementDisabledHandler
+  );
 }
 
 const _initMeasurementService = (MeasurementService, DisplaySetService) => {
@@ -384,6 +476,11 @@ const _connectMeasurementServiceToTools = (
     }
   ); */
 };
+
+const _getDefaultPosition = event => ({
+  x: (event && event.currentPoints.client.x) || 0,
+  y: (event && event.currentPoints.client.y) || 0,
+});
 
 // const {
 //   MEASUREMENT_ADDED,

--- a/platform/ui/index.js
+++ b/platform/ui/index.js
@@ -29,6 +29,7 @@ export {
 export {
   Button,
   ButtonGroup,
+  ContextMenu,
   DateRange,
   Dialog,
   Dropdown,
@@ -73,6 +74,7 @@ export {
   ThumbnailTracked,
   ThumbnailList,
   ToolbarButton,
+  ContextMenuMeasurements,
   Tooltip,
   TooltipClipboard,
   Typography,

--- a/platform/ui/src/components/ContextMenu/ContextMenu.jsx
+++ b/platform/ui/src/components/ContextMenu/ContextMenu.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Typography } from '@ohif/ui';
+
+const ContextMenu = ({ items }) => {
+  return (
+    <div
+      className="relative bg-secondary-dark rounded z-50 block w-48"
+      onContextMenu={e => e.preventDefault()}
+    >
+      {items.map((item, index) => (
+        <div
+          key={index}
+          onClick={() => item.action(item)}
+          className="flex px-4 py-3 cursor-pointer items-center transition duration-300 hover:bg-primary-dark border-b border-primary-dark last:border-b-0"
+        >
+          <Typography>{item.label}</Typography>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+ContextMenu.propTypes = {
+  items: PropTypes.arrayOf(
+    PropTypes.shape({
+      label: PropTypes.string.isRequired,
+      actionType: PropTypes.string.isRequired,
+      action: PropTypes.func.isRequired,
+    })
+  ).isRequired,
+};
+
+export default ContextMenu;

--- a/platform/ui/src/components/ContextMenu/ContextMenu.mdx
+++ b/platform/ui/src/components/ContextMenu/ContextMenu.mdx
@@ -1,0 +1,49 @@
+---
+name: Context Menu
+menu: General
+route: components/contextMenu
+---
+
+import { Playground, Props } from 'docz';
+import { ContextMenu } from '@ohif/ui';
+
+# Context Menu
+
+...
+
+## Import
+
+```javascript
+import { ContextMenu } from '@ohif/ui';
+```
+
+<Playground>
+  {() => {
+    const items = [
+      {
+        label: 'Delete measurement',
+        actionType: 'Delete',
+        action: () => alert('Delete'),
+      },
+      {
+        label: 'Relabel',
+        actionType: 'setLabel',
+        action: () => alert('Relabel'),
+      },
+      {
+        label: 'Add Description',
+        actionType: 'setDescription',
+        action: () => alert('Add Description'),
+      },
+    ];
+    return (
+      <div className="p-4">
+        <ContextMenu items={items} />
+      </div>
+    );
+  }}
+</Playground>
+
+## Properties
+
+<Props of={ContextMenu} />

--- a/platform/ui/src/components/ContextMenu/index.js
+++ b/platform/ui/src/components/ContextMenu/index.js
@@ -1,0 +1,1 @@
+export { default } from './ContextMenu';

--- a/platform/ui/src/components/ContextMenuMeasurements/ContextMenuMeasurements.jsx
+++ b/platform/ui/src/components/ContextMenuMeasurements/ContextMenuMeasurements.jsx
@@ -1,0 +1,56 @@
+import { ContextMenu } from '@ohif/ui';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+const ContextMenuMeasurements = ({
+  onSetLabel,
+  onSetDescription,
+  isTouchEvent,
+  eventData,
+  onClose,
+  onDelete,
+}) => {
+  const dropdownItems = [
+    {
+      label: 'Delete measurement',
+      actionType: 'Delete',
+      action: item => {
+        onDelete(item);
+        onClose();
+      },
+    },
+    {
+      label: 'Relabel',
+      actionType: 'setLabel',
+      action: item => {
+        onSetLabel(item);
+        onClose();
+      },
+    },
+    {
+      label: 'Add Description',
+      actionType: 'setDescription',
+      action: item => {
+        onSetDescription(item);
+        onClose();
+      },
+    },
+  ];
+
+  return <ContextMenu items={dropdownItems} />;
+};
+
+ContextMenuMeasurements.propTypes = {
+  isTouchEvent: PropTypes.bool,
+  eventData: PropTypes.object.isRequired,
+  onClose: PropTypes.func.isRequired,
+  onSetDescription: PropTypes.func.isRequired,
+  onSetLabel: PropTypes.func.isRequired,
+  onDelete: PropTypes.func.isRequired,
+};
+
+ContextMenuMeasurements.defaultProps = {
+  isTouchEvent: false,
+};
+
+export default ContextMenuMeasurements;

--- a/platform/ui/src/components/ContextMenuMeasurements/index.js
+++ b/platform/ui/src/components/ContextMenuMeasurements/index.js
@@ -1,0 +1,1 @@
+export { default } from './ContextMenuMeasurements';

--- a/platform/ui/src/components/index.js
+++ b/platform/ui/src/components/index.js
@@ -1,5 +1,6 @@
 import Button from './Button';
 import ButtonGroup from './ButtonGroup';
+import ContextMenu from './ContextMenu';
 import DateRange from './DateRange';
 import Dialog from './Dialog';
 import Dropdown from './Dropdown';
@@ -41,6 +42,7 @@ import ThumbnailNoImage from './ThumbnailNoImage';
 import ThumbnailTracked from './ThumbnailTracked';
 import ThumbnailList from './ThumbnailList';
 import ToolbarButton from './ToolbarButton';
+import ContextMenuMeasurements from './ContextMenuMeasurements';
 import ExpandableToolbarButton from './ExpandableToolbarButton';
 import ListMenu from './ListMenu';
 import Tooltip from './Tooltip';
@@ -55,6 +57,7 @@ import ViewportPane from './ViewportPane';
 export {
   Button,
   ButtonGroup,
+  ContextMenu,
   DateRange,
   Dialog,
   Dropdown,
@@ -99,6 +102,7 @@ export {
   ThumbnailTracked,
   ThumbnailList,
   ToolbarButton,
+  ContextMenuMeasurements,
   Tooltip,
   TooltipClipboard,
   Typography,


### PR DESCRIPTION
**OHIF-193**

### Description

- Created a new component `ContextMenu` to the UI library `@ohif/ui`.
- Created a `MeasurementsContextMenu` component based on the `ContextMenu` to be used when `UIDialogService` is called.
- Basic listener implementation (right-click) in the cornerstone library to show the context menu -- most of the implementation was preserved from the current `master`.
- Basic action implementation. The final implementation for `delete`, `set label`, and `set/edit description` will be done later.

### Preview

![Jun-29-2020 17-05-11](https://user-images.githubusercontent.com/1905961/86050777-b8338b80-ba2a-11ea-9668-13e44ebf0115.gif)


### PR Checklist

- [ ] Brief description of changes
- [ ] Links to any relevant issues
- [ ] Required status checks are passing
- [ ] User cases if changes impact the user's experience
- [ ] `@mention` a maintainer to request a review

<!--
  Links
  -->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
