### PR TITLE
[OHIF-231] Update dcmjs to fix bidirectional issue.

### DIFF
--- a/extensions/cornerstone/package.json
+++ b/extensions/cornerstone/package.json
@@ -35,7 +35,7 @@
     "cornerstone-math": "^0.1.8",
     "cornerstone-tools": "4.16.1",
     "cornerstone-wado-image-loader": "^3.1.2",
-    "dcmjs": "0.14.0",
+    "dcmjs": "0.14.2",
     "dicom-parser": "^1.8.3",
     "hammerjs": "^2.0.8",
     "prop-types": "^15.6.2",

--- a/extensions/default/package.json
+++ b/extensions/default/package.json
@@ -34,7 +34,7 @@
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "webpack": "^4.0.0",
-    "dcmjs": "0.14.0"
+    "dcmjs": "0.14.2"
   },
   "dependencies": {
     "@babel/runtime": "7.7.6"

--- a/extensions/dicom-html/package.json
+++ b/extensions/dicom-html/package.json
@@ -28,7 +28,7 @@
   },
   "peerDependencies": {
     "@ohif/core": "^0.50.0",
-    "dcmjs": "0.14.1",
+    "dcmjs": "0.14.2",
     "prop-types": "^15.6.2",
     "react": "^16.11.0",
     "react-dom": "^16.11.0"

--- a/extensions/dicom-rt/package.json
+++ b/extensions/dicom-rt/package.json
@@ -31,7 +31,7 @@
     "@ohif/core": "^0.50.0",
     "cornerstone-core": "^2.2.8",
     "cornerstone-tools": "4.16.1",
-    "dcmjs": "0.14.1",
+    "dcmjs": "0.14.2",
     "prop-types": "^15.6.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"

--- a/extensions/dicom-segmentation/package.json
+++ b/extensions/dicom-segmentation/package.json
@@ -31,7 +31,7 @@
     "@ohif/core": "^0.50.0",
     "cornerstone-core": "^2.2.8",
     "cornerstone-tools": "4.16.1",
-    "dcmjs": "0.14.1",
+    "dcmjs": "0.14.2",
     "prop-types": "^15.6.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"

--- a/extensions/dicom-sr/package.json
+++ b/extensions/dicom-sr/package.json
@@ -35,7 +35,7 @@
     "cornerstone-math": "^0.1.8",
     "cornerstone-tools": "4.16.1",
     "cornerstone-wado-image-loader": "^3.1.2",
-    "dcmjs": "0.14.1",
+    "dcmjs": "0.14.2",
     "dicom-parser": "^1.8.3",
     "hammerjs": "^2.0.8",
     "prop-types": "^15.6.2",

--- a/extensions/dicom-sr/src/getSopClassHandlerModule.js
+++ b/extensions/dicom-sr/src/getSopClassHandlerModule.js
@@ -523,8 +523,6 @@ function _getLabelFromMeasuredValueSequence(
   const { NumericValue, MeasurementUnitsCodeSequence } = MeasuredValueSequence;
   const { CodeValue } = MeasurementUnitsCodeSequence;
 
-  debugger;
-
   const formatedNumericValue = NumericValue
     ? Number(NumericValue).toFixed(2)
     : '';

--- a/extensions/measurement-tracking/package.json
+++ b/extensions/measurement-tracking/package.json
@@ -29,7 +29,7 @@
   "peerDependencies": {
     "@ohif/core": "^0.50.0",
     "cornerstone-tools": "4.16.1",
-    "dcmjs": "0.14.1",
+    "dcmjs": "0.14.2",
     "prop-types": "^15.6.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/extensions/vtk/package.json
+++ b/extensions/vtk/package.json
@@ -33,7 +33,7 @@
     "@ohif/ui": "^2.0.0",
     "cornerstone-core": "^2.3.0",
     "cornerstone-wado-image-loader": "^3.1.2",
-    "dcmjs": "0.14.1",
+    "dcmjs": "0.14.2",
     "dicom-parser": "^1.8.3",
     "i18next": "^17.0.3",
     "i18next-browser-languagedetector": "^3.0.1",

--- a/platform/core/package.json
+++ b/platform/core/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@babel/runtime": "7.7.6",
     "ajv": "^6.10.0",
-    "dcmjs": "0.14.1",
+    "dcmjs": "0.14.2",
     "dicomweb-client": "^0.6.0",
     "immer": "6.0.2",
     "isomorphic-base64": "^1.0.2",

--- a/platform/viewer/package.json
+++ b/platform/viewer/package.json
@@ -69,7 +69,7 @@
     "cornerstone-math": "^0.1.8",
     "cornerstone-tools": "4.16.1",
     "cornerstone-wado-image-loader": "^3.1.2",
-    "dcmjs": "0.14.1",
+    "dcmjs": "0.14.2",
     "dicom-parser": "^1.8.3",
     "dicomweb-client": "^0.4.4",
     "dotenv-webpack": "^1.7.0",


### PR DESCRIPTION
Fixes editability of bidirectional tool after import by this change to dcmjs: https://github.com/dcmjs-org/dcmjs/pull/133

Sometime between CST 4.3 and 4.16.1 some fields where added to the bidirectional tool schema which are actually breaking schema changes, the above PR updates the dcmjs cornerstone adapter to deal with this.