### PR TITLE
OHIF-250: The cornerstone viewport should not display "Loading 0%" when attempting to view an unloaded image. It should say "Loading"

### DIFF
--- a/extensions/measurement-tracking/src/viewports/TrackedCornerstoneViewport.js
+++ b/extensions/measurement-tracking/src/viewports/TrackedCornerstoneViewport.js
@@ -13,6 +13,7 @@ import {
 import { useTrackedMeasurements } from './../getContextModule';
 
 import ViewportOverlay from './ViewportOverlay';
+import ViewportLoadingIndicator from './ViewportLoadingIndicator';
 
 const { formatDate } = utils;
 
@@ -268,8 +269,8 @@ function TrackedCornerstoneViewport({
             spacing:
               PixelSpacing && PixelSpacing.length
                 ? `${PixelSpacing[0].toFixed(2)}mm x ${PixelSpacing[1].toFixed(
-                    2
-                  )}mm`
+                  2
+                )}mm`
                 : '',
             scanner: ManufacturerModelName || '',
           },
@@ -288,6 +289,7 @@ function TrackedCornerstoneViewport({
           isPlaying={false}
           frameRate={24}
           isOverlayVisible={true}
+          loadingIndicatorComponent={ViewportLoadingIndicator}
           viewportOverlayComponent={props => {
             return (
               <ViewportOverlay

--- a/extensions/measurement-tracking/src/viewports/ViewportLoadingIndicator.js
+++ b/extensions/measurement-tracking/src/viewports/ViewportLoadingIndicator.js
@@ -1,0 +1,41 @@
+import React from 'react';
+
+import PropTypes from 'prop-types';
+
+const ViewportLoadingIndicator = ({ error }) => {
+  if (error) {
+    return (
+      <>
+        <div className="bg-black h-full w-full absolute opacity-50"></div>
+        <div className="text-primary-light text-xl font-thin">
+          <h4>Error Loading Image</h4>
+          <p>An error has occurred.</p>
+          <p>{error.message}</p>
+        </div>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <div className="bg-black h-full w-full absolute opacity-50"></div>
+      <div className="absolute transparent w-full h-full flex items-center justify-center">
+        <p className="text-primary-light text-xl font-thin">
+          Loading...
+      </p>
+      </div>
+    </>
+  );
+};
+
+ViewportLoadingIndicator.propTypes = {
+  percentComplete: PropTypes.number,
+  error: PropTypes.object,
+};
+
+ViewportLoadingIndicator.defaultProps = {
+  percentComplete: 0,
+  error: null,
+};
+
+export default ViewportLoadingIndicator;


### PR DESCRIPTION
![Screen Shot 2020-07-02 at 15 31 18](https://user-images.githubusercontent.com/13886933/86396837-16ee4480-bc79-11ea-9101-468dd23c30a1.png)

### PR Checklist

- [ ] Brief description of changes
- [ ] Links to any relevant issues
- [ ] Required status checks are passing
- [ ] User cases if changes impact the user's experience
- [ ] `@mention` a maintainer to request a review

<!--
  Links
  -->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
