### PR TITLE
fix: OHIF-219 - Viewport Labels should be sequential

### DIFF
--- a/extensions/dicom-sr/src/OHIFCornerstoneSRViewport.js
+++ b/extensions/dicom-sr/src/OHIFCornerstoneSRViewport.js
@@ -399,10 +399,7 @@ function OHIFCornerstoneSRViewport({
     });
   }
 
-  const label =
-    viewports.length > 1
-      ? _viewportLabels[firstViewportIndexWithMatchingDisplaySetUid]
-      : '';
+  const label = viewports.length > 1 ? _viewportLabels[viewportIndex] : '';
 
   // TODO -> disabled double click for now: onDoubleClick={_onDoubleClick}
 

--- a/extensions/measurement-tracking/src/viewports/TrackedCornerstoneViewport.js
+++ b/extensions/measurement-tracking/src/viewports/TrackedCornerstoneViewport.js
@@ -245,10 +245,7 @@ function TrackedCornerstoneViewport({
     setIsTracked(!isTracked);
   }
 
-  const label =
-    viewports.length > 1
-      ? _viewportLabels[firstViewportIndexWithMatchingDisplaySetUid]
-      : '';
+  const label = viewports.length > 1 ? _viewportLabels[viewportIndex] : '';
 
   function switchMeasurement(direction) {
     if (!element) {

--- a/platform/ui/src/components/ThumbnailNoImage/ThumbnailNoImage.jsx
+++ b/platform/ui/src/components/ThumbnailNoImage/ThumbnailNoImage.jsx
@@ -15,7 +15,6 @@ const ThumbnailNoImage = ({
   onDoubleClick,
   dragData,
   isActive,
-  viewportIdentificator = '',
 }) => {
   const [collectedProps, drag, dragPreview] = useDrag({
     item: { ...dragData },
@@ -84,7 +83,6 @@ ThumbnailNoImage.propTypes = {
   onClick: PropTypes.func.isRequired,
   onDoubleClick: PropTypes.func.isRequired,
   isActive: PropTypes.bool.isRequired,
-  viewportIdentificator: PropTypes.string,
 };
 
 export default ThumbnailNoImage;

--- a/platform/ui/src/components/ThumbnailTracked/ThumbnailTracked.jsx
+++ b/platform/ui/src/components/ThumbnailTracked/ThumbnailTracked.jsx
@@ -21,6 +21,35 @@ const ThumbnailTracked = ({
   isActive,
 }) => {
   const trackedIcon = isTracked ? 'circled-checkmark' : 'dotted-circle';
+  const viewportIdentificatorLabel = viewportIdentificator.join(', ');
+  const renderViewportLabels = () => {
+    const MAX_LABELS_PER_COL = 3;
+    const shouldShowStack = viewportIdentificator.length > MAX_LABELS_PER_COL;
+    if (shouldShowStack) {
+      return (
+        <div>
+          <div>
+            {viewportIdentificator.slice(0, MAX_LABELS_PER_COL).map(label => (
+              <div key={label}>{label}</div>
+            ))}
+          </div>
+          <Tooltip
+            position="right"
+            content={
+              <div className="text-left max-w-40">
+                Series is displayed <br /> in viewport{' '}
+                {viewportIdentificatorLabel}
+              </div>
+            }
+          >
+            <Icon name="tool-more-menu" className="text-white py-2" />
+          </Tooltip>
+        </div>
+      );
+    }
+
+    return viewportIdentificator.map(label => <div key={label}>{label}</div>);
+  };
 
   return (
     <div
@@ -48,11 +77,11 @@ const ThumbnailTracked = ({
                       {isTracked ? ' tracked' : ' untracked'}
                     </span>
                   </span>
-                  {viewportIdentificator && (
+                  {!!viewportIdentificator.length && (
                     <span>
                       in viewport
                       <span className="ml-1 text-white">
-                        {viewportIdentificator}
+                        {viewportIdentificatorLabel}
                       </span>
                     </span>
                   )}
@@ -64,10 +93,10 @@ const ThumbnailTracked = ({
             }
           >
             <Icon name={trackedIcon} className="w-4 mb-2 text-primary-light" />
-            <div className="h-5 text-xl leading-tight text-white">
-              {viewportIdentificator}
-            </div>
           </Tooltip>
+          <div className="text-xl leading-tight text-white text-center">
+            {renderViewportLabels()}
+          </div>
         </div>
         {isTracked && (
           <div onClick={onClickUntrack}>
@@ -113,7 +142,7 @@ ThumbnailTracked.propTypes = {
   onClick: PropTypes.func.isRequired,
   onDoubleClick: PropTypes.func.isRequired,
   onClickUntrack: PropTypes.func.isRequired,
-  viewportIdentificator: PropTypes.string,
+  viewportIdentificator: PropTypes.array,
   isTracked: PropTypes.bool,
   isActive: PropTypes.bool.isRequired,
 };

--- a/platform/ui/src/contextProviders/ViewportGridProvider.jsx
+++ b/platform/ui/src/contextProviders/ViewportGridProvider.jsx
@@ -88,6 +88,8 @@ export function ViewportGridProvider({ children, service }) {
     DEFAULT_STATE
   );
 
+  console.log('viewportGridState',viewportGridState)
+
   const getState = useCallback(() => viewportGridState, [viewportGridState]);
   const setActiveViewportIndex = useCallback(
     index => dispatch({ type: 'SET_ACTIVE_VIEWPORT_INDEX', payload: index }),


### PR DESCRIPTION
**Part 1**

Viewports with matching displaysets currently use the same letter label:

- Viewport 1: DisplaySet 1 --> A
- Viewport 2: DisplaySet 1 --> A
- Viewport 3: DisplaySet 2 --> B

Regardless of the displayset, lettering should be sequential:

- Viewport 1: DisplaySet 1 --> A
- Viewport 2: DisplaySet 1 --> B
- Viewport 3: DisplaySet 2 --> C

**Part 2**

Each thumbnail should list each viewport label they are displayed in. For example, if DisplaySet 1 is the displayset in all 9 viewports in a 3x3 grid, it's label should be: A, B, C, D, E, F, G, H, I


## Previews

A provisional design was created for when the series is being shown in more than 3 viewports.

Series in 3 viewports:

![image](https://user-images.githubusercontent.com/1905961/86845624-2b1eb100-c080-11ea-8531-335d7a6c418e.png)


Series in more than 3 viewports (icon with a tooltip):

![image](https://user-images.githubusercontent.com/1905961/86845669-3b369080-c080-11ea-867a-a39a172624ca.png)


Tracked Series in more than 3 viewports:

![image](https://user-images.githubusercontent.com/1905961/86845692-438ecb80-c080-11ea-96c9-8a3a966a6750.png)

Viewport:

![image](https://user-images.githubusercontent.com/1905961/86845913-8fda0b80-c080-11ea-8f5d-769879205bac.png)
