### PR TITLE
OHIF-308: The first `mousedown` or `click` on a viewport should not place an annotation if the viewport is not already active

### DIFF
--- a/platform/ui/src/components/ViewportPane/ViewportPane.jsx
+++ b/platform/ui/src/components/ViewportPane/ViewportPane.jsx
@@ -41,9 +41,9 @@ function ViewportPane({
     }
   };
 
-  const onInteractionHandler = () => {
-    onInteraction();
+  const onInteractionHandler = (event) => {
     focus();
+    onInteraction(event);
   };
 
   const refHandler = element => {
@@ -101,7 +101,7 @@ ViewportPane.propTypes = {
   onDoubleClick: PropTypes.func,
 };
 
-const noop = () => {};
+const noop = () => { };
 
 ViewportPane.defaultProps = {
   onInteraction: noop,

--- a/platform/viewer/src/components/ViewportGrid.jsx
+++ b/platform/viewer/src/components/ViewportGrid.jsx
@@ -7,6 +7,7 @@ import { ViewportGrid, ViewportPane, useViewportGrid } from '@ohif/ui';
 import EmptyViewport from './EmptyViewport';
 import { classes } from '@ohif/core';
 const { ImageSet } = classes;
+import classNames from 'classnames';
 
 function ViewerViewportGrid(props) {
   const { servicesManager, viewportComponents, dataSource } = props;
@@ -14,10 +15,6 @@ function ViewerViewportGrid(props) {
     { numCols, numRows, activeViewportIndex, viewports, cachedLayout },
     viewportGridService,
   ] = useViewportGrid();
-
-  const setActiveViewportIndex = index => {
-    viewportGridService.setActiveViewportIndex(index);
-  };
 
   // TODO -> Need some way of selecting which displaySets hit the viewports.
   const { DisplaySetService } = servicesManager.services;
@@ -148,6 +145,7 @@ function ViewerViewportGrid(props) {
 
     for (let i = 0; i < numViewportPanes; i++) {
       const viewportIndex = i;
+      const isActive = activeViewportIndex === viewportIndex;
       const paneMetadata = viewports[i] || {};
       const { displaySetInstanceUID } = paneMetadata;
 
@@ -159,8 +157,15 @@ function ViewerViewportGrid(props) {
         viewportComponents
       );
 
-      const onInterationHandler = () => {
-        setActiveViewportIndex(viewportIndex);
+      const onInterationHandler = (event) => {
+        if (isActive) return;
+
+        if (event) {
+          event.preventDefault();
+          event.stopPropagation();
+        }
+
+        viewportGridService.setActiveViewportIndex(viewportIndex);
       };
 
       // TEMP -> Double click disabled for now
@@ -173,13 +178,15 @@ function ViewerViewportGrid(props) {
           acceptDropsFor="displayset"
           onDrop={onDropHandler.bind(null, viewportIndex)}
           onInteraction={onInterationHandler}
-          isActive={activeViewportIndex === viewportIndex}
+          isActive={isActive}
         >
-          <ViewportComponent
-            displaySet={displaySet}
-            viewportIndex={viewportIndex}
-            dataSource={dataSource}
-          />
+          <div className={classNames('h-full w-full flex flex-col align-center', { 'pointer-events-none': !isActive })}>
+            <ViewportComponent
+              displaySet={displaySet}
+              viewportIndex={viewportIndex}
+              dataSource={dataSource}
+            />
+          </div>
         </ViewportPane>
       );
     }


### PR DESCRIPTION
Block canvas events if viewport is not active.

### PR Checklist

- [x] Brief description of changes
- [ ] Links to any relevant issues
- [ ] Required status checks are passing
- [ ] User cases if changes impact the user's experience
- [ ] `@mention` a maintainer to request a review

<!--
  Links
  -->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
