### PR TITLE
fix: Use same config for branch deploys as for deploy previews (#1893)

### DIFF
--- a/.netlify/build-deploy-preview.sh
+++ b/.netlify/build-deploy-preview.sh
@@ -21,6 +21,19 @@ mv platform/viewer/dist/* .netlify/www/pwa -v
 # Build && Move script output
 # yarn run build:package
 
+# Build && Move Docz Output
+# Using local yarn install to prevent Gatsby from needing to access
+# node_modules above the platform/ui folder
+cd platform/ui
+yarn install
+yarn run build
+cd ../..
+mkdir -p ./.netlify/www/ui
+mv platform/ui/.docz/dist/* .netlify/www/ui -v
+
+# Cache all of the node_module dependencies in
+# extensions, modules, and platform packages
+yarn run lerna:cache
 echo 'Nothing left to see here. Go home, folks.'
 
 # Build using react-scripts

--- a/netlify-lerna-cache.sh
+++ b/netlify-lerna-cache.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+NODE_MODULES_CACHE="./node_modules"
+LERNA_CACHE="$NODE_MODULES_CACHE/lerna-cache"
+
+echo "Running netlify-lerna-cache.sh"
+mkdir -p "$NODE_MODULES_CACHE/lerna-cache"
+
+cache_deps() {
+    PACKAGES=$(ls -1 $1)
+
+    for PKG in $PACKAGES
+    do
+        PKG_NODE_MODULES="$1/$PKG/node_modules"
+        if [ -d $PKG_NODE_MODULES ];
+        then
+            mv $PKG_NODE_MODULES $LERNA_CACHE/$PKG
+            echo "Cached node modules for $PKG"
+        else
+            echo "Unable to cache node modules for $PKG"
+        fi
+    done
+}
+
+cache_deps platform
+cache_deps extensions
+cache_deps modes

--- a/netlify-lerna-restore.sh
+++ b/netlify-lerna-restore.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+NODE_MODULES_CACHE="./node_modules"
+LERNA_CACHE="$NODE_MODULES_CACHE/lerna-cache"
+
+echo "Running netlify-lerna-restore.sh"
+mkdir -p "$NODE_MODULES_CACHE/lerna-cache"
+echo "$NODE_MODULES_CACHE/lerna-cache/*"
+
+restore_deps() {
+    PACKAGES=$(ls -1 $1)
+
+    for PKG in $PACKAGES
+    do
+        PKG_CACHE="$LERNA_CACHE/$PKG"
+        if [ -d $PKG_CACHE ];
+        then
+            mv $PKG_CACHE $1/$PKG/node_modules
+            echo "Restored node modules for $PKG"
+        else
+            echo "Unable to restore cache for $PKG"
+        fi
+    done
+}
+
+restore_deps platform
+restore_deps extensions
+restore_deps modes

--- a/netlify.toml
+++ b/netlify.toml
@@ -8,6 +8,11 @@
 # managed by CircleCI and deployed to our Google Hosting
 #
 
+[build]
+  base = ""
+  publish = ".netlify/www/"
+  command = "chmod +x .netlify/build-deploy-preview.sh && .netlify/build-deploy-preview.sh"
+
 # NODE_VERSION in root `.nvmrc` takes priority
 # YARN_FLAGS: https://www.netlify.com/docs/build-gotchas/#yarn
 [build.environment]
@@ -16,18 +21,12 @@
   YARN_VERSION = "1.17.3"
   RUBY_VERSION = "2.6.2"
   YARN_FLAGS = "--no-ignore-optional --pure-lockfile"
+  NETLIFY_RESTORE = "1"
 
 # Production context: all deploys from the Production branch set in your site's
 # deploy contexts will inherit these settings.
 [context.production]
   ignore = "exit 0" # Never build production; We'll let our CI do that
-
-# Deploy Preview context: all deploys generated from a pull/merge request will
-# inherit these settings.
-[context.deploy-preview]
-  base = ""
-  publish = ".netlify/www/"
-  command = "chmod +x .netlify/build-deploy-preview.sh && .netlify/build-deploy-preview.sh"
 
 [[headers]]
   # Define which paths this specific [[headers]] block will cover.

--- a/package.json
+++ b/package.json
@@ -34,6 +34,9 @@
     "see-changed": "lerna changed",
     "docs:publish": "chmod +x ./build-and-publish-docs.sh && ./build-and-publish-docs.sh",
     "release": "yarn run lerna:version && yarn run lerna:publish",
+    "lerna:cache": "[ $NETLIFY_RESTORE = 1 ] && ./netlify-lerna-cache.sh || :",
+    "lerna:restore": "[ $NETLIFY_RESTORE = 1 ] && ./netlify-lerna-restore.sh || :",
+    "preinstall": "yarn lerna:restore",
     "lerna:version": "npx lerna version prerelease --force-publish",
     "lerna:publish": "lerna publish from-package --canary --dist-tag canary",
     "link-list": "npm ls --depth=0 --link=true"

--- a/platform/ui/gatsby-node.js
+++ b/platform/ui/gatsby-node.js
@@ -1,0 +1,25 @@
+const path = require('path');
+// ~~ Plugins
+const PnpWebpackPlugin = require(`pnp-webpack-plugin`); // Required until Webpack@5
+
+exports.onCreateWebpackConfig = args => {
+  args.actions.setWebpackConfig({
+    node: { fs: 'empty' },
+    resolve: {
+      plugins: [PnpWebpackPlugin],
+      // Note the '..' in the path because docz gatsby project lives in the '.docz' directory
+      modules: [
+        // platform/ui
+        path.resolve(__dirname, '../node_modules'),
+        // .docz
+        'node_modules',
+      ],
+      // resolve: {
+      //   symlinks: true,
+      // },
+    },
+    resolveLoader: {
+      plugins: [PnpWebpackPlugin.moduleLoader(module)],
+    },
+  });
+};


### PR DESCRIPTION
* fix: Use same config for branch deploys as for deploy previews

* chore: remove unnecessary duplicate build-deploy-preview.sh file

* fix: Attempt to workaround Netlify cache issues for Lerna repos

* chore: Remove useless debug file

* fix: try to make Gatsby less slow

### PR Checklist

- [ ] Brief description of changes
- [ ] Links to any relevant issues
- [ ] Required status checks are passing
- [ ] User cases if changes impact the user's experience
- [ ] `@mention` a maintainer to request a review

<!--
  Links
  -->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
