### PR TITLE
OHIF-328 up/down arrows keys on SR viewport.

### DIFF
--- a/extensions/cornerstone/src/commandsModule.js
+++ b/extensions/cornerstone/src/commandsModule.js
@@ -14,7 +14,6 @@ const commandsModule = ({ servicesManager }) => {
   const { ViewportGridService } = servicesManager.services;
 
   function _getActiveViewportsEnabledElement() {
-    debugger;
     const { activeViewportIndex } = ViewportGridService.getState();
     return getEnabledElement(activeViewportIndex);
   }
@@ -159,7 +158,6 @@ const commandsModule = ({ servicesManager }) => {
       });
     },
     nextImage: () => {
-      debugger;
       const enabledElement = _getActiveViewportsEnabledElement();
       scroll(enabledElement, 1);
     },

--- a/extensions/cornerstone/src/commandsModule.js
+++ b/extensions/cornerstone/src/commandsModule.js
@@ -14,6 +14,7 @@ const commandsModule = ({ servicesManager }) => {
   const { ViewportGridService } = servicesManager.services;
 
   function _getActiveViewportsEnabledElement() {
+    debugger;
     const { activeViewportIndex } = ViewportGridService.getState();
     return getEnabledElement(activeViewportIndex);
   }
@@ -158,6 +159,7 @@ const commandsModule = ({ servicesManager }) => {
       });
     },
     nextImage: () => {
+      debugger;
       const enabledElement = _getActiveViewportsEnabledElement();
       scroll(enabledElement, 1);
     },

--- a/extensions/cornerstone/src/init.js
+++ b/extensions/cornerstone/src/init.js
@@ -102,8 +102,6 @@ export default function init({ servicesManager, configuration }) {
   const handleOhifCornerstoneEnabledElementEvent = function(evt) {
     const { viewportIndex, enabledElement } = evt.detail;
 
-    debugger;
-
     setEnabledElement(viewportIndex, enabledElement);
   };
 

--- a/extensions/cornerstone/src/init.js
+++ b/extensions/cornerstone/src/init.js
@@ -102,6 +102,8 @@ export default function init({ servicesManager, configuration }) {
   const handleOhifCornerstoneEnabledElementEvent = function(evt) {
     const { viewportIndex, enabledElement } = evt.detail;
 
+    debugger;
+
     setEnabledElement(viewportIndex, enabledElement);
   };
 
@@ -153,8 +155,8 @@ export default function init({ servicesManager, configuration }) {
       },
     },
     DragProbe: {
-      defaultStrategy: 'minimal'
-    }
+      defaultStrategy: 'minimal',
+    },
   };
 
   /* Abstract tools configuration using extension configuration. */

--- a/extensions/dicom-sr/src/OHIFCornerstoneSRViewport.js
+++ b/extensions/dicom-sr/src/OHIFCornerstoneSRViewport.js
@@ -103,8 +103,19 @@ function OHIFCornerstoneSRViewport({
     );
 
     setTrackingUniqueIdentifiersForElement(targetElement);
-
     setElement(targetElement);
+
+    const OHIFCornerstoneEnabledElementEvent = new CustomEvent(
+      'ohif-cornerstone-enabled-element-event',
+      {
+        detail: {
+          enabledElement: targetElement,
+          viewportIndex,
+        },
+      }
+    );
+
+    document.dispatchEvent(OHIFCornerstoneEnabledElementEvent);
   };
 
   useEffect(() => {


### PR DESCRIPTION
The SR viewport just needed to be emit an event to register itself to the cornerstone extension's tracker, like the tracked viewport does.