### PR TITLE
OHIF-311: The left/right annotation navigation arrows in the viewport's actionbar should always be visible

### DIFF
--- a/extensions/dicom-sr/src/OHIFCornerstoneSRViewport.js
+++ b/extensions/dicom-sr/src/OHIFCornerstoneSRViewport.js
@@ -427,7 +427,6 @@ function OHIFCornerstoneSRViewport({
         }}
         onSeriesChange={onMeasurementChange}
         onHydrationClick={hydrateMeasurementService}
-        showNavArrows={viewportIndex === activeViewportIndex}
         studyData={{
           label,
           isTracked: false,
@@ -448,8 +447,8 @@ function OHIFCornerstoneSRViewport({
             spacing:
               PixelSpacing && PixelSpacing.length
                 ? `${PixelSpacing[0].toFixed(2)}mm x ${PixelSpacing[1].toFixed(
-                    2
-                  )}mm`
+                  2
+                )}mm`
                 : '',
             scanner: ManufacturerModelName || '',
           },

--- a/extensions/measurement-tracking/src/viewports/TrackedCornerstoneViewport.js
+++ b/extensions/measurement-tracking/src/viewports/TrackedCornerstoneViewport.js
@@ -298,8 +298,6 @@ function TrackedCornerstoneViewport({
     );
   }
 
-  const showNavArrows = isTracked && viewportIndex === activeViewportIndex;
-
   // TODO -> disabled double click for now: onDoubleClick={_onDoubleClick}
 
   return (
@@ -310,7 +308,6 @@ function TrackedCornerstoneViewport({
           evt.preventDefault();
         }}
         onSeriesChange={direction => switchMeasurement(direction)}
-        showNavArrows={showNavArrows}
         studyData={{
           label,
           isTracked,
@@ -330,8 +327,8 @@ function TrackedCornerstoneViewport({
             spacing:
               PixelSpacing && PixelSpacing.length
                 ? `${PixelSpacing[0].toFixed(2)}mm x ${PixelSpacing[1].toFixed(
-                    2
-                  )}mm`
+                  2
+                )}mm`
                 : '',
             scanner: ManufacturerModelName || '',
           },


### PR DESCRIPTION
### PR Checklist

- [ ] Brief description of changes
- [ ] Links to any relevant issues
- [ ] Required status checks are passing
- [ ] User cases if changes impact the user's experience
- [ ] `@mention` a maintainer to request a review

<!--
  Links
  -->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
