### PR TITLE
Remove "module" field from every package.json

### DIFF
--- a/extensions/cornerstone/package.json
+++ b/extensions/cornerstone/package.json
@@ -6,7 +6,6 @@
   "license": "MIT",
   "repository": "OHIF/Viewers",
   "main": "dist/index.umd.js",
-  "module": "src/index.js",
   "engines": {
     "node": ">=10",
     "npm": ">=6",

--- a/extensions/dicom-html/package.json
+++ b/extensions/dicom-html/package.json
@@ -6,7 +6,6 @@
   "license": "MIT",
   "repository": "OHIF/Viewers",
   "main": "dist/index.umd.js",
-  "module": "src/index.js",
   "engines": {
     "node": ">=10",
     "npm": ">=6",

--- a/extensions/dicom-microscopy/package.json
+++ b/extensions/dicom-microscopy/package.json
@@ -6,7 +6,6 @@
   "license": "MIT",
   "repository": "OHIF/Viewers",
   "main": "dist/index.umd.js",
-  "module": "src/index.js",
   "publishConfig": {
     "access": "public"
   },

--- a/extensions/dicom-p10-downloader/package.json
+++ b/extensions/dicom-p10-downloader/package.json
@@ -6,7 +6,6 @@
   "license": "MIT",
   "repository": "OHIF/Viewers",
   "main": "dist/index.umd.js",
-  "module": "src/index.js",
   "publishConfig": {
     "access": "public"
   },

--- a/extensions/dicom-pdf/package.json
+++ b/extensions/dicom-pdf/package.json
@@ -6,7 +6,6 @@
   "license": "MIT",
   "repository": "OHIF/Viewers",
   "main": "dist/index.umd.js",
-  "module": "src/index.js",
   "publishConfig": {
     "access": "public"
   },

--- a/extensions/dicom-rt/package.json
+++ b/extensions/dicom-rt/package.json
@@ -6,7 +6,6 @@
   "license": "MIT",
   "repository": "OHIF/Viewers",
   "main": "dist/index.umd.js",
-  "module": "src/index.js",
   "engines": {
     "node": ">=10",
     "npm": ">=6",

--- a/extensions/dicom-segmentation/package.json
+++ b/extensions/dicom-segmentation/package.json
@@ -6,7 +6,6 @@
   "license": "MIT",
   "repository": "OHIF/Viewers",
   "main": "dist/index.umd.js",
-  "module": "src/index.js",
   "engines": {
     "node": ">=10",
     "npm": ">=6",

--- a/extensions/lesion-tracker/package.json
+++ b/extensions/lesion-tracker/package.json
@@ -6,7 +6,6 @@
   "license": "MIT",
   "repository": "OHIF/Viewers",
   "main": "dist/index.umd.js",
-  "module": "src/index.js",
   "publishConfig": {
     "access": "public"
   },

--- a/extensions/vtk/package.json
+++ b/extensions/vtk/package.json
@@ -6,7 +6,6 @@
   "license": "MIT",
   "repository": "OHIF/Viewers",
   "main": "dist/index.umd.js",
-  "module": "src/index.js",
   "sideEffects": true,
   "publishConfig": {
     "access": "public"

--- a/platform/core/package.json
+++ b/platform/core/package.json
@@ -6,7 +6,6 @@
   "license": "MIT",
   "repository": "OHIF/Viewers",
   "main": "dist/index.umd.js",
-  "module": "src/index.js",
   "sideEffects": "false",
   "publishConfig": {
     "access": "public"

--- a/platform/i18n/package.json
+++ b/platform/i18n/package.json
@@ -6,7 +6,6 @@
   "license": "MIT",
   "repository": "OHIF/Viewers",
   "main": "dist/index.umd.js",
-  "module": "src/index.js",
   "engines": {
     "node": ">=10",
     "npm": ">=6",

--- a/platform/ui/package.json
+++ b/platform/ui/package.json
@@ -6,7 +6,6 @@
   "license": "MIT",
   "repository": "OHIF/Viewers",
   "main": "dist/index.umd.js",
-  "module": "src/index.js",
   "publishConfig": {
     "access": "public"
   },

--- a/platform/viewer/package.json
+++ b/platform/viewer/package.json
@@ -6,7 +6,6 @@
   "license": "MIT",
   "repository": "OHIF/Viewers",
   "main": "dist/index.umd.js",
-  "module": "src/index.js",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
### PR Checklist

See #1935 for explanation of why it seems to me that the `"module"` field can and should be removed. Feel free to close this if you don't think this is a good solution to that issue, or if you think this should be discussed in that issue first. 

Should fix #1935

<!--
  Links
  -->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
