### PR TITLE
[OHIF-313] - Sync measurement panel label updates to cornerstoneTools

### DIFF
--- a/extensions/cornerstone/src/utils/getCornerstoneMeasurementById.js
+++ b/extensions/cornerstone/src/utils/getCornerstoneMeasurementById.js
@@ -1,0 +1,31 @@
+import cornerstoneTools from 'cornerstone-tools';
+
+const { globalImageIdSpecificToolStateManager } = cornerstoneTools;
+
+export default function getCornerstoneMeasurementById(id) {
+  const globalToolState = globalImageIdSpecificToolStateManager.saveToolState();
+
+  const imageIds = Object.keys(globalToolState);
+
+  for (let i = 0; i < imageIds.length; i++) {
+    const imageId = imageIds[i];
+    const imageIdSpecificToolState = globalToolState[imageId];
+
+    const toolTypes = Object.keys(imageIdSpecificToolState);
+
+    for (let j = 0; j < toolTypes.length; j++) {
+      const toolType = toolTypes[j];
+      const toolData = imageIdSpecificToolState[toolType].data;
+
+      if (toolData) {
+        for (let k = 0; k < toolData.length; k++) {
+          const toolDataK = toolData[k];
+
+          if (toolDataK.id === id) {
+            return toolDataK;
+          }
+        }
+      }
+    }
+  }
+}

--- a/extensions/cornerstone/src/utils/measurementServiceMappings/Bidirectional.js
+++ b/extensions/cornerstone/src/utils/measurementServiceMappings/Bidirectional.js
@@ -46,7 +46,7 @@ const Bidirectional = {
       referenceSeriesUID: SeriesInstanceUID,
       referenceStudyUID: StudyInstanceUID,
       displaySetInstanceUID: displaySet.displaySetInstanceUID,
-      label: measurementData.text,
+      label: measurementData.label,
       description: measurementData.description,
       unit: measurementData.unit,
       shortestDiameter: measurementData.shortestDiameter,

--- a/extensions/cornerstone/src/utils/measurementServiceMappings/EllipticalRoi.js
+++ b/extensions/cornerstone/src/utils/measurementServiceMappings/EllipticalRoi.js
@@ -68,7 +68,7 @@ const EllipticalRoi = {
       referenceSeriesUID: SeriesInstanceUID,
       referenceStudyUID: StudyInstanceUID,
       displaySetInstanceUID: displaySet.displaySetInstanceUID,
-      label: measurementData.text,
+      label: measurementData.label,
       description: measurementData.description,
       unit: measurementData.unit,
       area:

--- a/extensions/cornerstone/src/utils/measurementServiceMappings/Length.js
+++ b/extensions/cornerstone/src/utils/measurementServiceMappings/Length.js
@@ -73,7 +73,7 @@ const Length = {
       referenceSeriesUID: SeriesInstanceUID,
       referenceStudyUID: StudyInstanceUID,
       displaySetInstanceUID: displaySet.displaySetInstanceUID,
-      label: measurementData.text,
+      label: measurementData.label,
       description: measurementData.description,
       unit: measurementData.unit,
       length: measurementData.length,

--- a/extensions/measurement-tracking/src/panels/PanelMeasurementTableTracking/index.js
+++ b/extensions/measurement-tracking/src/panels/PanelMeasurementTableTracking/index.js
@@ -173,10 +173,14 @@ function PanelMeasurementTableTracking({ servicesManager, extensionManager }) {
     const onSubmitHandler = ({ action, value }) => {
       switch (action.id) {
         case 'save': {
-          MeasurementService.update(id, {
-            ...measurement,
-            ...value,
-          });
+          MeasurementService.update(
+            id,
+            {
+              ...measurement,
+              ...value,
+            },
+            true
+          );
         }
       }
       UIDialogService.dismiss({ id: dialogId });

--- a/platform/core/src/services/MeasurementService/MeasurementService.js
+++ b/platform/core/src/services/MeasurementService/MeasurementService.js
@@ -50,6 +50,7 @@ const MEASUREMENT_SCHEMA_KEYS = [
 
 const EVENTS = {
   MEASUREMENT_UPDATED: 'event::measurement_updated',
+  INTERNAL_MEASUREMENT_UPDATED: 'event:internal_measurement_updated',
   MEASUREMENT_ADDED: 'event::measurement_added',
   MEASUREMENT_REMOVED: 'event::measurement_removed',
   MEASUREMENTS_CLEARED: 'event::measurements_cleared',
@@ -285,21 +286,28 @@ class MeasurementService {
     }
   }
 
-  update(id, measurement) {
+  update(id, measurement, notYetUpdatedAtSource = false) {
     if (this.measurements[id]) {
       const updatedMeasurement = {
         ...measurement,
         modifiedTimestamp: Math.floor(Date.now() / 1000),
       };
 
-      log.info(`Updating measurement...`, updatedMeasurement);
+      log.info(
+        `Updating internal measurement representation...`,
+        updatedMeasurement
+      );
 
       this.measurements[id] = updatedMeasurement;
 
       this._broadcastChange(
+        // Add an internal flag to say the measurement has not yet been updated at source.
         this.EVENTS.MEASUREMENT_UPDATED,
-        measurement.source,
-        updatedMeasurement
+        {
+          source: measurement.source,
+          measurement: updatedMeasurement,
+          notYetUpdatedAtSource,
+        }
       );
 
       return updatedMeasurement.id;
@@ -375,19 +383,17 @@ class MeasurementService {
         newMeasurement
       );
       this.measurements[internalId] = newMeasurement;
-      this._broadcastChange(
-        this.EVENTS.MEASUREMENT_UPDATED,
+      this._broadcastChange(this.EVENTS.MEASUREMENT_UPDATED, {
         source,
-        newMeasurement
-      );
+        measurement: newMeasurement,
+      });
     } else {
       log.info(`Measurement added.`, newMeasurement);
       this.measurements[internalId] = newMeasurement;
-      this._broadcastChange(
-        this.EVENTS.MEASUREMENT_ADDED,
+      this._broadcastChange(this.EVENTS.MEASUREMENT_ADDED, {
         source,
-        newMeasurement
-      );
+        measurement: newMeasurement,
+      });
     }
 
     return newMeasurement.id;
@@ -466,19 +472,18 @@ class MeasurementService {
         newMeasurement
       );
       this.measurements[internalId] = newMeasurement;
-      this._broadcastChange(
-        this.EVENTS.MEASUREMENT_UPDATED,
+      this._broadcastChange(this.EVENTS.MEASUREMENT_UPDATED, {
         source,
-        newMeasurement
-      );
+        measurement: newMeasurement,
+        notYetUpdatedAtSource: false,
+      });
     } else {
       log.info(`Measurement added.`, newMeasurement);
       this.measurements[internalId] = newMeasurement;
-      this._broadcastChange(
-        this.EVENTS.MEASUREMENT_ADDED,
+      this._broadcastChange(this.EVENTS.MEASUREMENT_ADDED, {
         source,
-        newMeasurement
-      );
+        measurement: newMeasurement,
+      });
     }
 
     return newMeasurement.id;
@@ -491,7 +496,10 @@ class MeasurementService {
     }
 
     delete this.measurements[id];
-    this._broadcastChange(this.EVENTS.MEASUREMENT_REMOVED, source, id);
+    this._broadcastChange(this.EVENTS.MEASUREMENT_REMOVED, {
+      source,
+      measurement: id, // This is weird :shrug:
+    });
   }
 
   clearMeasurements() {
@@ -610,30 +618,20 @@ class MeasurementService {
   /**
    * Broadcasts measurement changes.
    *
-   * @param {string} eventName The event name
-   * @param {MeasurementSource} source The measurement source
-   * @param {string} measurement The measurement id
+   * @param {string} eventName The event name.
+   * @param {MeasurementSource} eventData.source The measurement source.
+   * @param {string} eventData.measurement The measurement.
+   * @param {boolean} eventData.notYetUpdatedAtSource True if the measurement was edited
+   *      within the measurement service and the source needs to update.
    * @return void
    */
-  _broadcastChange(eventName, source, measurement) {
+  _broadcastChange(eventName, eventData) {
     const hasListeners = Object.keys(this.listeners).length > 0;
     const hasCallbacks = Array.isArray(this.listeners[eventName]);
 
-    if (!source) {
-      /* Broadcast to all sources */
-      /* Object.keys(this.sources).forEach(source => {
-        if (hasListeners && hasCallbacks) {
-          this.listeners[eventName].forEach(listener => {
-            listener.callback({ source, measurement });
-          });
-        }
-      });
-      return; */
-    }
-
     if (hasListeners && hasCallbacks) {
       this.listeners[eventName].forEach(listener => {
-        listener.callback({ source, measurement });
+        listener.callback(eventData);
       });
     }
   }


### PR DESCRIPTION
This PR adds a handler for cornerstoneTools that updates annotation labels upon an update to the measurement service annotation representation.

I had to add a field to `MeasurementService.update`'s emitted event data called `notYetUpdatedAtSource`, to prevent circular updates if the measurement service fires an update to listeners when cornerstone was the source of the update itself.

Edit: This also solved OHIF-271 & OHIF-275
