### PR TITLE
fix: Avoid lerna:restore unless we are on Netlify (closes #1926, #1996)

### DIFF
--- a/.netlify/build-deploy-preview.sh
+++ b/.netlify/build-deploy-preview.sh
@@ -11,6 +11,7 @@ node -v
 
 # Install build deps and all monorepo package dependencies. Yarn Workspaces
 # should also symlink all projects appropriately
+yarn run lerna:restore
 yarn install --no-ignore-optional --pure-lockfile
 
 # Build && Move PWA Output

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "release": "yarn run lerna:version && yarn run lerna:publish",
     "lerna:cache": "[ $NETLIFY_RESTORE = 1 ] && ./netlify-lerna-cache.sh || :",
     "lerna:restore": "[ $NETLIFY_RESTORE = 1 ] && ./netlify-lerna-restore.sh || :",
-    "preinstall": "yarn lerna:restore",
     "lerna:version": "npx lerna version prerelease --force-publish",
     "lerna:publish": "lerna publish from-package --canary --dist-tag canary",
     "link-list": "npm ls --depth=0 --link=true"

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "see-changed": "lerna changed",
     "docs:publish": "chmod +x ./build-and-publish-docs.sh && ./build-and-publish-docs.sh",
     "release": "yarn run lerna:version && yarn run lerna:publish",
-    "lerna:cache": "[ $NETLIFY_RESTORE = 1 ] && ./netlify-lerna-cache.sh || :",
-    "lerna:restore": "[ $NETLIFY_RESTORE = 1 ] && ./netlify-lerna-restore.sh || :",
+    "lerna:cache": "./netlify-lerna-cache.sh",
+    "lerna:restore": "./netlify-lerna-restore.sh",
     "lerna:version": "npx lerna version prerelease --force-publish",
     "lerna:publish": "lerna publish from-package --canary --dist-tag canary",
     "link-list": "npm ls --depth=0 --link=true"


### PR DESCRIPTION
### PR Checklist

- [ ] Brief description of changes
- [ ] Links to any relevant issues
- [ ] Required status checks are passing
- [ ] User cases if changes impact the user's experience
- [ ] `@mention` a maintainer to request a review

<!--
  Links
  -->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
