### PR TITLE
Increase simultaneous requests

### DIFF
--- a/extensions/cornerstone/src/initCornerstoneTools.js
+++ b/extensions/cornerstone/src/initCornerstoneTools.js
@@ -34,4 +34,11 @@ export default function(configuration = {}) {
   cornerstoneTools.toolColors.setActiveColor('rgb(0, 255, 0)');
 
   cornerstoneTools.store.state.touchProximity = 40;
+
+  // Configure stack prefetch
+  cornerstoneTools.stackPrefetch.setConfiguration({
+    maxImagesToPrefetch: Infinity,
+    preserveExistingPool: false,
+    maxSimultaneousRequests: 20,
+  });
 }


### PR DESCRIPTION
### PR Checklist

- [x] Brief description of changes
- [x] Links to any relevant issues
- [ ] Required status checks are passing
- [x] User cases if changes impact the user's experience
- [ ] `@mention` a maintainer to request a review

Hello, I am an intern at Google investigating ways in which to get optimal performance out of medical image viewers that integrate with the Google Healthcare API. One major optimization I've found is increasing the number of simultaneous requests made when fetching a series of DICOM instances/frames. So this PR adds a configuration to `cornerstoneTools.stackPrefetch` to increase the number of simultaneous http requests.

With the introduction of HTTP/2, there is no longer a limit of 6 simultaneous requests to a specific origin. Instead, one connection is made to a given origin and a hypothetically infinite number of requests can be made through that one connection (although browsers such as chrome do eventually limit these connections which appears to be around [100 requests](https://chromium.googlesource.com/chromium/src/+/b10f8ebcdc8deb79d736d6994bd92a6d5a6590ca/net/spdy/spdy_session.h#68)).  Increasing the number of simultaneous http requests higher than 6 yields major performance improvements as images load much faster.

Currently, a library used in Ohif [react-cornerstone-viewport](https://github.com/cornerstonejs/react-cornerstone-viewport) sets the cornerstoneTools maxSimultaneousRequests to 6, overriding any value that we set ourselves. However, [I have opened a pull request](https://github.com/cornerstonejs/react-cornerstone-viewport/pull/101) to remove this configuration which would allow viewers to set these values to whatever they like. Thus, if that pull request gets merged, then we can set the maxSimultaneousRequests to whatever value we like, and I'll add a commit to update to the latest version of react-cornerstone-viewport.

I did some performance tests comparing the load times of different values of concurrent requests w/ Ohif, when loading a study with 619 instances in it, results below:
| Max Simultaneous Requests | Time to Load all Instances |
|-----------------------------|---------------------------|
| 6                                              | 25.88s                                 |
| 10                                            | 17.21s                                   |
| 20                                            | 9.92s                                   |
| 50                                            | 9.59s                                   |
| 75                                            | 10.19s                                  |

It appears that after 20 max simultaneous requests, the added benefits become negligible. So in this PR I have set the maxSimultaneousRequests value to 20. As can be seen there is a very large decrease in load times for the 619 DICOM instances simply by increasing the number of simultaneous http requests, allowing users to view the instances much quicker and with less noticeable lag.

### Relevant issues
https://github.com/OHIF/Viewers/issues/820

If anyone would like to test this change before the [react-cornerstone-viewport](https://github.com/cornerstonejs/react-cornerstone-viewport/pull/101) PR gets merged, you can use [my forked version of the library](https://github.com/Alex979/react-cornerstone-viewport/tree/remove-config) which won't override the maxSimultaneousRequests.


<!--
  Links
  -->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
