### PR TITLE
Update react-cornerstone-viewport to version 4.0.2

### DIFF
--- a/extensions/cornerstone/package.json
+++ b/extensions/cornerstone/package.json
@@ -51,6 +51,6 @@
     "classnames": "^2.2.6",
     "lodash.merge": "^4.6.2",
     "lodash.throttle": "^4.1.1",
-    "react-cornerstone-viewport": "4.0.1"
+    "react-cornerstone-viewport": "4.0.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -15596,10 +15596,10 @@ react-codemirror2@^6.0.0:
   resolved "https://registry.yarnpkg.com/react-codemirror2/-/react-codemirror2-6.0.0.tgz#180065df57a64026026cde569a9708fdf7656525"
   integrity sha512-D7y9qZ05FbUh9blqECaJMdDwKluQiO3A9xB+fssd5jKM7YAXucRuEOlX32mJQumUvHUkHRHqXIPBjm6g0FW0Ag==
 
-react-cornerstone-viewport@4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/react-cornerstone-viewport/-/react-cornerstone-viewport-4.0.1.tgz#6a7ec4c01b0626c4ad11552368f3dfa6cd67bdd5"
-  integrity sha512-47YhFsLS5vCWjiOKS9FwLxtA738HIHuNfdn3EJw6GyWD9jwL5HJQ/Ue1mKATjyHRvb3AyJTJuC/lGl0bsqKbYw==
+react-cornerstone-viewport@4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/react-cornerstone-viewport/-/react-cornerstone-viewport-4.0.2.tgz#49bc8f8464164d8e779138dd9244d5c2524e0418"
+  integrity sha512-mF/piahoPG5U5TbxVMtc15bXrQZxcaPycbu4i4KD2rZkiWh1Zs24ryY1S+lFlDB/RcOAm0u+luEEt1tOg8F+UQ==
   dependencies:
     classnames "^2.2.6"
     date-fns "^2.2.1"


### PR DESCRIPTION
### PR Checklist

- [x] Brief description of changes
- [x] Links to any relevant issues
- [ ] Required status checks are passing
- [ ] User cases if changes impact the user's experience
- [x] `@mention` a maintainer to request a review

This PR updates the version of react-cornerstone-viewport to 4.0.2, which includes [this change](https://github.com/cornerstonejs/react-cornerstone-viewport/pull/101). This allows the benefits of https://github.com/OHIF/Viewers/pull/2000 to take effect.

@dannyrb 

<!--
  Links
  -->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
