### PR TITLE
Thumbnail Highlighting

### DIFF
--- a/platform/ui/src/components/studyBrowser/ImageThumbnail.styl
+++ b/platform/ui/src/components/studyBrowser/ImageThumbnail.styl
@@ -6,7 +6,7 @@
   --sidebar-transition: all 0.3s ease;
 }
 
-.ThumbnailEntry.active .ImageThumbnail
+.thumbnail.active .ImageThumbnail
   border-color: var(--active-color);
   box-shadow: none
   transition: var(--sidebar-transition);

--- a/platform/ui/src/components/studyBrowser/StudyBrowser.js
+++ b/platform/ui/src/components/studyBrowser/StudyBrowser.js
@@ -28,6 +28,7 @@ function StudyBrowser(props) {
                 SeriesDescription,
                 SeriesNumber,
                 stackPercentComplete,
+                active,
               } = thumb;
 
               return (
@@ -37,6 +38,7 @@ function StudyBrowser(props) {
                   data-cy="thumbnail-list"
                 >
                   <Thumbnail
+                    active={active}
                     supportsDrag={supportsDrag}
                     key={`${studyIndex}_${thumbIndex}`}
                     id={`${studyIndex}_${thumbIndex}`} // Unused?

--- a/platform/ui/src/components/studyBrowser/Thumbnail.js
+++ b/platform/ui/src/components/studyBrowser/Thumbnail.js
@@ -83,7 +83,6 @@ function Thumbnail(props) {
 
   const hasImage = imageSrc || imageId;
   const hasAltText = altImageText !== undefined;
-
   return (
     <div
       ref={drag}

--- a/platform/viewer/src/connectedComponents/ConnectedStudyBrowser.js
+++ b/platform/viewer/src/connectedComponents/ConnectedStudyBrowser.js
@@ -15,6 +15,13 @@ const mapStateToProps = (state, ownProps) => {
   // If we know that the stack loading progress details have changed,
   // we can try to update the component state so that the thumbnail
   // progress bar is updated
+
+  let activeUIDs = [];
+  let keys = Object.keys(state.viewports.viewportSpecificData);
+  for (let i = 0; i < keys.length; i++) {
+    let a = state.viewports.viewportSpecificData[keys[i]].displaySetInstanceUID;
+    activeUIDs.push(a);
+  }
   const stackLoadingProgressMap = state.loading.progress;
   const studiesWithLoadingData = cloneDeep(ownProps.studies);
 
@@ -23,7 +30,7 @@ const mapStateToProps = (state, ownProps) => {
       const { displaySetInstanceUID } = data;
       const stackId = `StackProgress:${displaySetInstanceUID}`;
       const stackProgressData = stackLoadingProgressMap[stackId];
-
+      if (~activeUIDs.indexOf(displaySetInstanceUID)) data.active = true;
       let stackPercentComplete = 0;
       if (stackProgressData) {
         stackPercentComplete = stackProgressData.percentComplete;


### PR DESCRIPTION
active prop is now passed to thumbnail via StudyBrowser
Iterated through state viewort.viewportSpecificData object to retreive activeUIDs.
set active props for those thumbnails whos displaySetInstanceUID is included in the activeUIDs array

### PR Checklist

- [ ] Brief description of changes
- [ ] Links to any relevant issues
- [ ] Required status checks are passing
- [ ] User cases if changes impact the user's experience
- [ ] `@mention` a maintainer to request a review

<!--
  Links
  -->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
