### PR TITLE
[IDC-2017] Harden segmentation import to support more SEGs

### DIFF
--- a/extensions/cornerstone/package.json
+++ b/extensions/cornerstone/package.json
@@ -36,7 +36,7 @@
     "cornerstone-math": "^0.1.8",
     "cornerstone-tools": "^4.20.1",
     "cornerstone-wado-image-loader": "^3.1.0",
-    "dcmjs": "0.16.0",
+    "dcmjs": "0.16.3",
     "dicom-parser": "^1.8.3",
     "hammerjs": "^2.0.8",
     "prop-types": "^15.6.2",

--- a/extensions/dicom-html/package.json
+++ b/extensions/dicom-html/package.json
@@ -29,7 +29,7 @@
   },
   "peerDependencies": {
     "@ohif/core": "^0.50.0",
-    "dcmjs": "0.16.0",
+    "dcmjs": "0.16.3",
     "prop-types": "^15.6.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"

--- a/extensions/dicom-rt/package.json
+++ b/extensions/dicom-rt/package.json
@@ -31,7 +31,7 @@
     "@ohif/core": "^0.50.0",
     "cornerstone-core": "^2.2.8",
     "cornerstone-tools": "^4.20.1",
-    "dcmjs": "0.16.0",
+    "dcmjs": "0.16.3",
     "prop-types": "^15.6.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"

--- a/extensions/dicom-segmentation/package.json
+++ b/extensions/dicom-segmentation/package.json
@@ -31,7 +31,7 @@
     "@ohif/core": "^0.50.0",
     "cornerstone-core": "^2.2.8",
     "cornerstone-tools": "^4.20.1",
-    "dcmjs": "0.16.0",
+    "dcmjs": "0.16.3",
     "prop-types": "^15.6.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"

--- a/extensions/dicom-segmentation/src/getSourceDisplaySet.js
+++ b/extensions/dicom-segmentation/src/getSourceDisplaySet.js
@@ -1,4 +1,7 @@
 import setActiveLabelmap from './utils/setActiveLabelMap';
+import { classes } from '@ohif/core';
+
+const { ImageSet } = classes;
 
 export default function getSourceDisplaySet(studies, segDisplaySet) {
   const referencedDisplaySet = _getReferencedDisplaySet(segDisplaySet, studies);
@@ -19,15 +22,49 @@ const _getReferencedDisplaySet = (segDisplaySet, studies) => {
     ds => ds.displaySetInstanceUID !== segDisplaySet.displaySetInstanceUID
   );
 
-  const ReferencedSeriesSequence = Array.isArray(
-    segDisplaySet.metadata.ReferencedSeriesSequence
-  )
-    ? segDisplaySet.metadata.ReferencedSeriesSequence
-    : [segDisplaySet.metadata.ReferencedSeriesSequence];
+  const { metadata } = segDisplaySet;
 
-  const referencedSeriesInstanceUIDs = ReferencedSeriesSequence.map(
-    ReferencedSeries => ReferencedSeries.SeriesInstanceUID
-  );
+  let referencedSeriesInstanceUIDs;
+
+  if (metadata.ReferencedSeriesSequence) {
+    const ReferencedSeriesSequence = _toArray(
+      metadata.ReferencedSeriesSequence
+    );
+
+    referencedSeriesInstanceUIDs = ReferencedSeriesSequence.map(
+      ReferencedSeries => ReferencedSeries.SeriesInstanceUID
+    );
+  } else {
+    const { PerFrameFunctionalGroupsSequence } = metadata;
+
+    let SourceImageSequence;
+
+    if (metadata.SourceImageSequence) {
+      SourceImageSequence = metadata.SourceImageSequence;
+    } else {
+      const firstFunctionalGroups = _toArray(
+        PerFrameFunctionalGroupsSequence
+      )[0];
+      const { DerivationImageSequence } = firstFunctionalGroups;
+
+      SourceImageSequence = DerivationImageSequence;
+    }
+
+    const firstSourceImage = _toArray(SourceImageSequence)[0];
+
+    const { ReferencedSOPInstanceUID } = firstSourceImage;
+
+    referencedSeriesInstanceUIDs = _findReferencedSeriesInstanceUIDsFromSOPInstanceUID(
+      otherDisplaySets,
+      ReferencedSOPInstanceUID
+    );
+
+    console.log(otherDisplaySets);
+
+    debugger;
+
+    debugger;
+  }
 
   const referencedDisplaySet = otherDisplaySets.find(ds =>
     referencedSeriesInstanceUIDs.includes(ds.SeriesInstanceUID)
@@ -35,3 +72,23 @@ const _getReferencedDisplaySet = (segDisplaySet, studies) => {
 
   return referencedDisplaySet;
 };
+
+const _findReferencedSeriesInstanceUIDsFromSOPInstanceUID = (
+  displaySets,
+  SOPInstanceUID
+) => {
+  const imageSets = displaySets.filter(ds => ds instanceof ImageSet);
+
+  for (let i = 0; i < imageSets.length; i++) {
+    const { images } = imageSets[i];
+    for (let j = 0; j < images.length; j++) {
+      if (images[j].SOPInstanceUID === SOPInstanceUID) {
+        return [images[j].getData().metadata.SeriesInstanceUID];
+      }
+    }
+  }
+};
+
+function _toArray(arrayOrObject) {
+  return Array.isArray(arrayOrObject) ? arrayOrObject : [arrayOrObject];
+}

--- a/extensions/dicom-segmentation/src/getSourceDisplaySet.js
+++ b/extensions/dicom-segmentation/src/getSourceDisplaySet.js
@@ -58,12 +58,6 @@ const _getReferencedDisplaySet = (segDisplaySet, studies) => {
       otherDisplaySets,
       ReferencedSOPInstanceUID
     );
-
-    console.log(otherDisplaySets);
-
-    debugger;
-
-    debugger;
   }
 
   const referencedDisplaySet = otherDisplaySets.find(ds =>

--- a/extensions/vtk/package.json
+++ b/extensions/vtk/package.json
@@ -35,7 +35,7 @@
     "cornerstone-core": "^2.2.8",
     "cornerstone-tools": "^4.20.1",
     "cornerstone-wado-image-loader": "^3.1.0",
-    "dcmjs": "0.16.0",
+    "dcmjs": "0.16.3",
     "dicom-parser": "^1.8.3",
     "i18next": "^17.0.3",
     "i18next-browser-languagedetector": "^3.0.1",

--- a/platform/core/package.json
+++ b/platform/core/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@babel/runtime": "^7.5.5",
     "ajv": "^6.10.0",
-    "dcmjs": "0.16.0",
+    "dcmjs": "0.16.3",
     "dicomweb-client": "^0.6.0",
     "immer": "6.0.2",
     "isomorphic-base64": "^1.0.2",

--- a/platform/viewer/package.json
+++ b/platform/viewer/package.json
@@ -67,7 +67,7 @@
     "cornerstone-math": "^0.1.8",
     "cornerstone-tools": "^4.20.1",
     "cornerstone-wado-image-loader": "^3.1.0",
-    "dcmjs": "0.16.0",
+    "dcmjs": "0.16.3",
     "dicom-parser": "^1.8.3",
     "dicomweb-client": "^0.4.4",
     "hammerjs": "^2.0.8",

--- a/platform/viewer/src/connectedComponents/ViewerLocalFileData.js
+++ b/platform/viewer/src/connectedComponents/ViewerLocalFileData.js
@@ -78,8 +78,6 @@ class ViewerLocalFileData extends Component {
         study.displaySets ||
         studyMetadata.createDisplaySets(sopClassHandlerModules);
 
-      debugger;
-
       studyMetadata.forEachDisplaySet(displayset => {
         displayset.localFile = true;
       });

--- a/yarn.lock
+++ b/yarn.lock
@@ -6539,10 +6539,10 @@ dateformat@^3.0.0:
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
 
-dcmjs@0.16.0:
-  version "0.16.0"
-  resolved "https://registry.yarnpkg.com/dcmjs/-/dcmjs-0.16.0.tgz#714755d006c3a49cf65ef13e627ff7a23151d35a"
-  integrity sha512-41nY3Isg5i5FoSd1s67aUgUHi146r+fb8JuiRvDsxvm7MEkkdjIzMYMtxjsrVwKRW1xRH+x34nxbV9+8cc7WQw==
+dcmjs@0.16.3:
+  version "0.16.3"
+  resolved "https://registry.yarnpkg.com/dcmjs/-/dcmjs-0.16.3.tgz#ef44ccc4988a473fd40e1601122c57f2babded11"
+  integrity sha512-pMQGifMpMW9i9ufCdUoEPHrLWnm6ilnpfLqUc+PPoWr7OnuBhiRVRunbv39oTtFDZOLhQ2Ampm7UrkidWAbqiA==
   dependencies:
     "@babel/polyfill" "^7.8.3"
     "@babel/runtime" "^7.8.4"


### PR DESCRIPTION
RE: #2017 
related: https://github.com/dcmjs-org/dcmjs/pull/146

> DICOM Segmentation objects can have their referenced data encoded in multiple ways. The dcmjs cornerstone adapter now parses a greater selection, tested on a lot of TCIA cases.

Tested on a slew of IDC cases and there seems to be no issues.