### PR TITLE
Split query parameter calls with app config.

### DIFF
--- a/platform/viewer/public/config/idc.js
+++ b/platform/viewer/public/config/idc.js
@@ -5,6 +5,7 @@ window.config = function(props) {
     disableMeasurementPanel: true,
     routerBasename: '/',
     enableGoogleCloudAdapter: true,
+    splitQueryParameterCalls: true, // Allows the user to split QIDO SeriesInstanceUID filters into multiple calls, if the server does not support multi-valued query parameters.
     enableGoogleCloudAdapterUI: false,
     showStudyList: true,
     filterQueryParam: true,

--- a/platform/viewer/src/connectedComponents/ViewerRetrieveStudyData.js
+++ b/platform/viewer/src/connectedComponents/ViewerRetrieveStudyData.js
@@ -341,7 +341,10 @@ function ViewerRetrieveStudyData({
         }
       }
 
-      if (appConfig.enableGoogleCloudAdapter) {
+      if (
+        appConfig.splitQueryParameterCalls ||
+        appConfig.enableGoogleCloudAdapter
+      ) {
         retrieveParams.push(true); // Seperate SeriesInstanceUID filter calls.
       }
 


### PR DESCRIPTION
If you are using a backend that does not support multiple valued QIDO filters, it is not sufficient to assume this backend is google cloud. Although setting `enableGoogleCloudAdapter` to true will split up these calls (as google does not support this), setting `splitQueryParameterCalls` will also split up query filters into multiple calls, if your dicomweb server does not support multi-valued QIDO filters.