### PR TITLE
fix: use SeriesMetadata method instead of property

### DIFF
--- a/platform/core/src/DICOMSR/utils/findMostRecentStructuredReport.js
+++ b/platform/core/src/DICOMSR/utils/findMostRecentStructuredReport.js
@@ -13,7 +13,7 @@ const findMostRecentStructuredReport = studies => {
       // Skip series that may not have instances yet
       // This can happen if we have retrieved just the initial
       // details about the series via QIDO-RS, but not the full metadata
-      if (!series.instances || !series.instances.length) {
+      if (!series || series.getInstanceCount() === 0) {
         return;
       }
 


### PR DESCRIPTION
### PR Checklist

- [x] Brief description of changes
  - Call getInstanceCount() instead of checking `instances.length`. The length did not work, as the instances property doesn't exist on the objects, and so all of the structured reports are ignored. This is why they don't show up in the measurements pane.
- [x] Links to any relevant issues
  - likely fixes #1714, fixes #1662, fixes #1907
  - might also be related to #1679, #1763, #1707 
- [x] Required status checks are passing
- [x] User cases if changes impact the user's experience
  - none
- [x] `@mention` a maintainer to request a review
  - @swederik (added the code there)

<!--
  Links
  -->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
