### PR TITLE
Misc. workflow fixes [OHIF-363]

### DIFF
--- a/extensions/measurement-tracking/src/contexts/TrackedMeasurementsContext/measurementTrackingMachine.js
+++ b/extensions/measurement-tracking/src/contexts/TrackedMeasurementsContext/measurementTrackingMachine.js
@@ -317,10 +317,22 @@ const defaultOptions = {
   },
   guards: {
     shouldSetDirty: (ctx, evt) => {
-      debugger;
+      // 1. We need to flip this _after_ tracking a new measurement,
+      //    but mark "clean" after save, and after restore
+      //
+      //    This is tricky, because the measurement service isn't notified
+      //    of new tracks to _existing_ measurements
+      //
+      //    So... We need to set this dirty after any new measurement to a tracked
+      //    viewport (see SET_DIRTY transition) and any tracking event not inspired
+      //    by the SR restore (now that we don't clear + restore after save)
+      console.warn('SHOULD SET DIRTY?', evt);
+      // debugger;
       return (
+        // When would this happen?
         evt.SeriesInstanceUID === undefined ||
-        ctx.trackedSeries.includes(evt.SeriesInstanceUID)
+        // Why wouldn't we care about measurements with the same series id?
+        !ctx.trackedSeries.includes(evt.SeriesInstanceUID)
       );
     },
     shouldKillMachine: (ctx, evt) =>

--- a/extensions/measurement-tracking/src/contexts/TrackedMeasurementsContext/promptTrackNewSeries.js
+++ b/extensions/measurement-tracking/src/contexts/TrackedMeasurementsContext/promptTrackNewSeries.js
@@ -17,13 +17,10 @@ function promptUser({ servicesManager, extensionManager }, ctx, evt) {
       viewportIndex
     );
 
-    if (ctx.isDirty && promptResult === RESPONSE.CREATE_REPORT) {
-      promptResult = await _askSaveDiscardOrCancel(
-        UIViewportDialogService,
-        viewportIndex
-      );
-    } else {
-      promptResult = RESPONSE.SET_STUDY_AND_SERIES;
+    if (promptResult === RESPONSE.CREATE_REPORT) {
+      promptResult = ctx.isDirty
+        ? await _askSaveDiscardOrCancel(UIViewportDialogService, viewportIndex)
+        : RESPONSE.SET_STUDY_AND_SERIES;
     }
 
     resolve({

--- a/extensions/measurement-tracking/src/contexts/TrackedMeasurementsContext/promptTrackNewStudy.js
+++ b/extensions/measurement-tracking/src/contexts/TrackedMeasurementsContext/promptTrackNewStudy.js
@@ -17,13 +17,10 @@ function promptUser({ servicesManager, extensionManager }, ctx, evt) {
       viewportIndex
     );
 
-    if (ctx.isDirty && promptResult === RESPONSE.SET_STUDY_AND_SERIES) {
-      promptResult = await _askSaveDiscardOrCancel(
-        UIViewportDialogService,
-        viewportIndex
-      );
-    } else {
-      promptResult = RESPONSE.SET_STUDY_AND_SERIES;
+    if (promptResult === RESPONSE.SET_STUDY_AND_SERIES) {
+      promptResult = ctx.isDirty
+        ? await _askSaveDiscardOrCancel(UIViewportDialogService, viewportIndex)
+        : RESPONSE.SET_STUDY_AND_SERIES;
     }
 
     resolve({


### PR DESCRIPTION
1.  Adding measurements to existing report

- Caused by short-circuit in logic for `promptTrackNewSeries`

2.  Creating a new report while tracking measurements

- Note added in PR. Issue identified, not yet resolved.

3.  Canceling new report while tracking measurements

- Caused by short-circuit in logic for `promptTrackNewSeries`

4.  Measurements spanning multiple studies

- Similar logic short-circuit issue in `promptTrackNewStudy`