### PR TITLE
PWA start url

### DIFF
--- a/platform/viewer/public/manifest.json
+++ b/platform/viewer/public/manifest.json
@@ -52,7 +52,7 @@
       "type": "image/png"
     }
   ],
-  "start_url": "./index.html",
+  "start_url": "./",
   "background_color": "#000000",
   "display": "standalone",
   "theme_color": "#20a5d6"


### PR DESCRIPTION
Issue: https://github.com/OHIF/Viewers/issues/2052

This changes the value of the start_url property in the manifest.json from "./index.html" to "./"

When the installed PWA app is launched, the url set in the start_url in the manifest.json is initially opened.
But the problem is ./index.html, which is currently set for the value of the property, has no matching routes, the following error is shown.
![image](https://user-images.githubusercontent.com/19254333/94629581-da86b080-0288-11eb-86e5-38e74486468a.png)

After changing the value to "./" this shows the main page.
 
![image](https://user-images.githubusercontent.com/19254333/94629811-6d274f80-0289-11eb-9749-716fd7ac223d.png)
