### PR TITLE
fix: swallow update-image error

### DIFF
--- a/extensions/measurement-tracking/src/_shared/setCornerstoneMeasurementActive.js
+++ b/extensions/measurement-tracking/src/_shared/setCornerstoneMeasurementActive.js
@@ -27,6 +27,13 @@ export default function setMeasurementActive(measurement) {
   const enabledElements = cornerstoneTools.store.state.enabledElements;
 
   enabledElements.forEach(element => {
-    cornerstone.updateImage(element);
+    try {
+      cornerstone.updateImage(element);
+    } catch (ex) {
+      // https://github.com/cornerstonejs/cornerstone/blob/master/src/updateImage.js#L16
+      // This fails if enabledElement.image is undefined and we have no layers
+      // Instead of throwing, it should _probably_ do nothing.
+      // We'll just swallow the exception
+    }
   });
 }


### PR DESCRIPTION
for "clicking annotation arrows"; as doing _nothing_ if the image isn't loaded yet is perfectly okay