### PR TITLE
[IDC-2005] Throw error if data too large in WebGL 1 enabled browser

### DIFF
--- a/extensions/vtk/src/index.js
+++ b/extensions/vtk/src/index.js
@@ -27,8 +27,9 @@ const vtkExtension = {
   getToolbarModule() {
     return toolbarModule;
   },
-  getCommandsModule({ commandsManager }) {
-    return commandsModule({ commandsManager });
+  getCommandsModule({ commandsManager, servicesManager }) {
+    const { UINotificationService } = servicesManager.services;
+    return commandsModule({ commandsManager, UINotificationService });
   },
 };
 


### PR DESCRIPTION
#2005 
If the browser does not support WebGL 2.0, and the data is too large to fit in 2D Texture memory, throw an error notification to alert the user when attempting to view MPR.