### PR TITLE
fix issue #2130 - With config.showStudyList : false -> Still showing …

### DIFF
--- a/platform/viewer/src/routes/NotFound.js
+++ b/platform/viewer/src/routes/NotFound.js
@@ -1,13 +1,17 @@
 import React from 'react';
 import './NotFound.css';
 import { Link } from 'react-router-dom';
+import { useAppContext } from '../context/AppContext';
 
 export default function NotFound({ message = 'Sorry, this page does not exist.', showGoBackButton = true }) {
+  
+  const context = useAppContext();
+  
   return (
     <div className={'not-found'}>
       <div>
         <h4>{message}</h4>
-        {showGoBackButton && (
+        {showGoBackButton && context.appConfig.showStudyList && (
           <h5>
             <Link to={'/'}>Go back to the Study List</Link>
           </h5>


### PR DESCRIPTION
…hyperlink to StudyList on Not Found Component

Solve issue #2130 (https://github.com/OHIF/Viewers/issues/2130) 
> If StudyList is disabled on configuration, and reach a non existent page, is still possible to go to StudyList, bceause hyperlink is present on Not Found Component. 

**Change description:**
Changed NotFound component to show only the "Go back to the Study List" only if the config parameter `showStudyList` is `true`. If the config parameter `showStudyList` is `false` hide the Link

Link to issue: https://github.com/OHIF/Viewers/issues/2130

Suggested reviewer: @dannyrb 


<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
