### PR TITLE
added MAX_CONCURRENCY limit to prevent crashes on bigger machines

### DIFF
--- a/platform/viewer/src/utils/initWebWorkers.js
+++ b/platform/viewer/src/utils/initWebWorkers.js
@@ -2,9 +2,11 @@ import cornerstoneWADOImageLoader from 'cornerstone-wado-image-loader';
 
 let initialized = false;
 
+const MAX_CONCURRENCY = 6;
+
 export default function initWebWorkers() {
   const config = {
-    maxWebWorkers: Math.max(navigator.hardwareConcurrency - 1, 1),
+    maxWebWorkers: Math.max(Math.min(navigator.hardwareConcurrency - 1, MAX_CONCURRENCY), 1),
     startWebWorkersOnDemand: true,
     taskConfiguration: {
       decodeTask: {


### PR DESCRIPTION
As each webworker costs RAM and machines with more cores are available (like AMD puts out or XEON) this can and does easily crash the processes.

Added a limit of six as a variable, but it could also be defined in a way overridable during the build process.

PS: In general, many more places in the code would benefit from BUILD time variables.