### PR TITLE
Remove hard-coded loadUserInfo to make it configurable

### DIFF
--- a/platform/viewer/src/utils/getUserManagerForOpenIdConnectClient.js
+++ b/platform/viewer/src/utils/getUserManagerForOpenIdConnectClient.js
@@ -15,7 +15,7 @@ import { loadUser, createUserManager } from 'redux-oidc';
  * @param {string} oidcSettings.responseType,
  * @param {string} oidcSettings.extraQueryParams,
  */
-export default function (store, oidcSettings) {
+export default function(store, oidcSettings) {
   if (!store || !oidcSettings) {
     return;
   }

--- a/platform/viewer/src/utils/getUserManagerForOpenIdConnectClient.js
+++ b/platform/viewer/src/utils/getUserManagerForOpenIdConnectClient.js
@@ -15,7 +15,7 @@ import { loadUser, createUserManager } from 'redux-oidc';
  * @param {string} oidcSettings.responseType,
  * @param {string} oidcSettings.extraQueryParams,
  */
-export default function(store, oidcSettings) {
+export default function (store, oidcSettings) {
   if (!store || !oidcSettings) {
     return;
   }
@@ -25,7 +25,6 @@ export default function(store, oidcSettings) {
     automaticSilentRenew: true,
     revokeAccessTokenOnSignout: true,
     filterProtocolClaims: true,
-    loadUserInfo: true,
   };
 
   const userManager = createUserManager(settings);


### PR DESCRIPTION
Hello @dannyrb ,

I have removed the hard-coded  `loadUserInfo: true,` when creating the UserManager. This flag causes an additional call to the userinfo endpoint as described in the oidc-client documents:

> loadUserInfo (boolean, default: true): Flag to control if additional identity data is loaded from the user info endpoint in order to populate the user's profile.

With AzureAD this call can cause a 401 as described in this ticket: https://github.com/IdentityModel/oidc-client-js/issues/1028
By hard-coding this to true, it is not possible to work around this issue. (If not configured this value is true by default anyway, which makes this even more useless) 

Without this line of code it is now possible to disable the loadUserInfo and therefore make the oidc authentication with AzureAD work. 
Example config:
```
window.config = {
  // default: '/'
  routerBasename: '/',
  whiteLabelling: {},
  extensions: [],
  showStudyList: true,
  filterQueryParam: false,
  servers: {
    dicomWeb: [
      {
        name: 'PACS',
        wadoUriRoot: "https://${root_uri}/wado",
        qidoRoot: "https://${root_uri}/dicom-web",
        wadoRoot: "https://${root_uri}/dicom-web",
        qidoSupportsIncludeField: true,
        imageRendering: 'wadouri',
        thumbnailRendering: 'wadouri',
        enableStudyLazyLoad: true,
      },
    ],
  },
  oidc: [
    {
      authority: 'https://login.microsoftonline.com/${tenant_id}',
      client_id: '${client_id}',
      redirect_uri: '/callback',
      response_type: 'code',
      loadUserInfo: false,
      scope: 'openid profile email ${resource_id}/.default',
      post_logout_redirect_uri: '/logout-redirect.html',
      metadata: {
        issuer: 'https://login.microsoftonline.com/${tenant_id}/v2.0',
        authorization_endpoint: 'https://login.microsoftonline.com/${tenant_id}/oauth2/v2.0/authorize',
        token_endpoint: 'https://login.microsoftonline.com/${tenant_id}/oauth2/v2.0/token',
        userinfo_endpoint: 'https://graph.microsoft.com/oidc/userinfo',
        jwks_uri: 'https://login.microsoftonline.com/${tenant_id}/discovery/v2.0/keys',

      },
      signingKeys: ${signingKeys}
  ],
  cornerstoneExtensionConfig: {}
}
```

