### PR TITLE
Update Google Healthcare API endpoint from v1beta1 to v1

### DIFF
--- a/platform/viewer/public/config/google.js
+++ b/platform/viewer/public/config/google.js
@@ -1,7 +1,7 @@
 window.config = {
   routerBasename: '/',
   enableGoogleCloudAdapter: true,
-  healthcareApiEndpoint: 'https://healthcare.googleapis.com/v1beta1',
+  healthcareApiEndpoint: 'https://healthcare.googleapis.com/v1',
   servers: {
     // This is an array, but we'll only use the first entry for now
     dicomWeb: [],


### PR DESCRIPTION
### PR Checklist

- [x] Brief description of changes
The Cloud Healthcare API and its DICOMweb API are in GA (v1).
- [ ] Links to any relevant issues
- [ ] Required status checks are passing
- [ ] User cases if changes impact the user's experience
- [ ] `@mention` a maintainer to request a review

<!--
  Links
  -->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
