### PR TITLE
Added memoization on VTKMPRToolbarButton component to avoid unnecesary rebuilds

### DIFF
--- a/extensions/vtk/src/toolbarComponents/VTKMPRToolbarButton.js
+++ b/extensions/vtk/src/toolbarComponents/VTKMPRToolbarButton.js
@@ -1,21 +1,18 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import { ToolbarButton } from '@ohif/ui';
 import { utils } from '@ohif/core';
-
+import { createSelector } from 'reselect';
 const { studyMetadataManager } = utils;
 
-let isVisible = true;
-
-const _isDisplaySetReconstructable = (viewportSpecificData = {}, activeViewportIndex) => {
-  if (!viewportSpecificData[activeViewportIndex]) {
+const _isDisplaySetReconstructable = (
+  displaySetInstanceUID = '',
+  StudyInstanceUID = ''
+) => {
+  if (displaySetInstanceUID == '' || StudyInstanceUID == '') {
     return false;
-  };
-
-  const { displaySetInstanceUID, StudyInstanceUID } = viewportSpecificData[
-    activeViewportIndex
-  ];
+  }
 
   const studies = studyMetadataManager.all();
 
@@ -27,7 +24,9 @@ const _isDisplaySetReconstructable = (viewportSpecificData = {}, activeViewportI
     return false;
   }
 
-  const displaySet = study._displaySets.find(set => set.displaySetInstanceUID === displaySetInstanceUID);
+  const displaySet = study._displaySets.find(
+    set => set.displaySetInstanceUID === displaySetInstanceUID
+  );
 
   if (!displaySet) {
     return false;
@@ -45,33 +44,43 @@ const _isDisplaySetReconstructable = (viewportSpecificData = {}, activeViewportI
     const image = displaySet.images[ii];
     if (!image) continue;
 
-    const imageIdControl = image.getImageId()
-    const instanceMetadataControl = cornerstone.metaData.get('instance', imageIdControl)
+    const imageIdControl = image.getImageId();
+    const instanceMetadataControl = cornerstone.metaData.get(
+      'instance',
+      imageIdControl
+    );
 
-    if (!instanceMetadataControl ||
+    if (
+      !instanceMetadataControl ||
       instanceMetadataControl === undefined ||
       !instanceMetadataControl.ImagePositionPatient ||
-      instanceMetadataControl.ImagePositionPatient === undefined) {
+      instanceMetadataControl.ImagePositionPatient === undefined
+    ) {
       // if ImagePositionPatient is missing, skip the 4D datasets check.
       // do not return false, because it could be a 3D dataset.
       continue;
     }
 
-    let xImagePositionPatientControl = instanceMetadataControl.ImagePositionPatient[0];
-    let yImagePositionPatientControl = instanceMetadataControl.ImagePositionPatient[1];
-    let zImagePositionPatientControl = instanceMetadataControl.ImagePositionPatient[2];
+    let xImagePositionPatientControl =
+      instanceMetadataControl.ImagePositionPatient[0];
+    let yImagePositionPatientControl =
+      instanceMetadataControl.ImagePositionPatient[1];
+    let zImagePositionPatientControl =
+      instanceMetadataControl.ImagePositionPatient[2];
 
     for (let jj = ii + 1; jj < displaySet.numImageFrames; ++jj) {
       const image = displaySet.images[jj];
       if (!image) continue;
 
-      const imageId = image.getImageId()
-      const instanceMetadata = cornerstone.metaData.get('instance', imageId)
+      const imageId = image.getImageId();
+      const instanceMetadata = cornerstone.metaData.get('instance', imageId);
 
-      if (!instanceMetadata ||
+      if (
+        !instanceMetadata ||
         instanceMetadata === undefined ||
         !instanceMetadata.ImagePositionPatient ||
-        instanceMetadata.ImagePositionPatient === undefined) {
+        instanceMetadata.ImagePositionPatient === undefined
+      ) {
         // if ImagePositionPatient is missing, skip the 4D datasets check.
         // do not return false, because it could be a 3D dataset.
         continue;
@@ -81,9 +90,11 @@ const _isDisplaySetReconstructable = (viewportSpecificData = {}, activeViewportI
       let yImagePositionPatient = instanceMetadata.ImagePositionPatient[1];
       let zImagePositionPatient = instanceMetadata.ImagePositionPatient[2];
 
-      if (xImagePositionPatientControl === xImagePositionPatient &&
+      if (
+        xImagePositionPatientControl === xImagePositionPatient &&
         yImagePositionPatientControl === yImagePositionPatient &&
-        zImagePositionPatientControl === zImagePositionPatient) {
+        zImagePositionPatientControl === zImagePositionPatient
+      ) {
         return false;
       }
     }
@@ -92,29 +103,52 @@ const _isDisplaySetReconstructable = (viewportSpecificData = {}, activeViewportI
   return displaySet.isReconstructable;
 };
 
-function VTKMPRToolbarButton({
-  parentContext,
-  toolbarClickCallback,
-  button,
-  activeButtons,
-  isActive,
-  className,
-}) {
-  const { id, label, icon } = button;
-  const { viewportSpecificData, activeViewportIndex } = useSelector(state => {
-    const { viewports = {} } = state;
-    const { viewportSpecificData, activeViewportIndex } = viewports;
+const selectDisplaySetInstanceUID = state => {
+  if (
+    state.viewports.viewportSpecificData[state.viewports.activeViewportIndex]
+  ) {
+    return state.viewports.viewportSpecificData[
+      state.viewports.activeViewportIndex
+    ].displaySetInstanceUID;
+  } else {
+    return '';
+  }
+};
 
+const selectStudyInstanceUID = state => {
+  if (
+    state.viewports.viewportSpecificData[state.viewports.activeViewportIndex]
+  ) {
+    return state.viewports.viewportSpecificData[
+      state.viewports.activeViewportIndex
+    ].StudyInstanceUID;
+  } else {
+    return '';
+  }
+};
+
+const stateSelector = createSelector(
+  [selectDisplaySetInstanceUID, selectStudyInstanceUID],
+  (displaySetInstanceUID, StudyInstanceUID) => {
     return {
-      viewportSpecificData,
-      activeViewportIndex,
-    }
-  });
+      displaySetInstanceUID,
+      StudyInstanceUID,
+    };
+  }
+);
 
-  isVisible = _isDisplaySetReconstructable(
-    viewportSpecificData,
-    activeViewportIndex,
+function VTKMPRToolbarButton({ toolbarClickCallback, button, isActive }) {
+  const { id, label, icon } = button;
+  const { displaySetInstanceUID, StudyInstanceUID } = useSelector(
+    stateSelector
   );
+
+  const isVisible = useMemo(() => {
+    return _isDisplaySetReconstructable(
+      displaySetInstanceUID,
+      StudyInstanceUID
+    );
+  }, [displaySetInstanceUID, StudyInstanceUID]);
 
   return (
     <React.Fragment>


### PR DESCRIPTION
When opening 2D MPR-capable series with many images, there is a drop in performance. This was because in the `VTKMPRToolbarButton` component, the `_isDisplaySetReconstructable` method was executed many times unnecessarily each time I scrolled through the images in a series.

To solve this, memoization was added to the component in order to listen only the state of the variables necessary for the operation of _isDisplaySetReconstructable and to be able to save the values previously calculated by the method and thus avoid unnecessary rebuilds.

To test it, open a 2D MPR-capable series with many images (~ 700) and scroll through it. 

### PR Checklist

- [ x] Brief description of changes
- [ ] Links to any relevant issues
- [x ] Required status checks are passing
- [ ] User cases if changes impact the user's experience
- [ x] `@mention` a maintainer to request a review
