### PR TITLE
IDC-2288: Update toolbar tabs after derived displayset loaded

### DIFF
--- a/platform/core/src/utils/loadAndCacheDerivedDisplaySets.js
+++ b/platform/core/src/utils/loadAndCacheDerivedDisplaySets.js
@@ -49,9 +49,7 @@ import studyMetadataManager from './studyMetadataManager';
  */
 const loadAndCacheDerivedDisplaySets = (referencedDisplaySet, studies) => {
   const { StudyInstanceUID, SeriesInstanceUID } = referencedDisplaySet;
-
   const promises = [];
-
   const studyMetadata = studyMetadataManager.get(StudyInstanceUID);
 
   if (!studyMetadata) {

--- a/platform/core/src/utils/loadAndCacheDerivedDisplaySets.js
+++ b/platform/core/src/utils/loadAndCacheDerivedDisplaySets.js
@@ -112,6 +112,16 @@ const loadAndCacheDerivedDisplaySets = (referencedDisplaySet, studies) => {
     promises.push(recentDisplaySet.load(referencedDisplaySet, studies));
   });
 
+  Promise.all(promises).then(() => {
+    /*
+     * TODO: Improve the way we notify parts of the app
+     * that depends on derived display sets to be loaded.
+     * (Implement pubsub for better tracking of derived display sets)
+     */
+    const event = new CustomEvent('deriveddisplaysetsloadedandcached');
+    document.dispatchEvent(event);
+  });
+
   return promises;
 };
 

--- a/platform/viewer/src/connectedComponents/ToolbarRow.js
+++ b/platform/viewer/src/connectedComponents/ToolbarRow.js
@@ -59,6 +59,9 @@ class ToolbarRow extends Component {
     this.seriesPerStudyCount = [];
 
     this._handleBuiltIn = _handleBuiltIn.bind(this);
+    this._onDerivedDisplaySetsLoadedAndCached = this._onDerivedDisplaySetsLoadedAndCached.bind(
+      this
+    );
 
     this.updateButtonGroups();
   }
@@ -106,6 +109,32 @@ class ToolbarRow extends Component {
       value: 'studies',
       icon: 'th-large',
       bottomLabel: this.props.t('Series'),
+    });
+  }
+
+  componentDidMount() {
+    /*
+     * TODO: Improve the way we notify parts of the app
+     * that depends on derived display sets to be loaded.
+     * (Implement pubsub for better tracking of derived display sets)
+     */
+    document.addEventListener(
+      'deriveddisplaysetsloadedandcached',
+      this._onDerivedDisplaySetsLoadedAndCached
+    );
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener(
+      'deriveddisplaysetsloadedandcached',
+      this._onDerivedDisplaySetsLoadedAndCached
+    );
+  }
+
+  _onDerivedDisplaySetsLoadedAndCached() {
+    this.updateButtonGroups();
+    this.setState({
+      toolbarButtons: _getVisibleToolbarButtons.call(this),
     });
   }
 

--- a/platform/viewer/src/connectedComponents/Viewer.js
+++ b/platform/viewer/src/connectedComponents/Viewer.js
@@ -271,6 +271,7 @@ class Viewer extends Component {
             activeViewport={
               this.props.viewports[this.props.activeViewportIndex]
             }
+            isDerivedDisplaySetsLoaded={this.props.isDerivedDisplaySetsLoaded}
             isLeftSidePanelOpen={this.state.isLeftSidePanelOpen}
             isRightSidePanelOpen={this.state.isRightSidePanelOpen}
             selectedLeftSidePanel={


### PR DESCRIPTION
- The ToolbarRow calls the toolbar module isDisabled function to get the state for an extension's panel tab. Now the isDisabled function depends on async data to be interpreted and used to decide whether the tab is displayed (e.g. check if this study has rt structs).
- Update ToolbarRow component so that it keeps track of derived display sets being loaded.
- Resolves issue #2288 

## Improvements
- Implement a pubsub utility class that studyMetadata could extend to trigger DERIVED_DISPLAY_SETS_CHANGED events that parts of the app could subscribe to update its content.
