### PR TITLE
IDC 2259: add warning UI for series inconsistencies

### DIFF
--- a/extensions/vtk/src/toolbarComponents/VTKMPRToolbarButton.js
+++ b/extensions/vtk/src/toolbarComponents/VTKMPRToolbarButton.js
@@ -1,18 +1,21 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import { ToolbarButton } from '@ohif/ui';
 import { utils } from '@ohif/core';
-import { createSelector } from 'reselect';
+
 const { studyMetadataManager } = utils;
 
-const _isDisplaySetReconstructable = (
-  displaySetInstanceUID = '',
-  StudyInstanceUID = ''
-) => {
-  if (displaySetInstanceUID == '' || StudyInstanceUID == '') {
+let isVisible = true;
+
+const _isDisplaySetReconstructable = (viewportSpecificData = {}, activeViewportIndex) => {
+  if (!viewportSpecificData[activeViewportIndex]) {
     return false;
-  }
+  };
+
+  const { displaySetInstanceUID, StudyInstanceUID } = viewportSpecificData[
+    activeViewportIndex
+  ];
 
   const studies = studyMetadataManager.all();
 
@@ -24,132 +27,38 @@ const _isDisplaySetReconstructable = (
     return false;
   }
 
-  const displaySet = study._displaySets.find(
-    set => set.displaySetInstanceUID === displaySetInstanceUID
-  );
+  const displaySet = study._displaySets.find(set => set.displaySetInstanceUID === displaySetInstanceUID);
 
   if (!displaySet) {
     return false;
-  }
-
-  // 2D MPR is not currently available for 4D datasets.
-
-  // Assuming that slices at different time have the same position, here we just check if
-  // there are multiple slices for the same ImagePositionPatient and disable MPR.
-
-  // A better heuristic would be checking 4D tags, e.g. the presence of multiple TemporalPositionIdentifier values.
-  // However, some studies (e.g. https://github.com/OHIF/Viewers/issues/2113) do not have such tags.
-
-  for (let ii = 0; ii < displaySet.numImageFrames; ++ii) {
-    const image = displaySet.images[ii];
-    if (!image) continue;
-
-    const imageIdControl = image.getImageId();
-    const instanceMetadataControl = cornerstone.metaData.get(
-      'instance',
-      imageIdControl
-    );
-
-    if (
-      !instanceMetadataControl ||
-      instanceMetadataControl === undefined ||
-      !instanceMetadataControl.ImagePositionPatient ||
-      instanceMetadataControl.ImagePositionPatient === undefined
-    ) {
-      // if ImagePositionPatient is missing, skip the 4D datasets check.
-      // do not return false, because it could be a 3D dataset.
-      continue;
-    }
-
-    let xImagePositionPatientControl =
-      instanceMetadataControl.ImagePositionPatient[0];
-    let yImagePositionPatientControl =
-      instanceMetadataControl.ImagePositionPatient[1];
-    let zImagePositionPatientControl =
-      instanceMetadataControl.ImagePositionPatient[2];
-
-    for (let jj = ii + 1; jj < displaySet.numImageFrames; ++jj) {
-      const image = displaySet.images[jj];
-      if (!image) continue;
-
-      const imageId = image.getImageId();
-      const instanceMetadata = cornerstone.metaData.get('instance', imageId);
-
-      if (
-        !instanceMetadata ||
-        instanceMetadata === undefined ||
-        !instanceMetadata.ImagePositionPatient ||
-        instanceMetadata.ImagePositionPatient === undefined
-      ) {
-        // if ImagePositionPatient is missing, skip the 4D datasets check.
-        // do not return false, because it could be a 3D dataset.
-        continue;
-      }
-
-      let xImagePositionPatient = instanceMetadata.ImagePositionPatient[0];
-      let yImagePositionPatient = instanceMetadata.ImagePositionPatient[1];
-      let zImagePositionPatient = instanceMetadata.ImagePositionPatient[2];
-
-      // ImagePositionPatient is float
-      if (
-        Math.abs( xImagePositionPatientControl - xImagePositionPatient ) < 1e-6 &&
-        Math.abs( yImagePositionPatientControl - yImagePositionPatient ) < 1e-6 &&
-        Math.abs( zImagePositionPatientControl - zImagePositionPatient ) < 1e-6
-      ) {
-        return false;
-      }
-    }
-  }
+  };
 
   return displaySet.isReconstructable;
 };
 
-const selectDisplaySetInstanceUID = state => {
-  if (
-    state.viewports.viewportSpecificData[state.viewports.activeViewportIndex]
-  ) {
-    return state.viewports.viewportSpecificData[
-      state.viewports.activeViewportIndex
-    ].displaySetInstanceUID;
-  } else {
-    return '';
-  }
-};
-
-const selectStudyInstanceUID = state => {
-  if (
-    state.viewports.viewportSpecificData[state.viewports.activeViewportIndex]
-  ) {
-    return state.viewports.viewportSpecificData[
-      state.viewports.activeViewportIndex
-    ].StudyInstanceUID;
-  } else {
-    return '';
-  }
-};
-
-const stateSelector = createSelector(
-  [selectDisplaySetInstanceUID, selectStudyInstanceUID],
-  (displaySetInstanceUID, StudyInstanceUID) => {
-    return {
-      displaySetInstanceUID,
-      StudyInstanceUID,
-    };
-  }
-);
-
-function VTKMPRToolbarButton({ toolbarClickCallback, button, isActive }) {
+function VTKMPRToolbarButton({
+  parentContext,
+  toolbarClickCallback,
+  button,
+  activeButtons,
+  isActive,
+  className,
+}) {
   const { id, label, icon } = button;
-  const { displaySetInstanceUID, StudyInstanceUID } = useSelector(
-    stateSelector
-  );
+  const { viewportSpecificData, activeViewportIndex } = useSelector(state => {
+    const { viewports = {} } = state;
+    const { viewportSpecificData, activeViewportIndex } = viewports;
 
-  const isVisible = useMemo(() => {
-    return _isDisplaySetReconstructable(
-      displaySetInstanceUID,
-      StudyInstanceUID
-    );
-  }, [displaySetInstanceUID, StudyInstanceUID]);
+    return {
+      viewportSpecificData,
+      activeViewportIndex,
+    }
+  });
+
+  isVisible = _isDisplaySetReconstructable(
+    viewportSpecificData,
+    activeViewportIndex,
+  );
 
   return (
     <React.Fragment>

--- a/platform/core/src/classes/metadata/StudyMetadata.js
+++ b/platform/core/src/classes/metadata/StudyMetadata.js
@@ -767,6 +767,16 @@ const isMultiFrame = instance => {
   return instance.getTagValue('NumberOfFrames') > 1;
 };
 
+/**
+ * Creates a display set for a series.
+ * Checks if a series is reconstructable to a 3D volume.
+ * If reconstructable, the frames are sorted.
+ *
+ * @param {SeriesMetadata} series The series metadata object from which the display sets will be created
+ * @param {Object[]} instances An array of `OHIFInstanceMetadata` objects.
+ *
+ * @returns {Object} imageSet.
+ */
 const makeDisplaySet = (series, instances) => {
   const instance = instances[0];
   const imageSet = new ImageSet(instances);
@@ -805,7 +815,6 @@ const makeDisplaySet = (series, instances) => {
   );
 
   const isReconstructable = isDisplaySetReconstructable(instances);
-
   imageSet.isReconstructable = isReconstructable.value;
 
   if (shallSort && imageSet.isReconstructable) {
@@ -816,6 +825,11 @@ const makeDisplaySet = (series, instances) => {
     // TODO -> This is currently unused, but may be used for reconstructing
     // Volumes with gaps later on.
     imageSet.missingFrames = isReconstructable.missingFrames;
+  }
+
+  if (!imageSet.isReconstructable) {
+    // It is not reconstrabale Save type of warning
+    imageSet.warningIssues = isReconstructable.warningIssues;
   }
 
   return imageSet;

--- a/platform/core/src/classes/metadata/StudyMetadata.js
+++ b/platform/core/src/classes/metadata/StudyMetadata.js
@@ -814,22 +814,22 @@ const makeDisplaySet = (series, instances) => {
     imageSet.getImage(0).getTagValue('InstanceNumber')
   );
 
-  const isReconstructable = isDisplaySetReconstructable(instances);
-  imageSet.isReconstructable = isReconstructable.value;
+  const displayReconstructableInfo = isDisplaySetReconstructable(instances);
+  imageSet.isReconstructable = displayReconstructableInfo.value;
 
   if (shallSort && imageSet.isReconstructable) {
     imageSet.sortByImagePositionPatient();
   }
 
-  if (isReconstructable.missingFrames) {
+  if (displayReconstructableInfo.missingFrames) {
     // TODO -> This is currently unused, but may be used for reconstructing
     // Volumes with gaps later on.
-    imageSet.missingFrames = isReconstructable.missingFrames;
+    imageSet.missingFrames = displayReconstructableInfo.missingFrames;
   }
 
-  if (!imageSet.isReconstructable) {
+  if (!imageSet.displayReconstructableInfo) {
     // It is not reconstrabale Save type of warning
-    imageSet.warningIssues = isReconstructable.warningIssues;
+    imageSet.warningIssues = displayReconstructableInfo.warningIssues;
   }
 
   return imageSet;

--- a/platform/core/src/enums.js
+++ b/platform/core/src/enums.js
@@ -1,0 +1,11 @@
+const ReconstructionIssues = {
+  DATASET_4D: 'datasetis4D',
+  VARYING_IMAGESDIMENSIONS: 'imagesdimensionsvarying',
+  VARYING_IMAGESCOMPONENTS: 'imagescomponentsvarying',
+  VARYING_IMAGESORIENTATION: 'imagesorientationvarying',
+  MISSING_FRAMES: 'missingframes',
+  IRREGULAR_SPACING: 'irregularspacing',
+  MULTIFFRAMES: 'multiframe',
+};
+
+export {ReconstructionIssues};

--- a/platform/ui/src/components/studyBrowser/StudyBrowser.js
+++ b/platform/ui/src/components/studyBrowser/StudyBrowser.js
@@ -28,6 +28,7 @@ function StudyBrowser(props) {
                 SeriesDescription,
                 SeriesNumber,
                 stackPercentComplete,
+                hasWarnings,
               } = thumb;
 
               return (
@@ -50,6 +51,7 @@ function StudyBrowser(props) {
                     numImageFrames={numImageFrames}
                     SeriesDescription={SeriesDescription}
                     SeriesNumber={SeriesNumber}
+                    hasWarnings={hasWarnings}
                     stackPercentComplete={stackPercentComplete}
                     // Events
                     onClick={onThumbnailClick.bind(

--- a/platform/ui/src/components/studyBrowser/Thumbnail.js
+++ b/platform/ui/src/components/studyBrowser/Thumbnail.js
@@ -190,7 +190,7 @@ Thumbnail.propTypes = {
   stackPercentComplete: PropTypes.number,
   /**
   altImageText will be used when no imageId or imageSrc is provided.
-It will be displayed inside the <div>. This is useful when it is difficult
+  It will be displayed inside the <div>. This is useful when it is difficult
   to make a preview for a type of DICOM series (e.g. DICOM-SR)
   */
   altImageText: PropTypes.string,

--- a/platform/ui/src/components/studyBrowser/Thumbnail.js
+++ b/platform/ui/src/components/studyBrowser/Thumbnail.js
@@ -1,8 +1,11 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { useDrag } from 'react-dnd';
 import ImageThumbnail from './ImageThumbnail';
 import classNames from 'classnames';
+import { Icon } from './../../elements/Icon';
+import { Tooltip } from './../tooltip';
+import { OverlayTrigger } from './../overlayTrigger';
 
 import './Thumbnail.styl';
 
@@ -11,7 +14,22 @@ function ThumbnailFooter({
   SeriesNumber,
   InstanceNumber,
   numImageFrames,
+  hasWarnings
 }) {
+  const [warningList, warningListSet] = useState([]);
+
+  useEffect(() => {
+    let unmounted = false
+    hasWarnings.then(response => {
+      if (!unmounted) {
+        warningListSet(response)
+      }
+    })
+    return () => {
+      unmounted = true
+    }
+  }, [])
+
   const infoOnly = !SeriesDescription;
 
   const getInfo = (value, icon, className = '') => {
@@ -22,28 +40,73 @@ function ThumbnailFooter({
       </div>
     );
   };
+
+  const getWarningContent = (warningList) => {
+    if (Array.isArray(warningList)) {
+      const listedWarnings = warningList.map((warn, index) => {
+        return <li key={index}>{warn}</li>;
+      });
+
+      return <ol>{listedWarnings}</ol>;
+    } else {
+      return <React.Fragment>{warningList}</React.Fragment>;
+    }
+  };
+
+  const getWarningInfo = (SeriesNumber, warningList) => {
+      return(
+        <React.Fragment>
+        {warningList.length != 0 ? (
+          <OverlayTrigger
+            key={SeriesNumber}
+            placement="left"
+            overlay={
+              <Tooltip
+                placement="left"
+                className="in tooltip-warning"
+                id="tooltip-left"
+              >
+                <div className="warningTitle">Series Inconsistencies</div>
+                <div className="warningContent">{getWarningContent(warningList)}</div>
+              </Tooltip>
+            }
+          >
+            <div className={classNames('warning')}>
+              <span className="warning-icon">
+                <Icon name="exclamation-triangle" />
+              </span>
+            </div>
+          </OverlayTrigger>
+        ) : (
+          <React.Fragment></React.Fragment>
+          )}
+      </React.Fragment>
+      );
+  };
   const getSeriesInformation = (
     SeriesNumber,
     InstanceNumber,
-    numImageFrames
+    numImageFrames,
+    warningList
   ) => {
     if (!SeriesNumber && !InstanceNumber && !numImageFrames) {
       return;
     }
-
-    return (
+    const seriesInformation =
       <div className="series-information">
         {getInfo(SeriesNumber, 'S:')}
         {getInfo(InstanceNumber, 'I:')}
         {getInfo(numImageFrames, '', 'image-frames')}
+        {getWarningInfo(SeriesNumber, warningList)}
       </div>
-    );
+
+    return (seriesInformation);
   };
 
   return (
     <div className={classNames('series-details', { 'info-only': infoOnly })}>
       <div className="series-description">{SeriesDescription}</div>
-      {getSeriesInformation(SeriesNumber, InstanceNumber, numImageFrames)}
+      {getSeriesInformation(SeriesNumber, InstanceNumber, numImageFrames, warningList)}
     </div>
   );
 }
@@ -60,6 +123,7 @@ function Thumbnail(props) {
     numImageFrames,
     SeriesDescription,
     SeriesNumber,
+    hasWarnings,
     stackPercentComplete,
     StudyInstanceUID,
     onClick,
@@ -133,6 +197,7 @@ It will be displayed inside the <div>. This is useful when it is difficult
   SeriesDescription: PropTypes.string,
   SeriesNumber: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   InstanceNumber: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  hasWarnings: PropTypes.instanceOf(Promise),
   numImageFrames: PropTypes.number,
   onDoubleClick: PropTypes.func,
   onClick: PropTypes.func,

--- a/platform/ui/src/components/studyBrowser/Thumbnail.styl
+++ b/platform/ui/src/components/studyBrowser/Thumbnail.styl
@@ -78,6 +78,17 @@
           height: 11px
           width: 11px
 
+    .warning
+      margin: auto 0;
+      opacity: 1
+      color: #e29e4a;
+
+      svg
+        width: 16px;
+        height: 14px;
+        pointer-events: inherit;
+
+
     .value
       color: var(--text-secondary-color);
       display: inline-block

--- a/platform/viewer/src/connectedComponents/Viewer.js
+++ b/platform/viewer/src/connectedComponents/Viewer.js
@@ -12,7 +12,7 @@ import ConnectedViewerMain from './ConnectedViewerMain.js';
 import SidePanel from './../components/SidePanel.js';
 import ErrorBoundaryDialog from './../components/ErrorBoundaryDialog';
 import { extensionManager } from './../App.js';
-import { reconstructionIssues } from './../../../core/src/utils/isDisplaySetReconstructable.js';
+import { ReconstructionIssues } from './../../../core/src/enums.js';
 
 // Contexts
 import WhiteLabelingContext from '../context/WhiteLabelingContext.js';
@@ -389,22 +389,22 @@ const _checkForSeriesInconsistencesWarnings = async function (displaySet) {
   if (displaySet.warningIssues && displaySet.warningIssues.length !== 0) {
     displaySet.warningIssues.forEach(warning => {
       switch (warning) {
-        case reconstructionIssues.DATASET_4D:
+        case ReconstructionIssues.DATASET_4D:
           warningsList.push("The dataset is 4D.");
           break;
-        case reconstructionIssues.VARYING_IMAGESDIMENSIONS:
+        case ReconstructionIssues.VARYING_IMAGESDIMENSIONS:
           warningsList.push("The dataset frames have different dimensions (rows, columns).");
           break;
-        case reconstructionIssues.VARYING_IMAGESCOMPONENTS:
+        case ReconstructionIssues.VARYING_IMAGESCOMPONENTS:
           warningsList.push("The dataset frames have different components (Sample per pixel).");
           break;
-        case reconstructionIssues.VARYING_IMAGESORIENTATION:
+        case ReconstructionIssues.VARYING_IMAGESORIENTATION:
           warningsList.push("The dataset frames have different orientation.");
           break;
-        case reconstructionIssues.IRREGULAR_SPACING:
+        case ReconstructionIssues.IRREGULAR_SPACING:
           warningsList.push("The dataset frames have different pixel spacing.");
           break;
-        case reconstructionIssues.MULTIFFRAMES:
+        case ReconstructionIssues.MULTIFFRAMES:
           warningsList.push("The dataset is a multiframes.");
           break;
         default:
@@ -416,7 +416,7 @@ const _checkForSeriesInconsistencesWarnings = async function (displaySet) {
 
   if (displaySet.missingFrames &&
     (!displaySet.warningIssues ||
-      (displaySet.warningIssues && !displaySet.warningIssues.find(warn => warn === reconstructionIssues.DATASET_4D)))) {
+      (displaySet.warningIssues && !displaySet.warningIssues.find(warn => warn === ReconstructionIssues.DATASET_4D)))) {
     warningsList.push('The datasets is missing frames: ' + displaySet.missingFrames + '.');
   }
 

--- a/platform/viewer/src/connectedComponents/Viewer.js
+++ b/platform/viewer/src/connectedComponents/Viewer.js
@@ -12,6 +12,7 @@ import ConnectedViewerMain from './ConnectedViewerMain.js';
 import SidePanel from './../components/SidePanel.js';
 import ErrorBoundaryDialog from './../components/ErrorBoundaryDialog';
 import { extensionManager } from './../App.js';
+import { reconstructionIssues } from './../../../core/src/utils/isDisplaySetReconstructable.js';
 
 // Contexts
 import WhiteLabelingContext from '../context/WhiteLabelingContext.js';
@@ -367,6 +368,62 @@ class Viewer extends Component {
 export default withDialog(Viewer);
 
 /**
+ * Async function to check if there are any inconsistences in the series
+ * (i.e. reconstructable to a 3D volume). If not reconstructable MPR is disabled.
+ * The actual computations are done in isDisplaySetReconstructable.
+ *
+ * 1) Is series multiframe?
+ * 2) Do the frames have different dimensions/numer of components/orientations?
+ * 3) Has the series any missing frames or irregular spacing?
+ * 4) Is the series 4D?
+ *
+ * @param {*object} displaySet
+ * @returns {[string]} an array of strings containing the warnings
+ */
+const _checkForSeriesInconsistencesWarnings = async function (displaySet) {
+  // NOTE: at the moment this function is async even if it does not perfom any heavy calculation.
+  //       We may add or move here some of the computations
+  //       done when creating the displaySet (see makeDisplaySet and isDisplaySetReconstructable).
+  //       the thumbnail footnotes warning react element is already set up to handle a promise.
+  const warningsList = [];
+  if (displaySet.warningIssues && displaySet.warningIssues.length !== 0) {
+    displaySet.warningIssues.forEach(warning => {
+      switch (warning) {
+        case reconstructionIssues.DATASET_4D:
+          warningsList.push("The dataset is 4D.");
+          break;
+        case reconstructionIssues.VARYING_IMAGESDIMENSIONS:
+          warningsList.push("The dataset frames have different dimensions (rows, columns).");
+          break;
+        case reconstructionIssues.VARYING_IMAGESCOMPONENTS:
+          warningsList.push("The dataset frames have different components (Sample per pixel).");
+          break;
+        case reconstructionIssues.VARYING_IMAGESORIENTATION:
+          warningsList.push("The dataset frames have different orientation.");
+          break;
+        case reconstructionIssues.IRREGULAR_SPACING:
+          warningsList.push("The dataset frames have different pixel spacing.");
+          break;
+        case reconstructionIssues.MULTIFFRAMES:
+          warningsList.push("The dataset is a multiframes.");
+          break;
+        default:
+          break;
+      }
+    });
+      warningsList.push('The datasets is not a reconstructable 3D volume. MPR mode is not available.');
+  }
+
+  if (displaySet.missingFrames &&
+    (!displaySet.warningIssues ||
+      (displaySet.warningIssues && !displaySet.warningIssues.find(warn => warn === reconstructionIssues.DATASET_4D)))) {
+    warningsList.push('The datasets is missing frames: ' + displaySet.missingFrames + '.');
+  }
+
+  return warningsList
+}
+
+/**
  * What types are these? Why do we have "mapping" dropped in here instead of in
  * a mapping layer?
  *
@@ -405,6 +462,8 @@ const _mapStudiesToThumbnails = function(studies) {
         altImageText = displaySet.Modality ? displaySet.Modality : 'UN';
       }
 
+      const hasWarnings = _checkForSeriesInconsistencesWarnings(displaySet)
+
       return {
         imageId,
         altImageText,
@@ -413,6 +472,7 @@ const _mapStudiesToThumbnails = function(studies) {
         InstanceNumber,
         numImageFrames,
         SeriesNumber,
+        hasWarnings,
       };
     });
 


### PR DESCRIPTION
IDC 2259: https://github.com/OHIF/Viewers/issues/2259
add warning UI for series inconsistencies in the footnote of the series thumbnails. E.g.:
![image](https://user-images.githubusercontent.com/7985338/112315295-4bdc7480-8caa-11eb-9fe6-0b9ff1754faf.png)

Other previous relevant IDC issues: 
https://github.com/OHIF/Viewers/issues/2289
https://github.com/OHIF/Viewers/issues/2113


@racacere I have removed the VTKMPRToolbarButton component memoization (i.e. PR https://github.com/OHIF/Viewers/pull/2274) since it is not anymore necessary (the 4D checks calculations have been moved to isDisplaySetReconstructable when creating the displaySet. See makeDisplaySet https://github.com/OHIF/Viewers/pull/2331/files#diff-cffb1ba058623c901e4d8ca2774946928f9bf564a4d00c77001b40bfc1cc4f65R780 and https://github.com/OHIF/Viewers/pull/2331/files#diff-7d4f87b19c454224e0282ce2d72f14c89e0d90833aa95e0f6e25e55445ca5fb3R8)

@igoroctaviano please test and review when you have time. Thanks!
relevant IDC dataset for testing:

1. https://idc-sandbox-000.firebaseapp.com/projects/idc-dev-etl/locations/us-central1/datasets/idc_tcia_dev/dicomStores/idc_tcia/study/1.3.6.1.4.1.14519.5.2.1.8162.4009.498881901170332065029863238265
2. https://viewer.imaging.datacommons.cancer.gov/viewer/1.3.6.1.4.1.14519.5.2.1.1706.4009.243406849348906151042089406192?seriesInstanceUID=1.3.6.1.4.1.14519.5.2.1.1706.4009.304054433668574201838767925472
3. https://viewer.imaging.datacommons.cancer.gov/viewer/1.3.6.1.4.1.14519.5.2.1.7695.1700.251725059071532256976802593346?seriesInstanceUID=1.3.6.1.4.1.14519.5.2.1.7695.1700.284567351304426376226790714264