### PR TITLE
IDC2332

### DIFF
--- a/extensions/dicom-segmentation/src/components/SegmentationPanel/SegmentationPanel.js
+++ b/extensions/dicom-segmentation/src/components/SegmentationPanel/SegmentationPanel.js
@@ -289,7 +289,7 @@ const SegmentationPanel = ({
       /* Map to display representation */
       const dateStr = `${SeriesDate}:${SeriesTime}`.split('.')[0];
       const date = moment(dateStr, 'YYYYMMDD:HHmmss');
-      const displayDate = date.format('ddd, MMM Do YYYY');
+      const displayDate = date.format('ddd, MMM Do YYYY, h:mm:ss a');
       const displayDescription = displaySet.SeriesDescription;
 
       return {
@@ -709,7 +709,7 @@ const _getReferencedSegDisplaysets = (StudyInstanceUID, SeriesInstanceUID) => {
   referencedDisplaysets.sort((a, b) => {
     const aNumber = Number(`${a.SeriesDate}${a.SeriesTime}`);
     const bNumber = Number(`${b.SeriesDate}${b.SeriesTime}`);
-    return aNumber - bNumber;
+    return bNumber - aNumber;
   });
 
   return referencedDisplaysets;

--- a/platform/viewer/src/connectedComponents/ViewerRetrieveStudyData.js
+++ b/platform/viewer/src/connectedComponents/ViewerRetrieveStudyData.js
@@ -301,6 +301,7 @@ function ViewerRetrieveStudyData({
       });
 
       setStudies(studies);
+      setIsStudyLoaded(true);
     }
   };
 


### PR DESCRIPTION
https://github.com/OHIF/Viewers/issues/2332

1) fix the loading of the segmentations when filtering study with ?seriesInstanceUID= syntax
2) add times in the dates of the items of the segmentation combobox list
3) order segmentation combobox list in reverse time order

![image](https://user-images.githubusercontent.com/7985338/113006995-1df9a300-9176-11eb-8c3b-48f5ebd388ef.png)

@igoroctaviano please review when you have time. 
Datasets: 
IDC dev: https://dev-viewer.canceridc.dev/viewer/1.3.6.1.4.1.14519.5.2.1.6279.6001.899353684702041035700102438716?seriesInstanceUID=1.3.6.1.4.1.14519.5.2.1.6279.6001.188059920088313909273628445208,1.2.276.0.7230010.3.1.3.0.10555.1553293857.414765

IDC sandbox: https://idc-sandbox-000.firebaseapp.com/projects/idc-tcia/locations/us-central1/datasets/lidc-idri-seg-sr-dcm/dicomStores/lidc-idri-seg-sr-dcm/study/1.3.6.1.4.1.14519.5.2.1.6279.6001.899353684702041035700102438716?seriesInstanceUID=1.3.6.1.4.1.14519.5.2.1.6279.6001.188059920088313909273628445208,1.2.276.0.7230010.3.1.3.0.10555.1553293857.414765

https://idc-sandbox-000.firebaseapp.com/projects/idc-tcia/locations/us-central1/datasets/lidc-idri-seg-sr-dcm/dicomStores/lidc-idri-seg-sr-dcm/study/1.3.6.1.4.1.14519.5.2.1.6279.6001.899353684702041035700102438716

