### PR TITLE
Update fetchPaletteColorLookupTableData.js

### DIFF
--- a/platform/core/src/utils/metadataProvider/fetchPaletteColorLookupTableData.js
+++ b/platform/core/src/utils/metadataProvider/fetchPaletteColorLookupTableData.js
@@ -112,7 +112,7 @@ const _paletteColorCache = {
 };
 
 function _getPaletteColor(server, paletteColorLookupTableData, lutDescriptor) {
-  const numLutEntries = lutDescriptor[0];
+  const numLutEntries = lutDescriptor[0] ? lutDescriptor[0] : 65536;
   const bits = lutDescriptor[2];
 
   const arrayBufferToPaletteColorLUT = arraybuffer => {


### PR DESCRIPTION
Opened issue https://github.com/OHIF/Viewers/issues/2366. 

Following http://dicom.nema.org/medical/Dicom/2018d/output/chtml/part03/sect_C.7.6.3.html#sect_C.7.6.3.1.5, LUT Entries shall be 0 if the table entries value is 2^16.

This is often used by Philips Ultrasound systems. In case of an LUT Entries value of 0, must be converted to 2^16.

If numLutEntries is 0, there is no for loop and return empty lut array.

Solution:

const numLutEntries = lutDescriptor[0] ? lutDescriptor[0] : 65536;