### PR TITLE
IDC: Add option to disable local storage of servers

### DIFF
--- a/platform/viewer/public/config/default.js
+++ b/platform/viewer/public/config/default.js
@@ -4,6 +4,7 @@ window.config = {
   extensions: [],
   showStudyList: true,
   filterQueryParam: false,
+  disableServersCache: false,
   servers: {
     dicomWeb: [
       {

--- a/platform/viewer/src/store/index.js
+++ b/platform/viewer/src/store/index.js
@@ -24,7 +24,7 @@ const preloadedState = {
   ...sessionStorage.loadState(),
 };
 
-if (window.disableServersCache === true) {
+if (window.config && window.config.disableServersCache === true) {
   delete preloadedState.servers;
 }
 

--- a/platform/viewer/src/store/index.js
+++ b/platform/viewer/src/store/index.js
@@ -24,6 +24,10 @@ const preloadedState = {
   ...sessionStorage.loadState(),
 };
 
+if (window.disableServersCache === true) {
+  delete preloadedState.servers;
+}
+
 const store = createStore(
   rootReducer,
   preloadedState,


### PR DESCRIPTION
- Servers config property is cached/retrieved from local storage by default.
- This change adds a new configuration property to disable servers cache in order to always get a fresh version of servers property if changed without having to clear the browser's cache.