### PR TITLE
improvement(#2483) make client-side code debuggable right from the sou…

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "pwa-chrome",
+      "request": "launch",
+      "name": "Launch Chrome against localhost",
+      "url": "http://localhost:3000",
+      "webRoot": "${workspaceFolder}"
+    }
+  ]
+}

--- a/platform/viewer/.webpack/webpack.pwa.js
+++ b/platform/viewer/.webpack/webpack.pwa.js
@@ -41,6 +41,13 @@ module.exports = (env, argv) => {
       path: DIST_DIR,
       filename: isProdBuild ? '[name].bundle.[chunkhash].js' : '[name].js',
       publicPath: PUBLIC_URL, // Used by HtmlWebPackPlugin for asset prefix
+      devtoolModuleFilenameTemplate: function(info) {
+        if (isProdBuild) {
+          return `webpack:///${info.resourcePath}`;
+        } else {
+          return 'file:///' + encodeURI(info.absoluteResourcePath);
+        }
+      },
     },
     module: {
       rules: [...extractStyleChunksRule(isProdBuild)],


### PR DESCRIPTION
This is an update to the webpack config to make client-side code debuggable right from the source code (editor) #2483 

This config change affects the values of the sources properties in source map files created when building.
This only changes the "development" build and no effect to the "production" build to make sure there is no side effect to production.

I pushed the sample launch.json in this PR. Feel free to remove it if you dont want it to be pushed.

Please follow the following step to debug from vscode after this change.
1) launch the viewer in the debug mode from your local environment
yarn run dev (in the root directory of the repo)

2) Run the vscode application and open workspace for the repo.

3) Open the debug view.
![image](https://user-images.githubusercontent.com/19254333/126907555-b950e209-5c10-4f07-a412-2c3e95d683d4.png)

4) Launch the debug from your favorite brower if the launch.json already exists.

Or you can create new launch.json script by clicking "create a launch.json file"
![image](https://user-images.githubusercontent.com/19254333/126907640-6613821a-860d-4a1f-8531-5ff14a27c518.png)

The following is the sample launch.json script
{
  // Use IntelliSense to learn about possible attributes.
  // Hover to view descriptions of existing attributes.
  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
  "version": "0.2.0",
  "configurations": [
    {
      "type": "pwa-chrome",
      "request": "launch",
      "name": "Launch Chrome against localhost",
      "url": "http://localhost:3000",
      "webRoot": "${workspaceFolder}"
    }
  ]
}
And run.
Then new browser will be opened.

5) Browse a source file and set a breakpoint.

6) Navigate to the page where the breakpoint is set.
![image](https://user-images.githubusercontent.com/19254333/126907702-3dda222c-3b3f-4024-a3ba-eba69a2a4244.png)


