### PR TITLE
fix CVE-2019-5021 caused by nginx-apline

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ RUN yarn run build
 
 # Stage 2: Bundle the built application into a Docker container
 # which runs Nginx using Alpine Linux
-FROM nginx:1.15.5-alpine
+FROM nginx:1.21.1-alpine
 RUN apk add --no-cache bash
 RUN rm -rf /etc/nginx/conf.d
 COPY .docker/Viewer-v2.x /etc/nginx/conf.d


### PR DESCRIPTION
### PR Checklist

Fixed issue that was caused by old version of the nginx:alpine container, that causes security scanners to report a high security alert CVE-2019-5021. Current version of nginx have already patched this vulnerability.

Please see:
https://github.com/nginx-proxy/nginx-proxy/issues/1280


<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
