### PR TITLE
OHIF-2570: Update badge number based on active ds

### DIFF
--- a/extensions/dicom-rt/src/index.js
+++ b/extensions/dicom-rt/src/index.js
@@ -112,6 +112,10 @@ export default {
                   ['RTSTRUCT'].includes(ds.Modality)
                 )
               ) {
+                triggerRTPanelUpdatedEvent({
+                  badgeNumber: referencedDisplaySets.length,
+                  target: 'rt-panel',
+                });
                 return false;
               }
             }

--- a/extensions/dicom-segmentation/src/index.js
+++ b/extensions/dicom-segmentation/src/index.js
@@ -126,7 +126,7 @@ export default {
           label: 'Segmentations',
           target: 'segmentation-panel',
           stateEvent: SegmentationPanelTabUpdatedEvent,
-          isDisabled: studies => {
+          isDisabled: (studies, activeViewport) => {
             if (!studies) {
               return true;
             }
@@ -139,6 +139,20 @@ export default {
                   const series = study.series[j];
 
                   if (series.Modality === 'SEG') {
+                    if (activeViewport) {
+                      const studyMetadata = studyMetadataManager.get(
+                        activeViewport.StudyInstanceUID
+                      );
+                      const referencedDS = studyMetadata.getDerivedDatasets({
+                        referencedSeriesInstanceUID:
+                          activeViewport.SeriesInstanceUID,
+                        Modality: 'SEG',
+                      });
+                      triggerSegmentationPanelTabUpdatedEvent({
+                        badgeNumber: referencedDS.length,
+                        target: 'segmentation-panel',
+                      });
+                    }
                     return false;
                   }
                 }


### PR DESCRIPTION
- Issue: #2570

This PR updates the badge number logic to be based on the active display set.
When the active series is changed, the segmentation menu shows the segmentations for that active series.