### PR TITLE
Re #2590: Fix segments visibility handler

### DIFF
--- a/extensions/dicom-segmentation/src/components/SegmentItem/SegmentItem.js
+++ b/extensions/dicom-segmentation/src/components/SegmentItem/SegmentItem.js
@@ -24,6 +24,7 @@ const SegmentItem = ({
   onClick,
   itemClass,
   color,
+  labelmap3D,
   visible,
   onVisibilityChange,
 }) => {
@@ -39,7 +40,7 @@ const SegmentItem = ({
     event.stopPropagation();
     const newVisibility = !isVisible;
     setIsVisible(newVisibility);
-    onVisibilityChange(newVisibility, index);
+    onVisibilityChange(newVisibility, index, labelmap3D);
   };
 
   return (

--- a/extensions/dicom-segmentation/src/getOHIFDicomSegSopClassHandler.js
+++ b/extensions/dicom-segmentation/src/getOHIFDicomSegSopClassHandler.js
@@ -64,8 +64,17 @@ export default function getSopClassHandlerModule({ servicesManager }) {
         metadata,
       };
 
-      segDisplaySet.getSourceDisplaySet = function(studies, activateLabelMap = true, onDisplaySetLoadFailureHandler) {
-        return getSourceDisplaySet(studies, segDisplaySet, activateLabelMap, onDisplaySetLoadFailureHandler);
+      segDisplaySet.getSourceDisplaySet = function(
+        studies,
+        activateLabelMap = true,
+        onDisplaySetLoadFailureHandler
+      ) {
+        return getSourceDisplaySet(
+          studies,
+          segDisplaySet,
+          activateLabelMap,
+          onDisplaySetLoadFailureHandler
+        );
       };
 
       segDisplaySet.load = async function(referencedDisplaySet, studies) {
@@ -98,6 +107,9 @@ export default function getSopClassHandlerModule({ servicesManager }) {
         if (labelmapBufferArray.length > 1) {
           let labelmapIndexes = [];
           for (let i = 0; i < labelmapBufferArray.length; ++i) {
+            segMetadata.segmentationSeriesInstanceUID =
+              segDisplaySet.SeriesInstanceUID;
+            segMetadata.hasOverlapping = true;
             labelmapIndexes.push(
               await loadSegmentation(
                 imageIds,
@@ -118,6 +130,9 @@ export default function getSopClassHandlerModule({ servicesManager }) {
           labelmapIndex = labelmapIndexes[0];
           console.warn('Overlapping segments!');
         } else {
+          segMetadata.segmentationSeriesInstanceUID =
+            segDisplaySet.SeriesInstanceUID;
+          segMetadata.hasOverlapping = false;
           labelmapIndex = await loadSegmentation(
             imageIds,
             segDisplaySet,


### PR DESCRIPTION
Fix https://github.com/OHIF/Viewers/issues/2590

The issue was generated since in the segment visibility handler, segmentations from different series were handled as overlapping segmentation from the same series.

Test data:
non overlapping segmentations in multiple series
https://viewer.imaging.datacommons.cancer.gov/viewer/1.3.6.1.4.1.14519.5.2.1.2744.7002.150059977302243314164020079415

overlapping segmentations from the same series
https://viewer.imaging.datacommons.cancer.gov/viewer/1.3.6.1.4.1.32722.99.99.203715003805996641695765332389135385095

