### PR TITLE
Add ability to build ExpandableToolMenu ToolbarRows recursively.

### DIFF
--- a/platform/ui/src/viewer/ExpandableToolMenu.js
+++ b/platform/ui/src/viewer/ExpandableToolMenu.js
@@ -58,13 +58,17 @@ class ExpandableToolMenu extends React.Component {
 
   getButtons = () => {
     return this.props.buttons.map((button, index) => {
-      return (
-        <ToolbarButton
-          key={index}
-          {...button}
-          isActive={button.id === this.props.activeCommand}
-        />
-      );
+      if (button.buttons && button.buttons.length) {
+        return (
+          <ExpandableToolMenu
+            key={`expandable-${index}`}
+            {...button}
+            activeCommand={button.activeButton}
+          />
+        );
+      } else {
+        return button;
+      }
     });
   };
 


### PR DESCRIPTION
- Add ability to build ExpandableToolMenu ToolbarRows recursively.
- Allows any number of sub-menus ( configured from the toolbarModule ).

### PR Checklist

- [ ] Brief description of changes
- [ ] Links to any relevant issues
- [ ] Required status checks are passing
- [ ] User cases if changes impact the user's experience
- [ ] `@mention` a maintainer to request a review

<!--
  Links
  -->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
