### PR TITLE
fix: don't retry thumbnail requests after errors

### DIFF
--- a/platform/ui/src/components/studyBrowser/ImageThumbnail.js
+++ b/platform/ui/src/components/studyBrowser/ImageThumbnail.js
@@ -93,12 +93,13 @@ function ImageThumbnail(props) {
   }, [canvasRef, image, image.imageId]);
 
   useEffect(() => {
-    if (!image.imageId || image.imageId !== imageId) {
+    if (!error && (!image.imageId || image.imageId !== imageId)) {
       purgeCancelablePromise();
       setImagePromise();
       fetchImagePromise();
     }
   }, [
+    error,
     fetchImagePromise,
     image.imageId,
     imageId,
@@ -130,7 +131,9 @@ function ImageThumbnail(props) {
           />
         </div>
       )}
-      {isLoading && <div className="image-thumbnail-loading-indicator"></div>}
+      {!error && isLoading && (
+        <div className="image-thumbnail-loading-indicator"></div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
When the request for a thumbnail image fails, it is retried immediately, which can cause a loop of infinite failed requests.

This checks the existing error state before starting a new request, and hides the loader if an error did occur.