### PR TITLE
feature: configurable max prefetch request count

### DIFF
--- a/platform/core/src/classes/StudyPrefetcher.js
+++ b/platform/core/src/classes/StudyPrefetcher.js
@@ -11,7 +11,7 @@ export class StudyPrefetcher {
     requestType: 'prefetch',
     preventCache: false,
     prefetchDisplaySetsTimeout: 300,
-    maxPrefetchRequestsNum: 1000,
+    maxNumPrefetchRequests: 100,
     includeActiveDisplaySet: false,
   };
 
@@ -154,7 +154,7 @@ export class StudyPrefetcher {
 
     imageLoadPoolManager.maxNumRequests = {
       ...imageLoadPoolManager.maxNumRequests,
-      prefetch: this.options.maxPrefetchRequestsNum,
+      prefetch: this.options.maxNumPrefetchRequests,
     };
 
     let requestFn;

--- a/platform/core/src/classes/StudyPrefetcher.js
+++ b/platform/core/src/classes/StudyPrefetcher.js
@@ -11,6 +11,7 @@ export class StudyPrefetcher {
     requestType: 'prefetch',
     preventCache: false,
     prefetchDisplaySetsTimeout: 300,
+    maxPrefetchRequestsNum: 1000,
     includeActiveDisplaySet: false,
   };
 
@@ -150,6 +151,11 @@ export class StudyPrefetcher {
   prefetchImageIds(imageIds) {
     const nonCachedImageIds = this.filterCachedImageIds(imageIds);
     const imageLoadPoolManager = cornerstone.imageLoadPoolManager;
+
+    imageLoadPoolManager.maxNumRequests = {
+      ...imageLoadPoolManager.maxNumRequests,
+      prefetch: this.options.maxPrefetchRequestsNum,
+    };
 
     let requestFn;
     if (this.options.preventCache) {

--- a/platform/viewer/public/config/default.js
+++ b/platform/viewer/public/config/default.js
@@ -11,6 +11,7 @@ window.config = {
     displaySetCount: 3,
     preventCache: false,
     prefetchDisplaySetsTimeout: 300,
+    maxPrefetchRequestsNum: 1000,
     displayProgress: true,
     includeActiveDisplaySet: true,
   },

--- a/platform/viewer/public/config/default.js
+++ b/platform/viewer/public/config/default.js
@@ -11,7 +11,7 @@ window.config = {
     displaySetCount: 3,
     preventCache: false,
     prefetchDisplaySetsTimeout: 300,
-    maxPrefetchRequestsNum: 1000,
+    maxNumPrefetchRequests: 100,
     displayProgress: true,
     includeActiveDisplaySet: true,
   },


### PR DESCRIPTION
While it is technically ok to use the default 1000 concurrent prefetch requests with HTTP/2, the event loop in js really doesn't like that. I tested on a large study (20+ series, 70/140 instances each).

cornerstone contains this commented out snippet:
```
      // TODO: This is the reason things aren't going as fast as expected
      // const maxSimultaneousRequests = getMaxSimultaneousRequests()
      // this.maxNumRequests = {
      //   interaction: Math.max(maxSimultaneousRequests, 1),
      //   thumbnail: Math.max(maxSimultaneousRequests - 2, 1),
      //   prefetch: Math.max(maxSimultaneousRequests - 1, 1),
      // }
```

So, with the default study prefetch settings (closest 3 series), if the user clicks, say, the 5th series and tries to scroll the stack, it will get stuck in "Loading..." until the first 3 series are prefetched, and only afterwards is the user's series fetched.

Techincally, `components/StudyPrefetcher` DOES check when the viewport changes, and calls prefetch again, with the relevant series. However, the event handler there doesn't actually run until after the first 3 series are done, even though `cs.EVENTS.NEW_IMAGE` is fired much earlier. The timeline goes something like this:
- initial load, first series is selected
- prefetch runs for series 1, 2 and 3
- user clicks on series 5, cs.EVENTS.NEW_IMAGE is fired here
- series 1,2,3 continue to load, and eventually finish
- only then is the listener code in StudyPrefetcher called, but it is too late

In fact, it doesn't even matter how many times the user changes the series, all of those events are stalled.

From what I can tell, this happens because all the hundreds of XHRs for the first 3 series are sent in the same tick of the event loop, and the new image listener is further back in the queue compared to the XHR response handlers (or maybe there's some priority in play, depends on the internals of v8). In any case, reducing the number of max prefetch requests to a smaller number, like 25, fixes the problem, so this PR makes it possible to configure the number, like other prefetcher options.