### PR TITLE
Fix/v3 remove unused measurement code

### DIFF
--- a/extensions/cornerstone/src/commandsModule.js
+++ b/extensions/cornerstone/src/commandsModule.js
@@ -291,32 +291,6 @@ const commandsModule = ({ servicesManager, commandsManager }) => {
         });
       }
     },
-    updateTableWithNewMeasurementData({
-      toolType,
-      measurementNumber,
-      location,
-      description,
-    }) {
-      // Update all measurements by measurement number
-      const measurementApi = OHIF.measurements.MeasurementApi.Instance;
-      const measurements = measurementApi.tools[toolType].filter(
-        m => m.measurementNumber === measurementNumber
-      );
-
-      measurements.forEach(measurement => {
-        measurement.location = location;
-        measurement.description = description;
-
-        measurementApi.updateMeasurement(measurement.toolType, measurement);
-      });
-
-      measurementApi.syncMeasurementsAndToolData();
-
-      // Update images in all active viewports
-      cornerstone.getEnabledElements().forEach(enabledElement => {
-        cornerstone.updateImage(enabledElement.element);
-      });
-    },
     getNearbyToolData({ element, canvasCoordinates, availableToolTypes }) {
       const nearbyTool = {};
       let pointNearTool = false;
@@ -416,11 +390,6 @@ const commandsModule = ({ servicesManager, commandsManager }) => {
     },
     removeToolState: {
       commandFn: actions.removeToolState,
-      storeContexts: [],
-      options: {},
-    },
-    updateTableWithNewMeasurementData: {
-      commandFn: actions.updateTableWithNewMeasurementData,
       storeContexts: [],
       options: {},
     },


### PR DESCRIPTION
The updateTableWithNewMeasurementData is obsolete code from OHIFv2 and should be removed.  Checked that measurements still work and that there are no references anywhere to this code.