### PR TITLE
docs(OHIFv3): fix v3 branch name in getting-started

### DIFF
--- a/platform/docs/docs/development/getting-started.md
+++ b/platform/docs/docs/development/getting-started.md
@@ -53,7 +53,7 @@ following commands:
 
 ```bash
 # Switch to the v3 branch
-git switch feat/v2-main
+git switch v3-stable
 
 # Restore dependencies
 yarn install


### PR DESCRIPTION
* the getting started page has the wrong branch name for v3, this PR fixes this
* related forum discussion: https://community.ohif.org/t/building-v3-ohif/45

