### PR TITLE
feat: Add headers to prevent preflight requests

### DIFF
--- a/extensions/cornerstone/src/initWADOImageLoader.js
+++ b/extensions/cornerstone/src/initWADOImageLoader.js
@@ -38,6 +38,9 @@ export default function initWADOImageLoader(UserAuthenticationService) {
       // For now we use image/jls and image/x-jls because some servers still use the old type
       // http://dicom.nema.org/medical/dicom/current/output/html/part18.html
       const xhrRequestHeaders = {
+        // To prevent Preflight requests:
+        accept: 'multipart/related; type=application/octet-stream',
+        //
         //accept: 'multipart/related; type="image/x-jls"',
         // 'multipart/related; type="image/x-jls", multipart/related; type="image/jls"; transfer-syntax="1.2.840.10008.1.2.4.80", multipart/related; type="image/x-jls", multipart/related; type="application/octet-stream"; transfer-syntax=*',
       };


### PR DESCRIPTION
Adds relevant headers to the xhr to prevent preflight requests in the demo (which makes the demo load faster) - [Read more](https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request)