### PR TITLE
fix: remove temporary link element after csv download

### DIFF
--- a/extensions/measurement-tracking/src/_shared/downloadCSVReport.js
+++ b/extensions/measurement-tracking/src/_shared/downloadCSVReport.js
@@ -161,4 +161,5 @@ function _createAndDownloadFile(csvContent) {
   link.setAttribute('download', 'MeasurementReport.csv');
   document.body.appendChild(link);
   link.click();
+  document.body.removeChild(link);
 }


### PR DESCRIPTION
- the `_createAndDownloadFile` method in `extensions/measurement-tracking/src/_shared/downloadCSVReport.js` creates a temporary link element to download the data
- currently this temporary element is not removed after download, which leads to many `<a>` elements being appended to the body when performing multiple downloads
- with this PR the temporary element is removed after download
