### PR TITLE
verify extensions when constructing modes.

### DIFF
--- a/extensions/cornerstone/package.json
+++ b/extensions/cornerstone/package.json
@@ -32,7 +32,7 @@
     "test:unit:ci": "jest --ci --runInBand --collectCoverage"
   },
   "peerDependencies": {
-    "@ohif/core": "^0.50.0",
+    "@ohif/core": "^2.9.7",
     "@ohif/ui": "^0.50.0",
     "cornerstone-core": "2.6.0",
     "cornerstone-math": "0.1.9",

--- a/extensions/default/package.json
+++ b/extensions/default/package.json
@@ -30,7 +30,7 @@
     "start": "yarn run dev"
   },
   "peerDependencies": {
-    "@ohif/core": "^0.50.0",
+    "@ohif/core": "^2.9.7",
     "@ohif/i18n": "^0.52.8",
     "dcmjs": "0.16.1",
     "dicomweb-client": "^0.6.0",

--- a/extensions/dicom-sr/package.json
+++ b/extensions/dicom-sr/package.json
@@ -32,7 +32,7 @@
     "test:unit:ci": "jest --ci --runInBand --collectCoverage --passWithNoTests"
   },
   "peerDependencies": {
-    "@ohif/core": "^0.50.0",
+    "@ohif/core": "^2.9.7",
     "@ohif/ui": "^0.50.0",
     "cornerstone-core": "^2.6.0",
     "cornerstone-math": "^0.1.9",

--- a/extensions/dicom-sr/src/viewports/OHIFCornerstoneSRViewport.js
+++ b/extensions/dicom-sr/src/viewports/OHIFCornerstoneSRViewport.js
@@ -76,11 +76,7 @@ function OHIFCornerstoneSRViewport({
 
   // TODO: this is a hook that fails if we register/de-register
   //
-  if (
-    extensionManager.registeredExtensionIds.includes(
-      MEASUREMENT_TRACKING_EXTENSION_ID
-    )
-  ) {
+  if (extensionManager.getExtensionVersion(MEASUREMENT_TRACKING_EXTENSION_ID)) {
     const contextModule = extensionManager.getModuleEntry(
       '@ohif/extension-measurement-tracking.contextModule.TrackedMeasurementsContext'
     );

--- a/extensions/measurement-tracking/package.json
+++ b/extensions/measurement-tracking/package.json
@@ -30,7 +30,7 @@
     "start": "yarn run dev"
   },
   "peerDependencies": {
-    "@ohif/core": "^0.50.0",
+    "@ohif/core": "^2.9.7",
     "classnames": "^2.2.6",
     "cornerstone-core": "^2.6.0",
     "cornerstone-tools": "6.0.2",

--- a/modes/longitudinal/package.json
+++ b/modes/longitudinal/package.json
@@ -32,7 +32,7 @@
     "test:unit:ci": "jest --ci --runInBand --collectCoverage --passWithNoTests"
   },
   "peerDependencies": {
-    "@ohif/core": "^2.12.3",
+    "@ohif/core": "^2.9.7",
     "@ohif/extension-default": "1.0.1",
     "@ohif/extension-cornerstone": "3.0.0",
     "@ohif/extension-dicom-sr": "0.0.1",

--- a/platform/cli/templates/extension/dependencies.json
+++ b/platform/cli/templates/extension/dependencies.json
@@ -15,7 +15,7 @@
     "start": "yarn run dev"
   },
   "peerDependencies": {
-    "@ohif/core": "^0.50.0",
+    "@ohif/core": "^2.9.7",
     "@ohif/i18n": "^0.52.8",
     "prop-types": "^15.6.2",
     "react": "^17.0.2",

--- a/platform/cli/templates/mode/dependencies.json
+++ b/platform/cli/templates/mode/dependencies.json
@@ -17,7 +17,7 @@
     "test:unit:ci": "jest --ci --runInBand --collectCoverage --passWithNoTests"
   },
   "peerDependencies": {
-    "@ohif/core": "^2.12.3"
+    "@ohif/core": "^2.9.7"
   },
   "dependencies": {
     "@babel/runtime": "7.7.6"

--- a/platform/cli/templates/mode/src/index.js
+++ b/platform/cli/templates/mode/src/index.js
@@ -69,7 +69,7 @@ function modeFactory({ modeConfiguration }) {
       },
     ],
     /** List of extensions that are used by the modde */
-    extensions: ['org.ohif.default'],
+    extensions: { '@ohif/extension-default': '^1.0.1' },
     /** HangingProtocols used by the mode */
     hangingProtocols: [''],
     /** SopClassHandlers used by the mode */

--- a/platform/core/package.json
+++ b/platform/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ohif/core",
-  "version": "2.9.6",
+  "version": "2.9.7",
   "description": "Generic business logic for web-based medical imaging applications",
   "author": "OHIF Core Team",
   "license": "MIT",

--- a/platform/core/src/extensions/ExtensionManager.js
+++ b/platform/core/src/extensions/ExtensionManager.js
@@ -9,7 +9,7 @@ export default class ExtensionManager {
     appConfig = {},
   }) {
     this.modules = {};
-    this.registeredExtensionIds = [];
+    this.registeredExtensions = [];
     this.moduleTypeNames = Object.values(MODULE_TYPES);
     //
     this._commandsManager = commandsManager;
@@ -33,7 +33,7 @@ export default class ExtensionManager {
 
   onModeEnter() {
     const {
-      registeredExtensionIds,
+      registeredExtensions,
       _servicesManager,
       _commandsManager,
       _hotkeysManager,
@@ -50,7 +50,7 @@ export default class ExtensionManager {
     ViewportGridService.reset();
     HangingProtocolService.reset();
 
-    registeredExtensionIds.forEach(extensionId => {
+    registeredExtensions.forEach(({ extensionId }) => {
       const onModeEnter = _extensionLifeCycleHooks.onModeEnter[extensionId];
 
       if (typeof onModeEnter === 'function') {
@@ -65,7 +65,7 @@ export default class ExtensionManager {
 
   onModeExit() {
     const {
-      registeredExtensionIds,
+      registeredExtensions,
       _servicesManager,
       _commandsManager,
       _extensionLifeCycleHooks,
@@ -81,7 +81,7 @@ export default class ExtensionManager {
     ViewportGridService.reset();
     HangingProtocolService.reset();
 
-    registeredExtensionIds.forEach(extensionId => {
+    registeredExtensions.forEach(({ extensionId }) => {
       const onModeExit = _extensionLifeCycleHooks.onModeExit[extensionId];
 
       if (typeof onModeExit === 'function') {
@@ -102,8 +102,6 @@ export default class ExtensionManager {
   registerExtensions = (extensions, dataSources = []) => {
     extensions.forEach(extension => {
       const hasConfiguration = Array.isArray(extension);
-
-      debugger;
 
       if (hasConfiguration) {
         const [ohifExtension, configuration] = extension;
@@ -133,7 +131,7 @@ export default class ExtensionManager {
       throw new Error(`Extension ID not set`);
     }
 
-    if (this.registeredExtensionIds.includes(extensionId)) {
+    if (this.getExtensionVersion(extensionId)) {
       log.warn(
         `Extension ID ${extensionId} has already been registered. Exiting before duplicating modules.`
       );
@@ -209,7 +207,7 @@ export default class ExtensionManager {
     });
 
     // Track extension registration
-    this.registeredExtensionIds.push(extensionId);
+    this.registeredExtensions.push({ extensionId, version: extension.version });
   };
 
   getModuleEntry = stringEntry => {
@@ -232,6 +230,18 @@ export default class ExtensionManager {
 
   getDataSource = () => {
     return this.dataSourceMap[this.activeDataSource];
+  };
+
+  getExtensionVersion = extensionId => {
+    const registeredExtension = this.registeredExtensions.find(
+      extension => extension.extensionId === extensionId
+    );
+
+    if (!registeredExtension) {
+      return;
+    }
+
+    return registeredExtension.version;
   };
 
   /**

--- a/platform/core/src/extensions/ExtensionManager.test.js
+++ b/platform/core/src/extensions/ExtensionManager.test.js
@@ -131,7 +131,7 @@ describe('ExtensionManager.js', () => {
     });
 
     it('logs a warning if the extension has an id that has already been registered', () => {
-      const extension = { id: 'hello-world' };
+      const extension = { id: 'hello-world', version: '1.0.0' };
       extensionManager.registerExtension(extension);
 
       // SUT

--- a/platform/core/src/extensions/ExtensionManager.test.js
+++ b/platform/core/src/extensions/ExtensionManager.test.js
@@ -120,11 +120,14 @@ describe('ExtensionManager.js', () => {
     it('tracks which extensions have been registered', () => {
       const extension = {
         id: 'hello-world',
+        version: '1.0.0',
       };
 
       extensionManager.registerExtension(extension);
 
-      expect(extensionManager.registeredExtensionIds).toContain(extension.id);
+      expect(extensionManager.getExtensionVersion(extension.id)).toContain(
+        extension.version
+      );
     });
 
     it('logs a warning if the extension has an id that has already been registered', () => {

--- a/platform/core/src/utils/index.js
+++ b/platform/core/src/utils/index.js
@@ -20,6 +20,8 @@ import resolveObjectPath from './resolveObjectPath';
 import hierarchicalListUtils from './hierarchicalListUtils';
 import progressTrackingUtils from './progressTrackingUtils';
 import isLowPriorityModality from './isLowPriorityModality';
+import { isImage } from './isImage';
+import isDisplaySetReconstructable from '.isDisplaySetReconstructable';
 
 // Commented out unused functionality.
 // Need to implement new mechanism for dervived displaySets using the displaySetManager.
@@ -47,6 +49,8 @@ const utils = {
   hierarchicalListUtils,
   progressTrackingUtils,
   isLowPriorityModality,
+  isImage,
+  isDisplaySetReconstructable,
 };
 
 export {
@@ -70,6 +74,8 @@ export {
   hierarchicalListUtils,
   progressTrackingUtils,
   isLowPriorityModality,
+  isImage,
+  isDisplaySetReconstructable,
 };
 
 export default utils;

--- a/platform/core/src/utils/index.js
+++ b/platform/core/src/utils/index.js
@@ -21,7 +21,7 @@ import hierarchicalListUtils from './hierarchicalListUtils';
 import progressTrackingUtils from './progressTrackingUtils';
 import isLowPriorityModality from './isLowPriorityModality';
 import { isImage } from './isImage';
-import isDisplaySetReconstructable from '.isDisplaySetReconstructable';
+import isDisplaySetReconstructable from './isDisplaySetReconstructable';
 
 // Commented out unused functionality.
 // Need to implement new mechanism for dervived displaySets using the displaySetManager.

--- a/platform/core/src/utils/index.test.js
+++ b/platform/core/src/utils/index.test.js
@@ -15,6 +15,8 @@ describe('Top level exports', () => {
       'formatDate',
       'formatPN',
       //'loadAndCacheDerivedDisplaySets',
+      'isDisplaySetReconstructable',
+      'isImage',
       'DicomLoaderService',
       'urlUtil',
       'makeDeferred',

--- a/platform/docs/docs/platform/extensions/installation.md
+++ b/platform/docs/docs/platform/extensions/installation.md
@@ -81,7 +81,7 @@ the extension. The following lines of code should be added to the OHIF:
 "dependencies": {
   /* ... */
   "@babel/runtime": "7.7.6",
-  "@ohif/core": "^2.5.1",
+  "@ohif/core": "^2.9.7",
   "@ohif/extension-cornerstone": "^2.4.0",
   "@ohif/extension-measurement-tracking": "^0.0.1",
   "@ohif/extension-template": "^0.0.1",

--- a/platform/viewer/package.json
+++ b/platform/viewer/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@babel/runtime": "7.7.6",
-    "@ohif/core": "^2.5.1",
+    "@ohif/core": "^2.9.7",
     "@ohif/extension-cornerstone": "^2.4.0",
     "@ohif/extension-default": "1.0.1",
     "@ohif/extension-dicom-sr": "0.0.1",

--- a/platform/viewer/src/routes/buildModeRoutes.js
+++ b/platform/viewer/src/routes/buildModeRoutes.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import ModeRoute from '@routes/Mode';
+import checkExtensionDependencies from './checkExtensionDependencies';
 
 /*
   Routes uniquely define an entry point to:
@@ -44,6 +45,8 @@ export default function buildModeRoutes({
   });
 
   modes.forEach(mode => {
+    checkExtensionDependencies(mode, extensionManager);
+
     // todo: for each route. add route to path.
     dataSourceNames.forEach(dataSourceName => {
       const path = `/${mode.routeName}/${dataSourceName}`;

--- a/platform/viewer/src/routes/checkExtensionDependencies.js
+++ b/platform/viewer/src/routes/checkExtensionDependencies.js
@@ -1,0 +1,44 @@
+export default function checkExtensionDependencies(mode, extensionManager) {
+  const extensionDependencies = mode.extensions;
+
+  const dependencyString = `Unmet extension dependency in mode: ${mode.id}@${mode.version}`;
+
+  Object.keys(extensionDependencies).forEach(extensionId => {
+    const requiredVersion = extensionDependencies[extensionId];
+    const installedVersion = extensionManager.getExtensionVersion(extensionId);
+
+    if (!installedVersion) {
+      throw new Error(
+        `${dependencyString}: extension ${extensionId}@${requiredVersion} not found`
+      );
+    }
+
+    if (!areVersionsCompatible(requiredVersion, installedVersion)) {
+      throw new Error(
+        `${dependencyString}: required version @${requiredVersion} not met, found version ${installedVersion}`
+      );
+    }
+  });
+}
+
+function areVersionsCompatible(semanticVersion, installedVersion) {
+  if (semanticVersion.includes('^')) {
+    // Major must match
+    const versionLessCaret = semanticVersion.split('^')[1];
+
+    // Index 0 is the major version.
+    return versionLessCaret[0] === installedVersion[0];
+  } else if (semanticVersion.includes('~')) {
+    // Major and minor must match
+    const versionLessTilde = semanticVersion.split('~')[1];
+
+    // Index 0 is the major version.
+    // Index 2 is the minor version.
+    return (
+      versionLessTilde[0] === installedVersion[0] &&
+      versionLessTilde[2] === installedVersion[2]
+    );
+  } else {
+    return semanticVersion === installedVersion;
+  }
+}

--- a/platform/viewer/src/routes/index.js
+++ b/platform/viewer/src/routes/index.js
@@ -45,8 +45,6 @@ const createRoutes = ({
       hotkeysManager,
     }) || [];
 
-  debugger;
-
   const allRoutes = [...routes, ...bakedInRoutes];
 
   function RouteWithErrorBoundary({ route, ...rest }) {


### PR DESCRIPTION
When constructing modes, check all extension dependencies are correct.

This is useful when multiple modes use the same extensions, and we can throw if the one installed doesn't satisfy one of the modes (i.e. one of the modes needs to be upgraded in order to be compatible in the same OHIF build.