### PR TITLE
IDC: update dcmjs to version 0.19.3

### DIFF
--- a/extensions/cornerstone/package.json
+++ b/extensions/cornerstone/package.json
@@ -36,7 +36,7 @@
     "cornerstone-math": "^0.1.9",
     "cornerstone-tools": "^6.0.6",
     "cornerstone-wado-image-loader": "^4.1.0",
-    "dcmjs": "0.19.2",
+    "dcmjs": "0.19.3",
     "dicom-parser": "^1.8.11",
     "hammerjs": "^2.0.8",
     "prop-types": "^15.6.2",

--- a/extensions/dicom-html/package.json
+++ b/extensions/dicom-html/package.json
@@ -29,7 +29,7 @@
   },
   "peerDependencies": {
     "@ohif/core": "^0.50.0",
-    "dcmjs": "0.19.2",
+    "dcmjs": "0.19.3",
     "prop-types": "^15.6.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"

--- a/extensions/dicom-rt/package.json
+++ b/extensions/dicom-rt/package.json
@@ -31,7 +31,7 @@
     "@ohif/core": "^0.50.0",
     "cornerstone-core": "^2.6.1",
     "cornerstone-tools": "^6.0.6",
-    "dcmjs": "0.19.2",
+    "dcmjs": "0.19.3",
     "gl-matrix": "^3.3.0",
     "prop-types": "^15.6.2",
     "react": "^16.8.6",

--- a/extensions/dicom-segmentation/package.json
+++ b/extensions/dicom-segmentation/package.json
@@ -31,7 +31,7 @@
     "@ohif/core": "^0.50.0",
     "cornerstone-core": "^2.6.1",
     "cornerstone-tools": "^6.0.6",
-    "dcmjs": "0.19.2",
+    "dcmjs": "0.19.3",
     "prop-types": "^15.6.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"

--- a/extensions/dicom-tag-browser/package.json
+++ b/extensions/dicom-tag-browser/package.json
@@ -28,7 +28,7 @@
   },
   "peerDependencies": {
     "@ohif/core": "^2.6.0",
-    "dcmjs": "0.19.2",
+    "dcmjs": "0.19.3",
     "react": "^16.8.6"
   },
   "dependencies": {

--- a/extensions/vtk/package.json
+++ b/extensions/vtk/package.json
@@ -35,7 +35,7 @@
     "cornerstone-core": "^2.6.1",
     "cornerstone-tools": "^6.0.6",
     "cornerstone-wado-image-loader": "^4.1.0",
-    "dcmjs": "0.19.2",
+    "dcmjs": "0.19.3",
     "dicom-parser": "^1.8.11",
     "i18next": "^17.0.3",
     "i18next-browser-languagedetector": "^3.0.1",

--- a/platform/core/package.json
+++ b/platform/core/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@babel/runtime": "^7.5.5",
     "ajv": "^6.10.0",
-    "dcmjs": "0.19.2",
+    "dcmjs": "0.19.3",
     "dicomweb-client": "^0.8.3",
     "immer": "6.0.2",
     "isomorphic-base64": "^1.0.2",

--- a/platform/viewer/package.json
+++ b/platform/viewer/package.json
@@ -66,7 +66,7 @@
     "cornerstone-math": "^0.1.9",
     "cornerstone-tools": "^6.0.6",
     "cornerstone-wado-image-loader": "^4.1.0",
-    "dcmjs": "0.19.2",
+    "dcmjs": "0.19.3",
     "dicom-parser": "^1.8.11",
     "dicomweb-client": "^0.8.3",
     "hammerjs": "^2.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6937,10 +6937,10 @@ dateformat@^3.0.0:
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
 
-dcmjs@0.19.2:
-  version "0.19.2"
-  resolved "https://registry.yarnpkg.com/dcmjs/-/dcmjs-0.19.2.tgz#f3ff81797b17cdb2663dc8212f8a3d7dfd145ae2"
-  integrity sha512-FXdKHnCoaONbgZFwxchpXUhLHOtSdIWGtG2A0UDS72FmptHDDXQH017j1e5aVm0Q5ee+42c+W+xWwBScmSyE7w==
+dcmjs@0.19.3:
+  version "0.19.3"
+  resolved "https://registry.yarnpkg.com/dcmjs/-/dcmjs-0.19.3.tgz#8b0c3ea920a09d1646493504a711b32c7d54aec3"
+  integrity sha512-MpUQF7AIvyIa291i7WoQ1PUClNLes11XBFe9IOP02mNkmjWCptE7JuvpD2maSuVaMY48ZIi0krOdn1Y+M3OmqA==
   dependencies:
     "@babel/polyfill" "^7.8.3"
     "@babel/runtime" "^7.8.4"


### PR DESCRIPTION
Update to dcmjs 0.19.3. Fix: https://github.com/dcmjs-org/dcmjs/issues/232