### PR TITLE
Updated retrieveMetadataLoaderAsync to use WADO-RS

### DIFF
--- a/platform/core/src/studies/services/wado/retrieveMetadataLoaderAsync.js
+++ b/platform/core/src/studies/services/wado/retrieveMetadataLoaderAsync.js
@@ -75,7 +75,7 @@ export default class RetrieveMetadataLoaderAsync extends RetrieveMetadataLoader 
 
     const client = new StaticWadoClient({
       ...server,
-      url: server.qidoRoot,
+      url: server.wadoRoot,
       headers: DICOMWeb.getAuthorizationHeader(server),
       errorInterceptor: errorHandler.getHTTPErrorHandler(),
       requestHooks: [getXHRRetryRequestHook()],


### PR DESCRIPTION
Updated retrieveMetadataLoaderAsync to use WADO-RS instead of QIDO-RS

### PR Checklist

- [x] Brief description of changes
- [x] Links to any relevant issues
- [x] Required status checks are passing
- [ ] User cases if changes impact the user's experience
- [x] `@mention` a maintainer to request a review

<!--
  Links
  -->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
