### PR TITLE
Remove validNumber for photometricInterpretation key

### DIFF
--- a/platform/core/src/classes/MetadataProvider.js
+++ b/platform/core/src/classes/MetadataProvider.js
@@ -244,9 +244,7 @@ class MetadataProvider {
       case WADO_IMAGE_LOADER_TAGS.IMAGE_PIXEL_MODULE:
         metadata = {
           samplesPerPixel: validNumber(instance.SamplesPerPixel),
-          photometricInterpretation: validNumber(
-            instance.PhotometricInterpretation
-          ),
+          photometricInterpretation: instance.PhotometricInterpretation,
           rows: validNumber(instance.Rows),
           columns: validNumber(instance.Columns),
           bitsAllocated: validNumber(instance.BitsAllocated),


### PR DESCRIPTION
I've had issues visualizing WADO DICOM files that had the `imagePixelModule` tag for the Image Loader.

It used to work on the master branch and while diving in, I realized the problem came from trying to parse a string value to a number one.

According to the [DICOM standards](https://dicom.innolitics.com/ciods/ct-image/image-pixel/00280004), `photometricInterpretation` should be a string (ex. "RGB", "HSV"...). In V3, a validation on numbers was added to all keys of the metadata object, including `photometricInterpretation` which returns undefined if it does not parse to a number. 

This PR suggests to remove the `validNumber` check for that key.

looks like #2420 , https://github.com/OHIF/Viewers/issues/2426#issuecomment-887435505

Before:
<img width="1680" alt="Screenshot 2022-02-23 at 17 50 59" src="https://user-images.githubusercontent.com/29004228/155367039-0b77e44c-62f4-427b-8ae3-c41db18c8e60.png">

After:
<img width="1680" alt="Screenshot 2022-02-23 at 17 50 23" src="https://user-images.githubusercontent.com/29004228/155367101-02aace0a-6924-4797-be6d-6a39e22cc675.png">



### PR Checklist

- [x] Brief description of changes
- [x] Links to any relevant issues
- [x] Required status checks are passing
- [ ] User cases if changes impact the user's experience
- [ ] `@mention` a maintainer to request a review

<!--
  Links
  -->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
