### PR TITLE
fix(cli): fix issues when trying to link an extension or a mode

### DIFF
--- a/platform/cli/src/commands/utils/addToConfig.js
+++ b/platform/cli/src/commands/utils/addToConfig.js
@@ -7,7 +7,7 @@ import {
 
 function addToAndOverwriteConfig(packageName, options, augmentConfigFuntion) {
   const installedVersion = options.version;
-  const pluginConfig = readPluginConfigFile();
+  let pluginConfig = readPluginConfigFile();
 
   if (!pluginConfig) {
     pluginConfig = {

--- a/platform/cli/src/commands/utils/private/readPluginConfigFile.js
+++ b/platform/cli/src/commands/utils/private/readPluginConfigFile.js
@@ -3,13 +3,11 @@ import fs from 'fs';
 export default function readPluginConfigFile() {
   let fileContents;
 
-  fileContents = fs.readFileSync('./pluginConfig.json', { flag: 'r' }, function(
-    err
-  ) {
-    if (err) {
-      return; // File doesn't exist yet.
-    }
-  });
+  try {
+    fileContents = fs.readFileSync('./pluginConfig.json', { flag: 'r' });
+  } catch (err) {
+    return; // File doesn't exist yet.
+  }
 
   if (fileContents) {
     fileContents = JSON.parse(fileContents);

--- a/platform/cli/src/index.js
+++ b/platform/cli/src/index.js
@@ -106,7 +106,8 @@ program
     'Links a local OHIF extension to the Viewer to be used for development'
   )
   .action(packageDir => {
-    linkExtension(packageDir, { viewerDirectory });
+    const fullPackageDir = path.join(currentDirectory, packageDir);
+    linkExtension(fullPackageDir, { viewerDirectory });
   });
 
 program
@@ -122,7 +123,8 @@ program
     'Links a local OHIF mode to the Viewer to be used for development'
   )
   .action(packageDir => {
-    linkMode(packageDir, { viewerDirectory });
+    const fullPackageDir = path.join(currentDirectory, packageDir);
+    linkMode(fullPackageDir, { viewerDirectory });
   });
 
 program

--- a/platform/cli/templates/extension/dependencies.json
+++ b/platform/cli/templates/extension/dependencies.json
@@ -1,5 +1,6 @@
 {
   "repository": "OHIF/Viewers",
+  "keywords": ["ohif-extension"],
   "main": "dist/index.umd.js",
   "module": "src/index.js",
   "engines": {

--- a/platform/cli/templates/mode/dependencies.json
+++ b/platform/cli/templates/mode/dependencies.json
@@ -1,5 +1,6 @@
 {
   "repository": "OHIF/Viewers",
+  "keywords": ["ohif-mode"],
   "main": "dist/index.umd.js",
   "module": "src/index.js",
   "engines": {


### PR DESCRIPTION
Hi,
I tried to run the CLI from the `ohif-cli` branch and faced some issues while trying to link an extension to the viewer package.

Here is what is caused my issues: 
- The module path wasn't correctly handled.
- The generated package.json doesn't contain the `keywords` property which is required by the `linkPackage` function.
- And when there is no `pluginOptions`, it fails while reading the file or while generating a default configuration.

### PR Checklist

- [x] Brief description of changes
- [ ] Links to any relevant issues
- [ ] Required status checks are passing
- [ ] User cases if changes impact the user's experience
- [x] `@mention` a maintainer to request a review: maybe @sedghi ?

<!--
  Links
  -->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
