### PR TITLE
fix(dicom-json): Series metadata retrieve

### DIFF
--- a/extensions/default/src/DicomJSONDataSource/index.js
+++ b/extensions/default/src/DicomJSONDataSource/index.js
@@ -134,7 +134,7 @@ function createDicomJSONApi(dicomJsonConfig) {
     },
     retrieve: {
       series: {
-        metaData: ({
+        metadata: ({
           StudyInstanceUID,
           madeInClient = false,
           customSort,


### PR DESCRIPTION
There was a typo in DicomJSON datasource to retrieve metadata. This was
causing an error in Mode.jsx (line 52)
This is almost the same as in #2717 

### PR Checklist

- [x] Brief description of changes
- [ ] Links to any relevant issues
- [ ] Required status checks are passing
- [ ] User cases if changes impact the user's experience
- [x] `@mention` a maintainer to request a review: @sedghi as he did the mentioned PR.

<!--
  Links
  -->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
