### PR TITLE
fix(ohif-cli): Update generated files

### DIFF
--- a/.webpack/rules/cssToJavaScript.js
+++ b/.webpack/rules/cssToJavaScript.js
@@ -1,11 +1,14 @@
 const autoprefixer = require('autoprefixer');
 const path = require('path');
+const fs = require('fs');
 const tailwindcss = require('tailwindcss');
 const tailwindConfigPath = path.resolve(
   '../../platform/viewer/tailwind.config.js'
 );
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const devMode = process.env.NODE_ENV !== 'production';
+
+const withTailwind = fs.existsSync(tailwindConfigPath);
 
 const cssToJavaScript = {
   test: /\.css$/,
@@ -19,9 +22,9 @@ const cssToJavaScript = {
         postcssOptions: {
           verbose: true,
           plugins: [
-            [tailwindcss(tailwindConfigPath)],
+            withTailwind && [tailwindcss(tailwindConfigPath)],
             [autoprefixer('last 2 version', 'ie >= 11')],
-          ],
+          ].filter(Boolean),
         },
       },
     },

--- a/platform/cli/templates/extension/.webpack/webpack.dev.js
+++ b/platform/cli/templates/extension/.webpack/webpack.dev.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const webpackCommon = require('./../../../.webpack/webpack.base.js');
+const webpackCommon = require('./../../.webpack/webpack.base.js');
 const SRC_DIR = path.join(__dirname, '../src');
 const DIST_DIR = path.join(__dirname, '../dist');
 

--- a/platform/cli/templates/extension/.webpack/webpack.prod.js
+++ b/platform/cli/templates/extension/.webpack/webpack.prod.js
@@ -1,10 +1,9 @@
 const webpack = require('webpack');
 const { merge } = require('webpack-merge');
 const path = require('path');
-const webpackCommon = require('./../../../.webpack/webpack.base.js');
+const webpackCommon = require('./../../.webpack/webpack.base.js');
 const pkg = require('./../package.json');
 
-const ROOT_DIR = path.join(__dirname, './..');
 const SRC_DIR = path.join(__dirname, '../src');
 const DIST_DIR = path.join(__dirname, '../dist');
 
@@ -29,11 +28,11 @@ module.exports = (env, argv) => {
       sideEffects: true,
     },
     output: {
-      path: ROOT_DIR,
+      path: DIST_DIR,
       library: 'OHIFExtCornerstone',
       libraryTarget: 'umd',
       libraryExport: 'default',
-      filename: pkg.main,
+      filename: path.basename(pkg.main),
     },
     plugins: [
       new webpack.optimize.LimitChunkCountPlugin({

--- a/platform/cli/templates/extension/babel.config.js
+++ b/platform/cli/templates/extension/babel.config.js
@@ -1,1 +1,1 @@
-module.exports = require('../../babel.config.js');
+module.exports = require('../babel.config.js');

--- a/platform/cli/templates/extension/jest.config.js
+++ b/platform/cli/templates/extension/jest.config.js
@@ -1,4 +1,4 @@
-const base = require('../../jest.config.base.js');
+const base = require('../jest.config.base.js');
 const pkg = require('./package');
 
 module.exports = {

--- a/platform/cli/templates/mode/.webpack/webpack.dev.js
+++ b/platform/cli/templates/mode/.webpack/webpack.dev.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const webpackCommon = require('./../../../.webpack/webpack.base.js');
+const webpackCommon = require('./../../.webpack/webpack.base.js');
 const SRC_DIR = path.join(__dirname, '../src');
 const DIST_DIR = path.join(__dirname, '../dist');
 

--- a/platform/cli/templates/mode/.webpack/webpack.prod.js
+++ b/platform/cli/templates/mode/.webpack/webpack.prod.js
@@ -1,10 +1,9 @@
 const webpack = require('webpack');
 const { merge } = require('webpack-merge');
 const path = require('path');
-const webpackCommon = require('./../../../.webpack/webpack.base.js');
+const webpackCommon = require('./../../.webpack/webpack.base.js');
 const pkg = require('./../package.json');
 
-const ROOT_DIR = path.join(__dirname, './..');
 const SRC_DIR = path.join(__dirname, '../src');
 const DIST_DIR = path.join(__dirname, '../dist');
 
@@ -29,11 +28,11 @@ module.exports = (env, argv) => {
       sideEffects: true,
     },
     output: {
-      path: ROOT_DIR,
+      path: DIST_DIR,
       library: 'OHIFModeLongitudinal',
       libraryTarget: 'umd',
       libraryExport: 'default',
-      filename: pkg.main,
+      filename: path.basename(pkg.main),
     },
     plugins: [
       new webpack.optimize.LimitChunkCountPlugin({

--- a/platform/cli/templates/mode/babel.config.js
+++ b/platform/cli/templates/mode/babel.config.js
@@ -1,1 +1,1 @@
-module.exports = require('../../babel.config.js');
+module.exports = require('../babel.config.js');


### PR DESCRIPTION
Hi!
I'm still working on an extension, and I think I faced other issues.

Generated webpack, babel and jest configuration assume that extension or mode are created in extensions directory, which is not the case with the CLI. This commit updates the paths accordingly. 
Base webpack requires having a tailwind config in the directory, which is not mandatory. It is now used only if the file exists.
Also, `yarn build` on an extension removes directory sources and put generated code in place. This commit fixes that.

Please tell me if I misunderstood where extensions are supposed to be generated: it is generated at the root of the application when I run it locally

### PR Checklist

- [x] Brief description of changes
- [ ] Links to any relevant issues
- [ ] Required status checks are passing
- [ ] User cases if changes impact the user's experience
- [x] `@mention` a maintainer to request a review: @sedghi 

<!--
  Links
  -->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
