### PR TITLE
Idc2698

### DIFF
--- a/extensions/debugging/src/DebugReportModal.css
+++ b/extensions/debugging/src/DebugReportModal.css
@@ -24,3 +24,21 @@
   overflow: scroll;
   max-height: 300px;
 }
+
+.debug-overflowText {
+  margin: 0 auto;
+  max-width: 300px;
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+  hyphens: auto;
+}
+
+.debug-overflowText-border {
+  margin: 0 auto;
+  max-width: 300px;
+  border: solid 2px #ccc;
+  padding: 12px;
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+  hyphens: auto;
+}


### PR DESCRIPTION
Fix IDC https://github.com/OHIF/Viewers/issues/2698 and (as dicussed during the OHIF-IDC meeeting) adds information of viewports referenced Segs and RTSTRUCT series  in the debug dialog

Test datasets: 
https://viewer.imaging.datacommons.cancer.gov/viewer/1.3.6.1.4.1.14519.5.2.1.3671.4754.133806669697115873569905534398 
https://viewer.imaging.datacommons.cancer.gov/viewer/1.3.6.1.4.1.32722.99.99.203715003805996641695765332389135385095 
https://viewer.imaging.datacommons.cancer.gov/viewer/1.3.6.1.4.1.14519.5.2.1.6279.6001.224985459390356936417021464571

Screenshot:
![Screenshot-20220310105756-897x1018](https://user-images.githubusercontent.com/7985338/157641639-b09f6afd-d23f-462b-adec-86cabd7449cf.png)
![Screenshot-20220310110247-883x1175](https://user-images.githubusercontent.com/7985338/157641634-64e50a1b-4c74-4f32-b5cd-8eeb9d8962e1.png)


txt example from copytoClipboard:

```
============= SESSION INFO =============
 
== App ==
version	4.12.18
 
== Extensions Versions ==
generic-viewer-commands	4.12.18
cornerstone	2.12.7
measurements-table	4.12.18
vtk	1.12.16
html	1.3.18
microscopy	0.52.0
pdf	1.1.2
com.ohif.dicom-segmentation	0.7.8
rt	0.7.8
dicom-p10-downloader	0.3.1
 
== Browser Info ==
name	 chrome
os	 Linux
type	 browser
version	 99.0.4844
 
== URL ==
URL	 http://localhost:3000/viewer/1.3.6.1.4.1.32722.99.99.203715003805996641695765332389135385095
 
== Viewport Layout ==
Rows	1
Columns	1
 
== SeriesInstanceUIDs ==
[0,0]	1.3.6.1.4.1.32722.99.99.232988001551799080335895423941323261228
== ReferencedSEGSeriesInstanceUIDs ==
[0,0]	1.2.276.0.7230010.3.1.3.2323910823.11504.1597260515.421
== ReferencedRTSTRUCTSeriesInstanceUIDs ==
[0,0]	1.3.6.1.4.1.32722.99.99.243267551266911245830259417117543245931
```
