### PR TITLE
Update dependency: dcmjs@0.19.8

### DIFF
--- a/extensions/cornerstone/package.json
+++ b/extensions/cornerstone/package.json
@@ -36,7 +36,7 @@
     "cornerstone-math": "^0.1.9",
     "cornerstone-tools": "^6.0.6",
     "cornerstone-wado-image-loader": "^4.1.0",
-    "dcmjs": "0.19.7",
+    "dcmjs": "0.19.8",
     "dicom-parser": "^1.8.11",
     "hammerjs": "^2.0.8",
     "prop-types": "^15.6.2",

--- a/extensions/dicom-html/package.json
+++ b/extensions/dicom-html/package.json
@@ -29,7 +29,7 @@
   },
   "peerDependencies": {
     "@ohif/core": "^0.50.0",
-    "dcmjs": "0.19.7",
+    "dcmjs": "0.19.8",
     "prop-types": "^15.6.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"

--- a/extensions/dicom-rt/package.json
+++ b/extensions/dicom-rt/package.json
@@ -31,7 +31,7 @@
     "@ohif/core": "^0.50.0",
     "cornerstone-core": "^2.6.1",
     "cornerstone-tools": "^6.0.6",
-    "dcmjs": "0.19.7",
+    "dcmjs": "0.19.8",
     "gl-matrix": "^3.3.0",
     "prop-types": "^15.6.2",
     "react": "^16.8.6",

--- a/extensions/dicom-segmentation/package.json
+++ b/extensions/dicom-segmentation/package.json
@@ -31,7 +31,7 @@
     "@ohif/core": "^0.50.0",
     "cornerstone-core": "^2.6.1",
     "cornerstone-tools": "^6.0.6",
-    "dcmjs": "0.19.7",
+    "dcmjs": "0.19.8",
     "prop-types": "^15.6.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"

--- a/extensions/dicom-tag-browser/package.json
+++ b/extensions/dicom-tag-browser/package.json
@@ -28,7 +28,7 @@
   },
   "peerDependencies": {
     "@ohif/core": "^2.6.0",
-    "dcmjs": "0.19.7",
+    "dcmjs": "0.19.8",
     "react": "^16.8.6"
   },
   "dependencies": {

--- a/extensions/vtk/package.json
+++ b/extensions/vtk/package.json
@@ -35,7 +35,7 @@
     "cornerstone-core": "^2.6.1",
     "cornerstone-tools": "^6.0.6",
     "cornerstone-wado-image-loader": "^4.1.0",
-    "dcmjs": "0.19.7",
+    "dcmjs": "0.19.8",
     "dicom-parser": "^1.8.11",
     "i18next": "^17.0.3",
     "i18next-browser-languagedetector": "^3.0.1",

--- a/platform/core/package.json
+++ b/platform/core/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@babel/runtime": "^7.5.5",
     "ajv": "^6.10.0",
-    "dcmjs": "0.19.7",
+    "dcmjs": "0.19.8",
     "dicomweb-client": "^0.8.3",
     "immer": "9.0.12",
     "isomorphic-base64": "^1.0.2",

--- a/platform/viewer/package.json
+++ b/platform/viewer/package.json
@@ -66,7 +66,7 @@
     "cornerstone-math": "^0.1.9",
     "cornerstone-tools": "^6.0.6",
     "cornerstone-wado-image-loader": "^4.1.0",
-    "dcmjs": "0.19.7",
+    "dcmjs": "0.19.8",
     "dicom-parser": "^1.8.11",
     "dicomweb-client": "^0.8.3",
     "hammerjs": "^2.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5449,10 +5449,10 @@ dateformat@^3.0.0:
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
 
-dcmjs@0.19.7:
-  version "0.19.7"
-  resolved "https://registry.yarnpkg.com/dcmjs/-/dcmjs-0.19.7.tgz#f7cf160d00871450dc3099dc5a76c9e719ef3e79"
-  integrity sha512-igvLdaAr4S4Cnvo3SphKSl1j9wXWpXMA3gWTpx999VM2m7CU65X81raRtNeZHldd5EVc6m7hB6GpbFr0t09ViQ==
+dcmjs@0.19.8:
+  version "0.19.8"
+  resolved "https://registry.yarnpkg.com/dcmjs/-/dcmjs-0.19.8.tgz#9be7471f8f2e20d4e09489b5f0c51dfa56621ec1"
+  integrity sha512-po/GWh7pXF+diO/umpqOfpF0Kk7MzAmhFlscOR+KchCIZbN0pmt2npFT3p8jMii/FBre++k+8PIvFa/LKh0P2A==
   dependencies:
     "@babel/polyfill" "^7.8.3"
     "@babel/runtime" "^7.8.4"


### PR DESCRIPTION
dcmjs
  * @ohif/core: 0.19.7 → 0.19.8
  * @ohif/extension-cornerstone: 0.19.7 → 0.19.8
  * @ohif/extension-dicom-html: 0.19.7 → 0.19.8
  * @ohif/extension-dicom-rt: 0.19.7 → 0.19.8
  * @ohif/extension-dicom-segmentation: 0.19.7 → 0.19.8
  * @ohif/extension-dicom-tag-browser: 0.19.7 → 0.19.8
  * @ohif/extension-vtk: 0.19.7 → 0.19.8
  * @ohif/viewer: 0.19.7 → 0.19.8

### PR Checklist

- [ ] Brief description of changes
- [ ] Links to any relevant issues
- [ ] Required status checks are passing
- [ ] User cases if changes impact the user's experience
- [ ] `@mention` a maintainer to request a review

<!--
  Links
  -->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
