### PR TITLE
Pass basename to BrowserRouter - Fixes #2769

### DIFF
--- a/platform/viewer/src/App.jsx
+++ b/platform/viewer/src/App.jsx
@@ -87,7 +87,7 @@ function App({ config, defaultExtensions, defaultModes }) {
 
   return (
     <CombinedProviders>
-      <BrowserRouter>
+      <BrowserRouter basename={routerBasename}>
         {authRoutes}
         {appRoutes}
       </BrowserRouter>


### PR DESCRIPTION
Fix build when PUBLIC_URL is defined

Pass basename to BrowserRouter

https://github.com/OHIF/Viewers/issues/2769

<!--
  Links
  -->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
