### PR TITLE
Fix: Thumbnails display fix

### DIFF
--- a/platform/ui/src/components/StudyBrowser/StudyBrowser.jsx
+++ b/platform/ui/src/components/StudyBrowser/StudyBrowser.jsx
@@ -105,7 +105,7 @@ const StudyBrowser = ({
           })}
         </ButtonGroup>
       </div>
-      <div className="flex flex-col flex-1 overflow-auto">
+      <div className="flex flex-col flex-1 overflow-auto ohif-scrollbar ">
         {getTabContent()}
       </div>
     </React.Fragment>

--- a/platform/ui/src/components/ThumbnailList/ThumbnailList.jsx
+++ b/platform/ui/src/components/ThumbnailList/ThumbnailList.jsx
@@ -11,7 +11,7 @@ const ThumbnailList = ({
   onClickUntrack,
 }) => {
   return (
-    <div className="py-3 bg-black overflow-y-hidden ohif-scrollbar">
+    <div className="py-3 bg-black overflow-y-hidden ohif-scrollbar" style={{ minHeight: '210px' }}>
       {thumbnails.map(
         ({
           displaySetInstanceUID,


### PR DESCRIPTION
Fixing the Thumbnails display refered here : https://github.com/OHIF/Viewers/issues/2796

You can compare the display here : 
Before =>
![bugged](https://user-images.githubusercontent.com/101793092/167844357-757b317f-b006-489e-b719-385444f3a2f3.png)

After => 
![Fixed_with_scrollbar](https://user-images.githubusercontent.com/101793092/167844402-72181a4e-1fec-4209-8783-d2b74a120b76.png)

As you can see I've just set a minimum size for the thumbnail to show and added the ohif-scroll bar css to the StudyBrowser component. 