### PR TITLE
fix thumbnails too small in case of long list

### DIFF
--- a/platform/ui/src/components/ThumbnailList/ThumbnailList.tsx
+++ b/platform/ui/src/components/ThumbnailList/ThumbnailList.tsx
@@ -11,7 +11,7 @@ const ThumbnailList = ({
   activeDisplaySetInstanceUIDs = [],
 }) => {
   return (
-    <div className="py-3 bg-black overflow-y-hidden ohif-scrollbar">
+    <div className="py-3 bg-black overflow-y-hidden ohif-scrollbar" style={{ minHeight: '210px' }}>
       {thumbnails.map(
         ({
           displaySetInstanceUID,


### PR DESCRIPTION
Add a minimum height for thumbnail list, as the user can select an image in case of a long list of studies (adding a minimum height to interact)
 
discussed at #2798  (made a cleaner PR with the current v3 stable branch). (#2798 can be closed)

Probably also @sedghi for review