### PR TITLE
fix: ohif cli bug for linking

### DIFF
--- a/platform/cli/src/commands/linkPackage.js
+++ b/platform/cli/src/commands/linkPackage.js
@@ -36,10 +36,13 @@ async function linkPackage(packageDir, options, addToConfig, keyword) {
   results = await execa(`yarn`, ['link']);
 
   // change directory to OHIF Platform root and execute yarn link
-  process.chdir(viewerDirectory);
+  process.chdir(`${viewerDirectory}/../..`);
 
   results = await execa(`yarn`, ['link', packageName]);
   console.log(results.stdout);
+
+  // change directory to viewer packages and add the config item
+  process.chdir(viewerDirectory);
   addToConfig(packageName, { version });
 }
 

--- a/platform/cli/templates/extension/dependencies.json
+++ b/platform/cli/templates/extension/dependencies.json
@@ -1,7 +1,7 @@
 {
   "repository": "OHIF/Viewers",
   "keywords": ["ohif-extension"],
-  "module": "src/index.js",
+  "module": "src/index.tsx",
   "engines": {
     "node": ">=14",
     "npm": ">=6",
@@ -42,6 +42,7 @@
     "babel-plugin-inline-react-svg": "^2.0.1",
     "@babel/preset-env": "^7.5.0",
     "@babel/preset-react": "^7.0.0",
+    "@babel/preset-typescript": "^7.18.6",
     "babel-eslint": "^8.0.3",
     "babel-loader": "^8.0.0-beta.4",
     "clean-webpack-plugin": "^4.0.0",

--- a/platform/cli/templates/mode/dependencies.json
+++ b/platform/cli/templates/mode/dependencies.json
@@ -1,7 +1,7 @@
 {
   "repository": "OHIF/Viewers",
   "keywords": ["ohif-mode"],
-  "module": "src/index.js",
+  "module": "src/index.tsx",
   "engines": {
     "node": ">=14",
     "npm": ">=6",


### PR DESCRIPTION
Make the cli linkages in the OHIF root directory node modules, rather than in a sub-directory.  This makes it more consistent for yarn (really, yarn should do this automatically, but doesn't).  Otherwise, you get differences between linked and package modules that can cause conflicts.