### PR TITLE
fix: cornerstone cache race condition

### DIFF
--- a/extensions/cornerstone/src/Viewport/OHIFCornerstoneViewport.tsx
+++ b/extensions/cornerstone/src/Viewport/OHIFCornerstoneViewport.tsx
@@ -232,22 +232,22 @@ const OHIFCornerstoneViewport = React.memo(props => {
     }
 
     const loadViewportData = async () => {
-      const viewportData = await CornerstoneCacheService.getViewportData(
+      await CornerstoneCacheService.getViewportData(
         viewportIndex,
         displaySets,
         viewportOptions.viewportType,
         dataSource,
+        (viewportDataLoaded) => {
+          CornerstoneViewportService.setViewportDisplaySets(
+            viewportIndex,
+            viewportDataLoaded,
+            viewportOptions,
+            displaySetOptions
+          );
+          setViewportData(viewportDataLoaded);
+        },
         initialImageIndex
       );
-
-      CornerstoneViewportService.setViewportDisplaySets(
-        viewportIndex,
-        viewportData,
-        viewportOptions,
-        displaySetOptions
-      );
-
-      setViewportData(viewportData);
     };
 
     loadViewportData();

--- a/extensions/cornerstone/src/Viewport/Overlays/ViewportOrientationMarkers.tsx
+++ b/extensions/cornerstone/src/Viewport/Overlays/ViewportOrientationMarkers.tsx
@@ -137,7 +137,7 @@ function ViewportOrientationMarkers({
       }
 
       const imageIndex = imageSliceData.imageIndex;
-      const imageId = viewportData?.imageIds[imageIndex];
+      const imageId = viewportData.imageIds?.[imageIndex];
 
       // Workaround for below TODO stub
       if (!imageId) {

--- a/extensions/cornerstone/src/services/ViewportService/CornerstoneCacheService.ts
+++ b/extensions/cornerstone/src/services/ViewportService/CornerstoneCacheService.ts
@@ -32,6 +32,8 @@ const EVENTS = {
   VIEWPORT_DATA_CHANGED: 'event::cornerstone::viewportdatachanged',
 };
 
+export type IViewportData = StackData | VolumeData;
+
 class CornerstoneCacheService {
   stackImageIds: Map<string, string[]> = new Map();
   volumeImageIds: Map<string, string[]> = new Map();
@@ -57,10 +59,11 @@ class CornerstoneCacheService {
     displaySets: unknown[],
     viewportType: string,
     dataSource: unknown,
+    callback: (val: IViewportData) => unknown,
     initialImageIndex?: number
   ): Promise<StackData | VolumeData> {
     const cs3DViewportType = getCornerstoneViewportType(viewportType);
-    let viewportData: StackData | VolumeData;
+    let viewportData: IViewportData;
 
     if (cs3DViewportType === Enums.ViewportType.STACK) {
       viewportData = await this._getStackViewportData(
@@ -76,6 +79,8 @@ class CornerstoneCacheService {
 
     viewportData.viewportType = cs3DViewportType;
 
+    await callback(viewportData);
+
     this._broadcastEvent(this.EVENTS.VIEWPORT_DATA_CHANGED, {
       viewportData,
       viewportIndex,
@@ -83,7 +88,6 @@ class CornerstoneCacheService {
 
     return viewportData;
   }
-
   public async invalidateViewportData(
     viewportData: VolumeData,
     invalidatedDisplaySetInstanceUID: string,


### PR DESCRIPTION
In the cornerstone cache service, the viewport data changed was fired before the viewport data was actually fully changed.
Also, in panelPetSUV, the panel was being updated on display set changed, which was incorrect, because it actually depends on the viewport data changed event.  Updated it so that panel also uses the viewport data changed event.