### PR TITLE
fix: displaySetService no event not needed

### DIFF
--- a/extensions/cornerstone/src/services/ViewportService/CornerstoneViewportService.ts
+++ b/extensions/cornerstone/src/services/ViewportService/CornerstoneViewportService.ts
@@ -168,12 +168,14 @@ class CornerstoneViewportService implements IViewportService {
     const viewportInfo = this.viewportsInfo.get(viewportIndex);
     viewportInfo.setRenderingEngineId(renderingEngine.id);
 
-    const { viewportOptions, displaySetOptions } =
-      this._getViewportAndDisplaySetOptions(
-        publicViewportOptions,
-        publicDisplaySetOptions,
-        viewportInfo
-      );
+    const {
+      viewportOptions,
+      displaySetOptions,
+    } = this._getViewportAndDisplaySetOptions(
+      publicViewportOptions,
+      publicDisplaySetOptions,
+      viewportInfo
+    );
 
     viewportInfo.setViewportOptions(viewportOptions);
     viewportInfo.setDisplaySetOptions(displaySetOptions);
@@ -267,9 +269,7 @@ class CornerstoneViewportService implements IViewportService {
     viewportInfo: ViewportInfo
   ) {
     const displaySetOptions = viewportInfo.getDisplaySetOptions();
-    const viewportOptions = viewportInfo.getViewportOptions();
     const { imageIds, initialImageIndex } = viewportData;
-    const { hangingProtocolService } = this;
 
     let initialImageIndexToUse = initialImageIndex;
 
@@ -418,8 +418,9 @@ class CornerstoneViewportService implements IViewportService {
     ) {
       const { index, preset } = initialImageOptions;
 
-      const { numberOfSlices } =
-        csUtils.getImageSliceDataForVolumeViewport(viewport);
+      const { numberOfSlices } = csUtils.getImageSliceDataForVolumeViewport(
+        viewport
+      );
 
       const imageIndex = this._getInitialImageIndex(
         numberOfSlices,
@@ -555,7 +556,7 @@ class CornerstoneViewportService implements IViewportService {
   ): {
     viewportOptions: ViewportOptions;
     displaySetOptions: DisplaySetOptions[];
-    } {
+  } {
     const viewportIndex = viewportInfo.getViewportIndex();
 
     // Creating a temporary viewportInfo to handle defaults

--- a/extensions/cornerstone/src/utils/interleaveCenterLoader.ts
+++ b/extensions/cornerstone/src/utils/interleaveCenterLoader.ts
@@ -8,8 +8,8 @@ const viewportIdVolumeInputArrayMap = new Map<string, unknown[]>();
 
 /**
  * This function caches the volumeUIDs until all the volumes inside the
- * hangging protocol are initialized. Then it goes through the imageIds
- * of the volumes, and interleav them, in order for the volumes to be loaded
+ * hanging protocol are initialized. Then it goes through the imageIds
+ * of the volumes, and interleave them, in order for the volumes to be loaded
  * together from middle to the start and the end.
  * @param {Object} props image loading properties from Cornerstone ViewportService
  * @returns
@@ -17,7 +17,7 @@ const viewportIdVolumeInputArrayMap = new Map<string, unknown[]>();
 export default function interleaveCenterLoader({
   data: { viewportId, volumeInputArray },
   displaySetsMatchDetails,
-  matchDetails,
+  viewportMatchDetails: matchDetails,
 }) {
   viewportIdVolumeInputArrayMap.set(viewportId, volumeInputArray);
 

--- a/extensions/cornerstone/src/utils/interleaveTopToBottom.ts
+++ b/extensions/cornerstone/src/utils/interleaveTopToBottom.ts
@@ -16,7 +16,7 @@ const viewportIdVolumeInputArrayMap = new Map<string, unknown[]>();
 export default function interleaveTopToBottom({
   data: { viewportId, volumeInputArray },
   displaySetsMatchDetails,
-  matchDetails,
+  viewportMatchDetails: matchDetails,
 }) {
   viewportIdVolumeInputArrayMap.set(viewportId, volumeInputArray);
 

--- a/extensions/default/src/DicomWebDataSource/index.js
+++ b/extensions/default/src/DicomWebDataSource/index.js
@@ -473,10 +473,11 @@ function createDicomWebApi(dicomWebConfig, UserAuthenticationService) {
 
       DicomMetadataStore.addSeriesMetadata(seriesSummaryMetadata, madeInClient);
 
-      const seriesDeliveredPromises = seriesPromises.map(
-        promise => promise.then(instances => {
+      const seriesDeliveredPromises = seriesPromises.map(promise =>
+        promise.then(instances => {
           storeInstances(instances);
-        }));
+        })
+      );
       await Promise.all(seriesDeliveredPromises);
       setSuccessFlag();
     },

--- a/extensions/tmtv/src/Panels/PanelPetSUV.tsx
+++ b/extensions/tmtv/src/Panels/PanelPetSUV.tsx
@@ -28,6 +28,7 @@ export default function PanelPetSUV({ servicesManager, commandsManager }) {
     DisplaySetService,
     ToolGroupService,
     ToolBarService,
+    HangingProtocolService,
   } = servicesManager.services;
   const [metadata, setMetadata] = useState(DEFAULT_MEATADATA);
   const [ptDisplaySet, setPtDisplaySet] = useState(null);
@@ -52,8 +53,10 @@ export default function PanelPetSUV({ servicesManager, commandsManager }) {
     [metadata]
   );
 
-  const getMatchingPTDisplaySet = useCallback(() => {
-    const ptDisplaySet = commandsManager.runCommand('getMatchingPTDisplaySet');
+  const getMatchingPTDisplaySet = useCallback(viewportMatchDetails => {
+    const ptDisplaySet = commandsManager.runCommand('getMatchingPTDisplaySet', {
+      viewportMatchDetails,
+    });
 
     if (!ptDisplaySet) {
       return;
@@ -70,13 +73,13 @@ export default function PanelPetSUV({ servicesManager, commandsManager }) {
   }, []);
 
   useEffect(() => {
-    const displaySets = DisplaySetService.activeDisplaySets;
-
+    const displaySets = DisplaySetService.getActiveDisplaySets();
+    const { viewportMatchDetails } = HangingProtocolService.getMatchDetails();
     if (!displaySets.length) {
       return;
     }
 
-    const displaySetInfo = getMatchingPTDisplaySet();
+    const displaySetInfo = getMatchingPTDisplaySet(viewportMatchDetails);
 
     if (!displaySetInfo) {
       return;
@@ -89,10 +92,10 @@ export default function PanelPetSUV({ servicesManager, commandsManager }) {
 
   // get the patientMetadata from the StudyInstanceUIDs and update the state
   useEffect(() => {
-    const { unsubscribe } = DisplaySetService.subscribe(
-      DisplaySetService.EVENTS.DISPLAY_SETS_ADDED,
-      () => {
-        const displaySetInfo = getMatchingPTDisplaySet();
+    const { unsubscribe } = HangingProtocolService.subscribe(
+      HangingProtocolService.EVENTS.PROTOCOL_CHANGED,
+      ({ viewportMatchDetails }) => {
+        const displaySetInfo = getMatchingPTDisplaySet(viewportMatchDetails);
 
         if (!displaySetInfo) {
           return;

--- a/extensions/tmtv/src/Panels/PanelPetSUV.tsx
+++ b/extensions/tmtv/src/Panels/PanelPetSUV.tsx
@@ -33,27 +33,24 @@ export default function PanelPetSUV({ servicesManager, commandsManager }) {
   const [metadata, setMetadata] = useState(DEFAULT_MEATADATA);
   const [ptDisplaySet, setPtDisplaySet] = useState(null);
 
-  const handleMetadataChange = useCallback(
-    metadata => {
-      setMetadata(prevState => {
-        const newState = { ...prevState };
-        Object.keys(metadata).forEach(key => {
-          if (typeof metadata[key] === 'object') {
-            newState[key] = {
-              ...prevState[key],
-              ...metadata[key],
-            };
-          } else {
-            newState[key] = metadata[key];
-          }
-        });
-        return newState;
+  const handleMetadataChange = metadata => {
+    setMetadata(prevState => {
+      const newState = { ...prevState };
+      Object.keys(metadata).forEach(key => {
+        if (typeof metadata[key] === 'object') {
+          newState[key] = {
+            ...prevState[key],
+            ...metadata[key],
+          };
+        } else {
+          newState[key] = metadata[key];
+        }
       });
-    },
-    [metadata]
-  );
+      return newState;
+    });
+  };
 
-  const getMatchingPTDisplaySet = useCallback(viewportMatchDetails => {
+  const getMatchingPTDisplaySet = viewportMatchDetails => {
     const ptDisplaySet = commandsManager.runCommand('getMatchingPTDisplaySet', {
       viewportMatchDetails,
     });
@@ -70,7 +67,7 @@ export default function PanelPetSUV({ servicesManager, commandsManager }) {
       ptDisplaySet,
       metadata,
     };
-  }, []);
+  };
 
   useEffect(() => {
     const displaySets = DisplaySetService.getActiveDisplaySets();

--- a/extensions/tmtv/src/Panels/PanelPetSUV.tsx
+++ b/extensions/tmtv/src/Panels/PanelPetSUV.tsx
@@ -97,7 +97,6 @@ export default function PanelPetSUV({ servicesManager, commandsManager }) {
         if (!displaySetInfo) {
           return;
         }
-
         const { ptDisplaySet, metadata } = displaySetInfo;
         setPtDisplaySet(ptDisplaySet);
         setMetadata(metadata);

--- a/extensions/tmtv/src/commandsModule.js
+++ b/extensions/tmtv/src/commandsModule.js
@@ -41,9 +41,9 @@ const commandsModule = ({
   }
 
   function _getMatchedViewportsToolGroupIds() {
-    const [matchedViewports] = HangingProtocolService.getState();
+    const { viewportMatchDetails } = HangingProtocolService.getMatchDetails();
     const toolGroupIds = [];
-    matchedViewports.forEach(({ viewportOptions }) => {
+    viewportMatchDetails.forEach(({ viewportOptions }) => {
       const { toolGroupId } = viewportOptions;
       if (toolGroupIds.indexOf(toolGroupId) === -1) {
         toolGroupIds.push(toolGroupId);
@@ -54,33 +54,30 @@ const commandsModule = ({
   }
 
   const actions = {
-    getMatchingPTDisplaySet: () => {
+    getMatchingPTDisplaySet: ({ viewportMatchDetails }) => {
       // Todo: this is assuming that the hanging protocol has successfully matched
       // the correct PT. For future, we should have a way to filter out the PTs
       // that are in the viewer layout (but then we have the problem of the attenuation
       // corrected PT vs the non-attenuation correct PT)
-      const matches = HangingProtocolService.getDisplaySetsMatchDetails();
-
-      const matchedSeriesInstanceUIDs = Array.from(matches.values()).map(
-        ({ SeriesInstanceUID }) => SeriesInstanceUID
-      );
 
       let ptDisplaySet = null;
-      for (const SeriesInstanceUID of matchedSeriesInstanceUIDs) {
-        const displaySets = DisplaySetService.getDisplaySetsForSeries(
-          SeriesInstanceUID
+      for (const matched of viewportMatchDetails) {
+        const { displaySetsInfo } = matched;
+        const displaySets = displaySetsInfo.map(({ displaySetInstanceUID }) =>
+          DisplaySetService.getDisplaySetByUID(displaySetInstanceUID)
         );
 
         if (!displaySets || displaySets.length === 0) {
           continue;
         }
 
-        const displaySet = displaySets[0];
-        if (displaySet.Modality !== 'PT') {
-          continue;
-        }
+        ptDisplaySet = displaySets.find(
+          displaySet => displaySet.Modality === 'PT'
+        );
 
-        ptDisplaySet = displaySet;
+        if (ptDisplaySet) {
+          break;
+        }
       }
 
       return ptDisplaySet;

--- a/extensions/tmtv/src/commandsModule.js
+++ b/extensions/tmtv/src/commandsModule.js
@@ -118,7 +118,10 @@ const commandsModule = ({
     createNewLabelmapFromPT: async () => {
       // Create a segmentation of the same resolution as the source data
       // using volumeLoader.createAndCacheDerivedVolume.
-      const ptDisplaySet = actions.getMatchingPTDisplaySet();
+      const { viewportMatchDetails } = HangingProtocolService.getMatchDetails();
+      const ptDisplaySet = actions.getMatchingPTDisplaySet({
+        viewportMatchDetails,
+      });
 
       if (!ptDisplaySet) {
         UINotificationService.error('No matching PT display set found');
@@ -562,8 +565,11 @@ const commandsModule = ({
     },
     setFusionPTColormap: ({ toolGroupId, colormap }) => {
       const toolGroup = ToolGroupService.getToolGroup(toolGroupId);
+      const { viewportMatchDetails } = HangingProtocolService.getMatchDetails();
 
-      const ptDisplaySet = actions.getMatchingPTDisplaySet();
+      const ptDisplaySet = actions.getMatchingPTDisplaySet({
+        viewportMatchDetails,
+      });
 
       if (!ptDisplaySet) {
         return;

--- a/modes/tmtv/src/index.js
+++ b/modes/tmtv/src/index.js
@@ -100,17 +100,19 @@ function modeFactory({ modeConfiguration }) {
           // For fusion toolGroup we need to add the volumeIds for the crosshairs
           // since in the fusion viewport we don't want both PT and CT to render MIP
           // when slabThickness is modified
-          const matches = HangingProtocolService.getDisplaySetsMatchDetails();
+          const {
+            displaySetMatchDetails,
+          } = HangingProtocolService.getMatchDetails();
 
           setCrosshairsConfiguration(
-            matches,
+            displaySetMatchDetails,
             toolNames,
             ToolGroupService,
             DisplaySetService
           );
 
           setFusionActiveVolume(
-            matches,
+            displaySetMatchDetails,
             toolNames,
             ToolGroupService,
             DisplaySetService

--- a/platform/core/src/services/DicomMetadataStore/DicomMetadataStore.js
+++ b/platform/core/src/services/DicomMetadataStore/DicomMetadataStore.js
@@ -214,7 +214,7 @@ const BaseImplementation = {
       // Will typically be undefined with a compliant DICOMweb server, reset later
       study.StudyDescription = seriesSummaryMetadata[0].StudyDescription;
       seriesSummaryMetadata.forEach(item => {
-        if (study.ModalitiesInStudy.indexOf(item.Modality) == -1) {
+        if (study.ModalitiesInStudy.indexOf(item.Modality) === -1) {
           study.ModalitiesInStudy.push(item.Modality);
         }
       });

--- a/platform/core/src/services/DicomMetadataStore/createStudyMetadata.js
+++ b/platform/core/src/services/DicomMetadataStore/createStudyMetadata.js
@@ -41,7 +41,9 @@ function createStudyMetadata(StudyInstanceUID) {
      */
     addInstancesToSeries: function(instances) {
       const { SeriesInstanceUID } = instances[0];
-      if (!this.StudyDescription) this.StudyDescription = instances[0].StudyDescription;
+      if (!this.StudyDescription) {
+        this.StudyDescription = instances[0].StudyDescription;
+      }
       const existingSeries = this.series.find(
         s => s.SeriesInstanceUID === SeriesInstanceUID
       );

--- a/platform/core/src/services/DisplaySetService/DisplaySetService.js
+++ b/platform/core/src/services/DisplaySetService/DisplaySetService.js
@@ -33,7 +33,6 @@ export default class DisplaySetService {
     this.activeDisplaySets = [];
     this.listeners = {};
     this.EVENTS = EVENTS;
-    this._suppressDisplaySetsChangedEvent = false;
 
     Object.assign(this, pubSubServiceInterface);
   }
@@ -42,7 +41,6 @@ export default class DisplaySetService {
     this.extensionManager = extensionManager;
     this.SOPClassHandlerIds = SOPClassHandlerIds;
     this.activeDisplaySets = [];
-    this._suppressDisplaySetsChangedEvent = false;
   }
 
   _addDisplaySetsToCache(displaySets) {
@@ -119,9 +117,7 @@ export default class DisplaySetService {
     displaySetCache.splice(displaySetCacheIndex, 1);
     activeDisplaySets.splice(activeDisplaySetsIndex, 1);
 
-    if (!this._suppressDisplaySetsChangedEvent) {
-      this._broadcastEvent(EVENTS.DISPLAY_SETS_CHANGED, this.activeDisplaySets);
-    }
+    this._broadcastEvent(EVENTS.DISPLAY_SETS_CHANGED, this.activeDisplaySets);
     this._broadcastEvent(EVENTS.DISPLAY_SETS_REMOVED, {
       displaySetInstanceUIDs: [displaySetInstanceUID],
     });
@@ -184,12 +180,7 @@ export default class DisplaySetService {
     // TODO: This is tricky. How do we know we're not resetting to the same/existing DSs?
     // TODO: This is likely run anytime we touch DicomMetadataStore. How do we prevent unnecessary broadcasts?
     if (displaySetsAdded && displaySetsAdded.length) {
-      if (!madeInClient && !this._suppressDisplaySetsChangedEvent) {
-        this._broadcastEvent(
-          EVENTS.DISPLAY_SETS_CHANGED,
-          this.activeDisplaySets
-        );
-      }
+      this._broadcastEvent(EVENTS.DISPLAY_SETS_CHANGED, this.activeDisplaySets);
       this._broadcastEvent(EVENTS.DISPLAY_SETS_ADDED, {
         displaySetsAdded,
         options,
@@ -198,15 +189,6 @@ export default class DisplaySetService {
       return displaySetsAdded;
     }
   };
-
-  suppressDisplaySetsChangedEvent() {
-    this._suppressDisplaySetsChangedEvent = true;
-  }
-
-  broadcastDisplaySetsChangedEvent() {
-    this._suppressDisplaySetsChangedEvent = false;
-    this._broadcastEvent(EVENTS.DISPLAY_SETS_CHANGED, this.activeDisplaySets);
-  }
 
   makeDisplaySetForInstances(instancesSrc, settings) {
     let instances = instancesSrc;

--- a/platform/core/src/services/DisplaySetService/IDisplaySet.ts
+++ b/platform/core/src/services/DisplaySetService/IDisplaySet.ts
@@ -1,7 +1,7 @@
-interface DisplaySet {
+interface IDisplaySet {
   displaySetInstanceUID: string;
   StudyInstanceUID: string;
   SeriesInstanceUID?: string;
 }
 
-export default DisplaySet;
+export default IDisplaySet;

--- a/platform/core/src/services/HangingProtocolService/HPMatcher.js
+++ b/platform/core/src/services/HangingProtocolService/HPMatcher.js
@@ -40,7 +40,7 @@ const match = (
       readValues[attribute] =
         metadataInstance[attribute] ??
         ((metadataInstance.images || metadataInstance.others || [])[0] || {})[
-        attribute
+          attribute
         ];
     }
 

--- a/platform/core/src/services/HangingProtocolService/HangingProtocolService.test.js
+++ b/platform/core/src/services/HangingProtocolService/HangingProtocolService.test.js
@@ -137,11 +137,14 @@ describe('HangingProtocolService', () => {
   describe('run', () => {
     it('matches best image match', () => {
       hps.run({ studies: [studyMatch], displaySets: studyMatchDisplaySets });
-      const state = hps.getState();
-      const [matchDetails, alreadyApplied] = state;
-      expect(alreadyApplied).toMatchObject([false]);
-      expect(matchDetails.length).toBe(1);
-      expect(matchDetails[0]).toMatchObject({
+      const {
+        hpAlreadyApplied,
+        viewportMatchDetails,
+        displaySetMatchDetails,
+      } = hps.getMatchDetails();
+      expect(hpAlreadyApplied).toMatchObject([false]);
+      expect(viewportMatchDetails.length).toBe(1);
+      expect(viewportMatchDetails[0]).toMatchObject({
         viewportOptions: {
           viewportId: 'ctAXIAL',
           viewportType: 'volume',

--- a/platform/core/src/services/HangingProtocolService/HangingProtocolService.ts
+++ b/platform/core/src/services/HangingProtocolService/HangingProtocolService.ts
@@ -39,6 +39,12 @@ type DisplaySetMatchDetails = {
   sortingInfo: any;
 };
 
+type HangingProtocolMatchDetails = {
+  displaySetMatchDetails: Map<string, DisplaySetMatchDetails>;
+  viewportMatchDetails: ViewportMatchDetails[];
+  hpAlreadyApplied: boolean[];
+};
+
 class HangingProtocolService {
   studies: StudyMetadata[];
   protocols: Record<string, unknown>[];
@@ -116,11 +122,7 @@ class HangingProtocolService {
     // this.ProtocolEngine.reset()
   }
 
-  public getMatchDetails(): {
-    viewportMatchDetails: ViewportMatchDetails[];
-    displaySetMatchDetails: Map<string, DisplaySetMatchDetails>;
-    hpAlreadyApplied: boolean[];
-  } {
+  public getMatchDetails(): HangingProtocolMatchDetails {
     return {
       viewportMatchDetails: this.viewportMatchDetails,
       displaySetMatchDetails: this.displaySetMatchDetails,
@@ -330,6 +332,7 @@ class HangingProtocolService {
 
     this._broadcastChange(this.EVENTS.PROTOCOL_CHANGED, {
       viewportMatchDetails: this.viewportMatchDetails,
+      displaySetMatchDetails: this.displaySetMatchDetails,
       hpAlreadyApplied: this.hpAlreadyApplied,
     });
   }
@@ -665,6 +668,7 @@ class HangingProtocolService {
     this._broadcastChange(this.EVENTS.STAGE_CHANGE, {
       viewportMatchDetails: this.viewportMatchDetails,
       hpAlreadyApplied: this.hpAlreadyApplied,
+      displaySetMatchDetails: this.displaySetMatchDetails,
     });
     return true;
   }

--- a/platform/core/src/services/HangingProtocolService/HangingProtocolService.ts
+++ b/platform/core/src/services/HangingProtocolService/HangingProtocolService.ts
@@ -2,7 +2,7 @@ import pubSubServiceInterface from '../_shared/pubSubServiceInterface';
 import sortBy from '../../utils/sortBy';
 import ProtocolEngine from './ProtocolEngine';
 import StudyMetadata from '../DicomMetadataStore/StudyMetadata';
-import DisplaySet from '../DisplaySetService/DisplaySet';
+import IDisplaySet from '../DisplaySetService/IDisplaySet';
 
 const EVENTS = {
   STAGE_CHANGE: 'event::hanging_protocol_stage_change',
@@ -21,7 +21,7 @@ class HangingProtocolService {
   matchDetails: object[];
   hpAlreadyApplied: boolean[] = [];
   customViewportSettings = [];
-  displaySets: DisplaySet[] = [];
+  displaySets: IDisplaySet[] = [];
   activeStudy: object;
   debugLogging: false;
 
@@ -167,7 +167,7 @@ class HangingProtocolService {
     return (
       this.activeImageLoadStrategyName !== null &&
       this.registeredImageLoadStrategies[
-      this.activeImageLoadStrategyName
+        this.activeImageLoadStrategyName
       ] instanceof Function
     );
   }

--- a/platform/core/src/services/HangingProtocolService/HangingProtocolService.ts
+++ b/platform/core/src/services/HangingProtocolService/HangingProtocolService.ts
@@ -6,23 +6,50 @@ import IDisplaySet from '../DisplaySetService/IDisplaySet';
 
 const EVENTS = {
   STAGE_CHANGE: 'event::hanging_protocol_stage_change',
+  PROTOCOL_CHANGED: 'event::hanging_protocol_changed',
   NEW_LAYOUT: 'event::hanging_protocol_new_layout',
   CUSTOM_IMAGE_LOAD_PERFORMED:
     'event::hanging_protocol_custom_image_load_performed',
 };
 
+type ViewportOptions = {
+  orientation: string;
+  toolGroupId: string;
+  viewportId: string;
+  viewportType: string;
+  initialImageOptions: Record<string, unknown>;
+  syncGroups: Record<string, unknown>;
+};
+
+type ViewportMatchDetails = {
+  viewportOptions: ViewportOptions;
+  displaySetsInfo: {
+    SeriesInstanceUID: string;
+    displaySetInstanceUID: string;
+    displaySetOptions: Record<string, unknown>;
+  };
+};
+
+type DisplaySetMatchDetails = {
+  SeriesInstanceUID: string;
+  StudyInstanceUID: string;
+  displaySetInstanceUID: string;
+  matchDetails: any;
+  matchingScore: number;
+  sortingInfo: any;
+};
+
 class HangingProtocolService {
   studies: StudyMetadata[];
-  protocols: object[];
-  protocol: object;
+  protocols: Record<string, unknown>[];
+  protocol: Record<string, unknown>;
   stage: number;
-  _commandsManager: object;
+  _commandsManager: Record<string, unknown>;
   protocolEngine: ProtocolEngine;
-  matchDetails: object[];
   hpAlreadyApplied: boolean[] = [];
   customViewportSettings = [];
   displaySets: IDisplaySet[] = [];
-  activeStudy: object;
+  activeStudy: Record<string, unknown>;
   debugLogging: false;
 
   customAttributeRetrievalCallbacks = {
@@ -53,18 +80,16 @@ class HangingProtocolService {
 
   /**
    * displaySetMatchDetails = <displaySetId, match>
-   * DisplaySetId is the id defined in the hangingProtocol
-   * match is an object that contains information about
-   *
-   * {
-   *   SeriesInstanceUID,
-   *   StudyInstanceUID,
-   *   matchDetails,
-   *   matchingScore,
-   *   sortingInfo
-   * }
+   * DisplaySetId is the id defined in the hangingProtocol object itself
+   * and match is an object that contains information about
    */
-  displaySetMatchDetails = new Map();
+  displaySetMatchDetails: Map<string, DisplaySetMatchDetails> = new Map();
+
+  /**
+   * An array that contains for each viewport (viewportIndex) specified in the
+   * hanging protocol, an object of the form
+   */
+  viewportMatchDetails = [] as ViewportMatchDetails[];
 
   constructor(commandsManager) {
     this._commandsManager = commandsManager;
@@ -72,16 +97,7 @@ class HangingProtocolService {
     this.protocolEngine = undefined;
     this.protocol = undefined;
     this.stage = undefined;
-    /**
-     * An array that contains for each viewport (viewportIndex) specified in the
-     * hanging protocol, an object of the form
-     *
-     * {
-     *   viewportOptions,
-     *   displaySetsInfo, // contains array of  [ { SeriesInstanceUID, displaySetOPtions}, ... ]
-     * }
-     */
-    this.matchDetails = [];
+
     this.studies = [];
     Object.defineProperty(this, 'EVENTS', {
       value: EVENTS,
@@ -96,16 +112,20 @@ class HangingProtocolService {
     this.studies = [];
     this.protocols = [];
     this.hpAlreadyApplied = [];
-    this.matchDetails = [];
+    this.viewportMatchDetails = [];
     // this.ProtocolEngine.reset()
   }
 
-  public getDisplaySetsMatchDetails() {
-    return this.displaySetMatchDetails;
-  }
-
-  public getState() {
-    return [this.matchDetails, this.hpAlreadyApplied];
+  public getMatchDetails(): {
+    viewportMatchDetails: ViewportMatchDetails[];
+    displaySetMatchDetails: Map<string, DisplaySetMatchDetails>;
+    hpAlreadyApplied: boolean[];
+  } {
+    return {
+      viewportMatchDetails: this.viewportMatchDetails,
+      displaySetMatchDetails: this.displaySetMatchDetails,
+      hpAlreadyApplied: this.hpAlreadyApplied,
+    };
   }
 
   public getProtocols() {
@@ -241,8 +261,8 @@ class HangingProtocolService {
     ];
     const loadedData = loader({
       data,
-      displaySetsMatchDetails: this.getDisplaySetsMatchDetails(),
-      matchDetails: this.matchDetails,
+      displaySetsMatchDetails: this.displaySetMatchDetails,
+      viewportMatchDetails: this.viewportMatchDetails,
     });
 
     // if loader successfully re-arranged the data with the custom strategy
@@ -307,6 +327,11 @@ class HangingProtocolService {
       }
     }
     this._updateViewports();
+
+    this._broadcastChange(this.EVENTS.PROTOCOL_CHANGED, {
+      viewportMatchDetails: this.viewportMatchDetails,
+      hpAlreadyApplied: this.hpAlreadyApplied,
+    });
   }
 
   /**
@@ -435,7 +460,7 @@ class HangingProtocolService {
         }
       );
 
-      this.matchDetails[viewportIndex] = {
+      this.viewportMatchDetails[viewportIndex] = {
         viewportOptions,
         displaySetsInfo,
       };
@@ -638,7 +663,7 @@ class HangingProtocolService {
 
     // Everything went well
     this._broadcastChange(this.EVENTS.STAGE_CHANGE, {
-      matchDetails: this.matchDetails,
+      viewportMatchDetails: this.viewportMatchDetails,
       hpAlreadyApplied: this.hpAlreadyApplied,
     });
     return true;

--- a/platform/core/src/services/HangingProtocolService/ProtocolEngine.js
+++ b/platform/core/src/services/HangingProtocolService/ProtocolEngine.js
@@ -71,10 +71,10 @@ export default class ProtocolEngine {
 
       // If it is not already in the MatchedProtocols Collection, insert it with its score
       if (!this.matchedProtocols.has(protocol.id)) {
-        // console.log(
-        //   'ProtocolEngine::updateProtocolMatches inserting protocol match',
-        //   matchedDetail
-        // );
+        console.log(
+          'ProtocolEngine::updateProtocolMatches inserting protocol match',
+          matchedDetail
+        );
         this.matchedProtocols.set(protocol.id, protocol);
         this.matchedProtocolScores[protocol.id] = matchedDetail.score;
       }

--- a/platform/core/src/services/HangingProtocolService/lib/validator.js
+++ b/platform/core/src/services/HangingProtocolService/lib/validator.js
@@ -1,29 +1,35 @@
 import validate from 'validate.js';
 
-validate.validators.equals = function (value, options, key, attributes) {
+validate.validators.equals = function(value, options, key, attributes) {
   const testValue = options?.value ?? options;
   if (value !== testValue) {
     return key + 'must equal ' + testValue;
   }
 };
 
-validate.validators.doesNotEqual = function (value, options, key) {
+validate.validators.doesNotEqual = function(value, options, key) {
   const testValue = options?.value ?? options;
   if (value === testValue) {
     return key + 'cannot equal ' + testValue;
   }
 };
 
-validate.validators.contains = function (value, options, key) {
+validate.validators.contains = function(value, options, key) {
   const testValue = options?.value ?? options;
   if (Array.isArray(value)) {
     if (value.some(item => !validate.validators.contains(item, options, key))) {
       return undefined;
     }
-    return `No item of ${value.join(',')} contains ${JSON.stringify(testValue)}`
+    return `No item of ${value.join(',')} contains ${JSON.stringify(
+      testValue
+    )}`;
   }
   if (Array.isArray(testValue)) {
-    if (testValue.some(subTest => !validate.validators.contains(value, subTest, key))) {
+    if (
+      testValue.some(
+        subTest => !validate.validators.contains(value, subTest, key)
+      )
+    ) {
       return;
     }
     return `${key} must contain at least one of ${testValue.join(',')}`;
@@ -33,41 +39,50 @@ validate.validators.contains = function (value, options, key) {
   }
 };
 
-validate.validators.doesNotContain = function (value, options, key) {
+validate.validators.doesNotContain = function(value, options, key) {
   if (options && value.indexOf && value.indexOf(options.value) !== -1) {
     return key + 'cannot contain ' + options.value;
   }
 };
 
-validate.validators.startsWith = function (value, options, key) {
+validate.validators.startsWith = function(value, options, key) {
   if (options && value.startsWith && !value.startsWith(options.value)) {
     return key + 'must start with ' + options.value;
   }
 };
 
-validate.validators.endsWith = function (value, options, key) {
+validate.validators.endsWith = function(value, options, key) {
   if (options && value.endsWith && !value.endsWith(options.value)) {
     return key + 'must end with ' + options.value;
   }
 };
 
-validate.validators.greaterThan = function (value, options, key) {
+validate.validators.greaterThan = function(value, options, key) {
   const testValue = options?.value ?? options;
   if (testValue !== undefined && value <= testValue) {
-
     return key + 'with value ' + value + ' must be greater than ' + testValue;
   }
-
 };
 
-validate.validators.range = function (value, options, key) {
+validate.validators.range = function(value, options, key) {
   const testValue = options?.value ?? options;
-  if (testValue !== undefined && value < testValue[0] || value > testValue[1]) {
-    return key + 'with value ' + value + ' must be between ' + testValue[0] + ' and ' + testValue[1];
+  if (
+    (testValue !== undefined && value < testValue[0]) ||
+    value > testValue[1]
+  ) {
+    return (
+      key +
+      'with value ' +
+      value +
+      ' must be between ' +
+      testValue[0] +
+      ' and ' +
+      testValue[1]
+    );
   }
-
 };
 
-validate.validators.notNull = (value) => ((value === null || value === undefined) ? "Value is null" : undefined);
+validate.validators.notNull = value =>
+  value === null || value === undefined ? 'Value is null' : undefined;
 
 export default validate;

--- a/platform/docs/docs/platform/services/data/DisplaySetService.md
+++ b/platform/docs/docs/platform/services/data/DisplaySetService.md
@@ -10,41 +10,7 @@ sidebar_label: DisplaySet Service
 
 > Based on the instanceMetadata's `SOPClassHandlerId`, the correct module from the registered extensions is found by `OHIF` and its `getDisplaySetsFromSeries` runs to create a DisplaySet for the Series.
 
-
-```js title="platform/core/src/services/DisplaySetService/DisplaySetService.js"
-init(extensionManager, SOPClassHandlerIds) {
-  this.extensionManager = extensionManager;
-  this.SOPClassHandlerIds = SOPClassHandlerIds;
-  this.activeDisplaySets = [];
-}
-```
-
-in `Mode.jsx`
-
-```js title="platform/viewer/src/routes/Mode/Mode.jsx"
-export default function ModeRoute(/** ... **/) {
-  /** ... **/
-  const { DisplaySetService } = servicesManager.services
-  const { sopClassHandlers } = mode
-  /** ... **/
-  useEffect(
-    () => {
-      /** ... **/
-
-      // Add SOPClassHandlers to a new SOPClassManager.
-      DisplaySetService.init(extensionManager, sopClassHandlers)
-
-      /** ... **/
-    }
-    /** ... **/
-  )
-  /** ... **/
-  return <> /** ... **/ </>
-}
-```
-
-
-
+DisplaySets are created synchronously when the instances metadata is retrieved and added to the [DicomMetaDataStore](../data//DicomMetadataStore.md).
 
 ## Events
 There are three events that get broadcasted in `DisplaySetService`:

--- a/platform/docs/versioned_docs/version-3.0/platform/services/data/DisplaySetService.md
+++ b/platform/docs/versioned_docs/version-3.0/platform/services/data/DisplaySetService.md
@@ -57,11 +57,6 @@ There are three events that get broadcasted in `DisplaySetService`:
 | DISPLAY_SETS_CHANGED | Fires when a displayset is changed                   |
 | DISPLAY_SETS_REMOVED | Fires when a displayset is removed                   |
 
-For the DISPLAY_SETS_CHANGED event, the firing of the event can be held by
-calling `DisplaySetService.suppressDisplaySetsChangedEvent()`, and then re-enabled by
-calling `DisplaySetService.broadcastDisplaySetsChangedEvent()`.  This allows loading
-all data before firing the display sets changed, so as to get a single
-notification.
 
 
 ## API

--- a/platform/docs/versioned_docs/version-3.0/platform/services/data/DisplaySetService.md
+++ b/platform/docs/versioned_docs/version-3.0/platform/services/data/DisplaySetService.md
@@ -58,8 +58,8 @@ There are three events that get broadcasted in `DisplaySetService`:
 | DISPLAY_SETS_REMOVED | Fires when a displayset is removed                   |
 
 For the DISPLAY_SETS_CHANGED event, the firing of the event can be held by
-calling `DisplaySetService.holdChangeEvents()`, and then re-enabled by
-calling `DisplaySetService.fireHoldChangeEvents()`.  This allows loading
+calling `DisplaySetService.suppressDisplaySetsChangedEvent()`, and then re-enabled by
+calling `DisplaySetService.broadcastDisplaySetsChangedEvent()`.  This allows loading
 all data before firing the display sets changed, so as to get a single
 notification.
 

--- a/platform/viewer/src/components/ViewportGrid.tsx
+++ b/platform/viewer/src/components/ViewportGrid.tsx
@@ -26,12 +26,12 @@ function ViewerViewportGrid(props) {
         return;
       }
 
-      const [
-        matchDetails,
+      const {
+        viewportMatchDetails,
         hpAlreadyApplied,
-      ] = HangingProtocolService.getState();
+      } = HangingProtocolService.getMatchDetails();
 
-      if (!matchDetails.length) {
+      if (!viewportMatchDetails.length) {
         return;
       }
 
@@ -43,11 +43,11 @@ function ViewerViewportGrid(props) {
         }
 
         // if current viewport doesn't have a match
-        if (matchDetails[i] === undefined) {
+        if (viewportMatchDetails[i] === undefined) {
           return;
         }
 
-        const { displaySetsInfo, viewportOptions } = matchDetails[i];
+        const { displaySetsInfo, viewportOptions } = viewportMatchDetails[i];
 
         const displaySetUIDsToHang = [];
         const displaySetUIDsToHangOptions = [];

--- a/platform/viewer/src/components/ViewportGrid.tsx
+++ b/platform/viewer/src/components/ViewportGrid.tsx
@@ -113,10 +113,11 @@ function ViewerViewportGrid(props) {
 
   // Using Hanging protocol engine to match the displaySets
   useEffect(() => {
-    const { unsubscribe } = DisplaySetService.subscribe(
-      DisplaySetService.EVENTS.DISPLAY_SETS_CHANGED,
-      activeDisplaySets => {
-        updateDisplaySetsForViewports(activeDisplaySets);
+    const { unsubscribe } = HangingProtocolService.subscribe(
+      HangingProtocolService.EVENTS.PROTOCOL_CHANGED,
+      () => {
+        const displaySets = DisplaySetService.getActiveDisplaySets();
+        updateDisplaySetsForViewports(displaySets);
       }
     );
 

--- a/platform/viewer/src/routes/Mode/Mode.tsx
+++ b/platform/viewer/src/routes/Mode/Mode.tsx
@@ -67,20 +67,20 @@ function defaultRouteInit({ servicesManager, studyInstanceUIDs, dataSource }) {
       seriesAddedUnsubscribe();
     }
   );
-  // Add the unsubscription to the list in case the cancel happens before the
+  // Add the unsubscriptions to the list in case the cancel happens before the
   // service is done.
   unsubscriptions.push(seriesAddedUnsubscribe);
 
   // The hanging protocol matching service is fairly expensive to run multiple
   // times, and doesn't allow partial matches to be made (it will simply fail
-  // to display anything if a required match failes), so hold off the matches
+  // to display anything if a required match fails), so hold off the matches
   // here until the entire study is ready.
-  DisplaySetService.holdChangeEvents();
+  DisplaySetService.suppressDisplaySetsChangedEvent();
   const allRetrieves = studyInstanceUIDs.map(StudyInstanceUID =>
     dataSource.retrieve.series.metadata({ StudyInstanceUID })
   );
   Promise.allSettled(allRetrieves).then(() => {
-    DisplaySetService.fireHoldChangeEvents();
+    DisplaySetService.broadcastDisplaySetsChangedEvent();
   });
 
   return unsubscriptions;

--- a/platform/viewer/src/routes/Mode/Mode.tsx
+++ b/platform/viewer/src/routes/Mode/Mode.tsx
@@ -24,13 +24,20 @@ function defaultRouteInit({ servicesManager, studyInstanceUIDs, dataSource }) {
   } = servicesManager.services;
 
   const unsubscriptions = [];
-  // TODO: This should be baked into core, not manual?
-  // DisplaySetService would wire this up?
   const {
     unsubscribe: instanceAddedUnsubscribe,
   } = DicomMetadataStore.subscribe(
     DicomMetadataStore.EVENTS.INSTANCES_ADDED,
-    ({ StudyInstanceUID, SeriesInstanceUID, madeInClient = false }) => {
+    // Todo: DisplaySetService makes the displayset when ALL instances are added
+    // However, making a displayset only requires one instance and one instance only
+    // you can look at the sopClassHandlers which you will see only the first instance
+    // is used to make the displayset. This is a huge performance bottleneck
+    // since we are waiting for all instances to be added before making the displayset
+    // Making a displaySet can be broken down into 2 steps: 1) as soon as the first
+    // instance is added, create the displayset and 2) when all instances are
+    // added to the store, update the displayset with the rest of instances.
+    // This improvement will make the first draw of the hung viewport way faster.
+    function({ StudyInstanceUID, SeriesInstanceUID, madeInClient = false }) {
       const seriesMetadata = DicomMetadataStore.getSeries(
         StudyInstanceUID,
         SeriesInstanceUID
@@ -42,45 +49,42 @@ function defaultRouteInit({ servicesManager, studyInstanceUIDs, dataSource }) {
 
   unsubscriptions.push(instanceAddedUnsubscribe);
 
-  const { unsubscribe: seriesAddedUnsubscribe } = DisplaySetService.subscribe(
-    DisplaySetService.EVENTS.DISPLAY_SETS_CHANGED,
-    displaySets => {
-      if (!displaySets || !displaySets.length) return;
-      const studyMap = {};
-      // Prior studies don't quite work properly yet, but the studies list
-      // is at least being generated and passed in.
-      const studies = displaySets.reduce((prev, curr) => {
-        const { StudyInstanceUID } = curr;
-        if (!studyMap[StudyInstanceUID]) {
-          const study = DicomMetadataStore.getStudy(StudyInstanceUID);
-          studyMap[StudyInstanceUID] = study;
-          prev.push(study);
-        }
-        return prev;
-      }, []);
-      // The assumption is that the display set at position 0 is the first
-      // study being displayed, and is thus the "active" study.
-      const activeStudy = studies[0];
-      HangingProtocolService.run({ studies, activeStudy, displaySets });
-      // Don't fire off any more hanging protocol service initiates since
-      // it may well re-layout the study.
-      seriesAddedUnsubscribe();
-    }
+  const allRetrieves = studyInstanceUIDs.map(StudyInstanceUID =>
+    dataSource.retrieve.series.metadata({ StudyInstanceUID })
   );
-  // Add the unsubscriptions to the list in case the cancel happens before the
-  // service is done.
-  unsubscriptions.push(seriesAddedUnsubscribe);
 
   // The hanging protocol matching service is fairly expensive to run multiple
   // times, and doesn't allow partial matches to be made (it will simply fail
   // to display anything if a required match fails), so hold off the matches
   // here until the entire study is ready.
-  DisplaySetService.suppressDisplaySetsChangedEvent();
-  const allRetrieves = studyInstanceUIDs.map(StudyInstanceUID =>
-    dataSource.retrieve.series.metadata({ StudyInstanceUID })
-  );
+
   Promise.allSettled(allRetrieves).then(() => {
-    DisplaySetService.broadcastDisplaySetsChangedEvent();
+    const displaySets = DisplaySetService.getActiveDisplaySets();
+
+    if (!displaySets || !displaySets.length) {
+      return;
+    }
+
+    const studyMap = {};
+
+    // Prior studies don't quite work properly yet, but the studies list
+    // is at least being generated and passed in.
+    const studies = displaySets.reduce((prev, curr) => {
+      const { StudyInstanceUID } = curr;
+      if (!studyMap[StudyInstanceUID]) {
+        const study = DicomMetadataStore.getStudy(StudyInstanceUID);
+        studyMap[StudyInstanceUID] = study;
+        prev.push(study);
+      }
+      return prev;
+    }, []);
+
+    // The assumption is that the display set at position 0 is the first
+    // study being displayed, and is thus the "active" study.
+    const activeStudy = studies[0];
+
+    // run the hanging protocol matching service on the displaySets
+    HangingProtocolService.run({ studies, activeStudy, displaySets });
   });
 
   return unsubscriptions;


### PR DESCRIPTION
### Fix
- We don't need to suppress events on displaySet service, we can just wait, since after the async metadata the part for instances add -> displaySet creation is syncronous.
- The PR broke the PanelSUV which is fixed now

### Add
- A new event on the HP (`PROTOCOL_CHANGED`), to let subscribers know that the protocol match for viewports is performed

### Refactor
- We had so many matchdetails in the HP service, I refactored all to be more clear and added many types for HP

### Note to discuss cc @swederik 

~~Todo: DisplaySetService makes the displayset when ALL instances are added
However, making a displayset only requires one instance and one instance only
you can look at the sopClassHandlers which you will see only the first instance
is used to make the displayset. This is a huge performance bottleneck
since we are waiting for all instances to be added before making the displayset
Making a displaySet can be broken down into 2 steps: 1) as soon as the first
instance is added, create the displayset and 2) when all instances are
added to the store, update the displayset with the rest of instances.
This improvement will make the first draw of the hung viewport way faster.~~

Update: since we are doing HP on DisplaySet the above comment is not valid anymore
