### PR TITLE
fix(datasource): configurability of additional data source extensions

### DIFF
--- a/platform/core/package.json
+++ b/platform/core/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "repository": "OHIF/Viewers",
   "main": "dist/index.umd.js",
-  "module": "src/index.js",
+  "module": "src/index.ts",
   "sideEffects": "false",
   "publishConfig": {
     "access": "public"

--- a/platform/core/src/index.test.js
+++ b/platform/core/src/index.test.js
@@ -1,4 +1,4 @@
-import * as OHIF from './index.js';
+import * as OHIF from './index';
 
 describe('Top level exports', () => {
   test('have not changed', () => {
@@ -31,6 +31,7 @@ describe('Top level exports', () => {
       'DisplaySetService',
       'MeasurementService',
       'ToolBarService',
+      'Types',
       'ViewportGridService',
       'SegmentationService',
       'HangingProtocolService',

--- a/platform/core/src/index.ts
+++ b/platform/core/src/index.ts
@@ -1,6 +1,6 @@
 import { ExtensionManager, MODULE_TYPES } from './extensions';
 import { ServicesManager } from './services';
-import classes, { CommandsManager, HotkeysManager } from './classes/';
+import classes, { CommandsManager, HotkeysManager } from './classes';
 
 import DICOMWeb from './DICOMWeb';
 import errorHandler from './errorHandler.js';
@@ -8,8 +8,9 @@ import log from './log.js';
 import object from './object.js';
 import string from './string.js';
 import user from './user.js';
-import utils from './utils/';
+import utils from './utils';
 import defaults from './defaults';
+import * as Types from './types';
 
 import {
   CineService,
@@ -107,6 +108,7 @@ export {
   IWebApiDataSource,
   DicomMetadataStore,
   pubSubServiceInterface,
+  Types,
 };
 
 export { OHIF };

--- a/platform/core/src/services/DicomMetadataStore/StudyMetadata.ts
+++ b/platform/core/src/services/DicomMetadataStore/StudyMetadata.ts
@@ -1,7 +1,0 @@
-/** Defines a typescript type for study metadata */
-interface StudyMetadata {
-  readonly StudyInstanceUID: string;
-  StudyDescription?: string;
-}
-
-export default StudyMetadata;

--- a/platform/core/src/services/HangingProtocolService/HangingProtocolService.ts
+++ b/platform/core/src/services/HangingProtocolService/HangingProtocolService.ts
@@ -1,7 +1,7 @@
 import pubSubServiceInterface from '../_shared/pubSubServiceInterface';
 import sortBy from '../../utils/sortBy';
 import ProtocolEngine from './ProtocolEngine';
-import StudyMetadata from '../DicomMetadataStore/StudyMetadata';
+import StudyMetadata from '../../types/StudyMetadata';
 import IDisplaySet from '../DisplaySetService/IDisplaySet';
 
 const EVENTS = {

--- a/platform/core/src/types/Consumer.ts
+++ b/platform/core/src/types/Consumer.ts
@@ -1,0 +1,3 @@
+import Params from './ParamsType';
+type Consumer = (props: Params) => void;
+export default Consumer;

--- a/platform/core/src/types/Consumer.ts
+++ b/platform/core/src/types/Consumer.ts
@@ -1,3 +1,5 @@
-import Params from './ParamsType';
-type Consumer = (props: Params) => void;
+/**
+ * Just a function that consumes a single argument, with no return.
+ */
+type Consumer = (props: Record<string, unknown>) => void;
 export default Consumer;

--- a/platform/core/src/types/IPubSub.ts
+++ b/platform/core/src/types/IPubSub.ts
@@ -1,0 +1,12 @@
+import { Consumer } from './Consumer';
+
+
+export default interface IPubSub {
+  subscribe: (eventName: string, callback: Consumer) => void;
+  _broadcastEvent: (
+    eventName: string,
+    callbackProps: Record<string, unknown>
+  ) => void;
+  _unsubscribe: (eventName: string, listenerId: string) => void;
+  _isValidEvent: (eventName: string) => boolean;
+}

--- a/platform/core/src/types/StudyMetadata.ts
+++ b/platform/core/src/types/StudyMetadata.ts
@@ -1,0 +1,23 @@
+/** Defines a typescript type for study metadata */
+
+export interface PatientMetadata extends Record<string, unknown> {
+  PatientName?: string;
+  PatientId?: string;
+}
+
+export interface StudyMetadata extends Record<string, unknown> {
+  readonly StudyInstanceUID?: string;
+  StudyDescription?: string;
+}
+
+export interface SeriesMetadata extends StudyMetadata {
+  readonly SeriesInstanceUID?: string;
+  SeriesDescription?: string;
+  SeriesNumber?: string | number;
+}
+
+export interface InstanceMetadata extends SeriesMetadata {
+  readonly SOPInstanceUID: string;
+  InstanceNumber?: string | number;
+}
+export default StudyMetadata;

--- a/platform/core/src/types/index.ts
+++ b/platform/core/src/types/index.ts
@@ -1,0 +1,9 @@
+import {
+  StudyMetadata,
+  SeriesMetadata,
+  InstanceMetadata,
+} from './StudyMetadata';
+
+import Consumer from './Consumer';
+
+export { StudyMetadata, SeriesMetadata, InstanceMetadata, Consumer };

--- a/platform/ui/src/components/StudyBrowser/StudyBrowser.tsx
+++ b/platform/ui/src/components/StudyBrowser/StudyBrowser.tsx
@@ -4,7 +4,7 @@ import classnames from 'classnames';
 import { useTranslation } from 'react-i18next';
 
 import { ButtonGroup, Button, StudyItem, ThumbnailList } from '../';
-import { StringNumber } from '../../Types';
+import { StringNumber } from '../../types';
 
 const buttonClasses = 'text-white text-base border-none bg-black p-2 min-w-18';
 const activeButtonClasses = 'bg-primary-main';

--- a/platform/ui/src/components/Thumbnail/Thumbnail.tsx
+++ b/platform/ui/src/components/Thumbnail/Thumbnail.tsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { useDrag } from 'react-dnd';
 import { Icon } from '../';
-import { StringNumber } from '../../Types';
+import { StringNumber } from '../../types';
 
 /**
  *

--- a/platform/ui/src/components/ThumbnailList/ThumbnailList.tsx
+++ b/platform/ui/src/components/ThumbnailList/ThumbnailList.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { Thumbnail, ThumbnailNoImage, ThumbnailTracked } from '../';
-import * as Types from '../../Types';
+import * as Types from '../../types';
 
 const ThumbnailList = ({
   thumbnails,

--- a/platform/ui/src/components/ThumbnailTracked/ThumbnailTracked.tsx
+++ b/platform/ui/src/components/ThumbnailTracked/ThumbnailTracked.tsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
 import { Icon, Thumbnail, Tooltip } from '../';
-import { StringNumber } from '../../Types';
+import { StringNumber } from '../../types';
 
 const ThumbnailTracked = ({
   displaySetInstanceUID,

--- a/platform/ui/src/components/ViewportActionBar/ViewportActionBar.tsx
+++ b/platform/ui/src/components/ViewportActionBar/ViewportActionBar.tsx
@@ -4,7 +4,7 @@ import classnames from 'classnames';
 import { Icon, ButtonGroup, Button, Tooltip, CinePlayer } from '../';
 import useOnClickOutside from '../../utils/useOnClickOutside';
 import { useTranslation } from 'react-i18next';
-import { StringNumber } from '../../Types';
+import { StringNumber } from '../../types';
 
 const classes = {
   infoHeader: 'text-base text-primary-light',

--- a/platform/ui/src/index.js
+++ b/platform/ui/src/index.js
@@ -4,7 +4,7 @@
 
 /** CONTEXT/HOOKS */
 // Export types - need to do as two lines due to a bug in babel
-import * as Types from './Types';
+import * as Types from './types';
 
 export {
   useCine,

--- a/platform/ui/src/types/ThumbnailType.ts
+++ b/platform/ui/src/types/ThumbnailType.ts
@@ -1,0 +1,7 @@
+import PropTypes from 'prop-types';
+
+export default PropTypes.oneOf([
+  'thumbnail',
+  'thumbnailTracked',
+  'thumbnailNoImage',
+]);

--- a/platform/ui/src/types/index.ts
+++ b/platform/ui/src/types/index.ts
@@ -1,4 +1,7 @@
 import PropTypes from 'prop-types';
+import ThumbnailType from './ThumbnailType';
+
+// A few miscellaneous types declared inline here.
 
 /**
  * StringNumber often comes back from DICOMweb for integer valued items.
@@ -10,11 +13,5 @@ const StringNumber = PropTypes.oneOfType([PropTypes.string, PropTypes.number]);
  * might have multiple values such as window level descriptions.
  */
 const StringArray = PropTypes.oneOfType([PropTypes.string, PropTypes.array]);
-
-const ThumbnailType = PropTypes.oneOf([
-  'thumbnail',
-  'thumbnailTracked',
-  'thumbnailNoImage',
-]);
 
 export { StringNumber, StringArray, ThumbnailType };

--- a/platform/viewer/src/routes/DataSourceWrapper.tsx
+++ b/platform/viewer/src/routes/DataSourceWrapper.tsx
@@ -32,11 +32,16 @@ function DataSourceWrapper(props) {
     return acc.concat(mods);
   }, []);
 
-  // Grabbing first for now - should get active?
-  const name = webApiDataSources[0].name;
+  // Grabbing first defined for now - should get active
   // TODO: Why does this return an array?
-  const dataSource = extensionManager.getDataSources(name)[0];
-
+  const dataSource = webApiDataSources
+    .map(ds => extensionManager.getDataSources(ds.name)?.[0])
+    .find(it => it !== undefined);
+  if (!dataSource) {
+    throw new Error(
+      `No data source found for any of ${webApiDataSources.map(it => it.name)}`
+    );
+  }
   // Route props --> studies.mapParams
   // mapParams --> studies.search
   // studies.search --> studies.processResults
@@ -168,7 +173,7 @@ function _getQueryFilterValues(query, queryLimit) {
   return queryFilterValues;
 
   function _tryParseInt(str, defaultValue) {
-    var retValue = defaultValue;
+    let retValue = defaultValue;
     if (str !== null) {
       if (str.length > 0) {
         if (!isNaN(str)) {


### PR DESCRIPTION
This just fixes the configurability of additional data source extensions - without it, there isn't a way to define a second data source type without removing the default extension.