### PR TITLE
Added support for TID 1410 relationship types

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,28 +21,24 @@
 
 # Stage 1: Build the application
 # docker build -t ohif/viewer:latest .
-#FROM node:14.3.0-slim as json-copier
-FROM node:16.15.0-slim as json-copier
+FROM node:14.3.0-slim as json-copier
 
 RUN mkdir /usr/src/app
 WORKDIR /usr/src/app
 
 
-#COPY ["package.json", "yarn.lock", "./"]
-COPY ["package.json", "yarn.lock", "preinstall.js", "./"]
+COPY ["package.json", "yarn.lock", "./"]
 COPY extensions /usr/src/app/extensions
 COPY modes /usr/src/app/modes
 COPY platform /usr/src/app/platform
 
 # Find and remove non-package.json files
-# RUN find extensions \! -name "package.json" -mindepth 2 -maxdepth 2 -print | xargs rm -rf
-# RUN find modes \! -name "package.json" -mindepth 2 -maxdepth 2 -print | xargs rm -rf
-# RUN find platform \! -name "package.json" -mindepth 2 -maxdepth 2 -print | xargs rm -rf
-
+RUN find extensions \! -name "package.json" -mindepth 2 -maxdepth 2 -print | xargs rm -rf
+RUN find modes \! -name "package.json" -mindepth 2 -maxdepth 2 -print | xargs rm -rf
+RUN find platform \! -name "package.json" -mindepth 2 -maxdepth 2 -print | xargs rm -rf
 
 # Copy Files
-#FROM node:14.3.0-slim as builder
-FROM node:16.15.0-slim as builder
+FROM node:14.3.0-slim as builder
 RUN mkdir /usr/src/app
 WORKDIR /usr/src/app
 
@@ -50,19 +46,19 @@ COPY --from=json-copier /usr/src/app .
 
 # Run the install before copying the rest of the files
 RUN yarn config set workspaces-experimental true
-RUN yarn install --frozen-lockfile --verbose
+RUN yarn install --frozen-lockfile
 
 COPY . .
 
 # To restore workspaces symlinks
-RUN yarn install --frozen-lockfile --verbose
+RUN yarn install --frozen-lockfile
 
 ENV PATH /usr/src/app/node_modules/.bin:$PATH
 ENV QUICK_BUILD true
 # ENV GENERATE_SOURCEMAP=false
 # ENV REACT_APP_CONFIG=config/default.js
 
-RUN yarn run build as final
+RUN yarn run build
 
 # Stage 3: Bundle the built application into a Docker container
 # which runs Nginx using Alpine Linux

--- a/extensions/cornerstone-dicom-sr/src/getSopClassHandlerModule.js
+++ b/extensions/cornerstone-dicom-sr/src/getSopClassHandlerModule.js
@@ -378,7 +378,6 @@ function _processMeasurement(mergedContentSequence) {
 function _processTID1410Measurement(mergedContentSequence) {
   // Need to deal with TID 1410 style measurements, which will have a SCOORD or SCOORD3D at the top level,
   // And non-geometric representations where each NUM has "INFERRED FROM" SCOORD/SCOORD3D
-  // TODO -> Look at RelationshipType => Contains means
 
   const graphicItem = mergedContentSequence.find(
     group => group.ValueType === 'SCOORD'
@@ -539,9 +538,11 @@ function _getCoordsFromSCOORDOrSCOORD3D(item) {
   const { ValueType, RelationshipType, GraphicType, GraphicData } = item;
 
   if (
-    !(RelationshipType == RELATIONSHIP_TYPE.INFERRED_FROM ||
-      RelationshipType == RELATIONSHIP_TYPE.CONTAINS )
-    ) {
+    !(
+      RelationshipType == RELATIONSHIP_TYPE.INFERRED_FROM ||
+      RelationshipType == RELATIONSHIP_TYPE.CONTAINS
+    )
+  ) {
     console.warn(
       `Relationshiptype === ${RelationshipType}. Cannot deal with NON TID-1400 SCOORD group with RelationshipType !== "INFERRED FROM" or "CONTAINS"`
     );
@@ -602,21 +603,16 @@ function _getReferencedImagesList(ImagingMeasurementReportContentSequence) {
 
   _getSequenceAsArray(ImageLibraryGroup.ContentSequence).forEach(item => {
     const { ReferencedSOPSequence } = item;
-    // const {
-    //   ReferencedSOPClassUID,
-    //   ReferencedSOPInstanceUID,
-    // } = ReferencedSOPSequence;
 
-    // referencedImages.push({ ReferencedSOPClassUID, ReferencedSOPInstanceUID });
     if (item.hasOwnProperty('ReferencedSOPClassUID')) {
-    const {
-      ReferencedSOPClassUID,
-      ReferencedSOPInstanceUID,
+      const {
+        ReferencedSOPClassUID,
+        ReferencedSOPInstanceUID,
       } = ReferencedSOPSequence;
 
-    referencedImages.push({
-      ReferencedSOPClassUID,
-      ReferencedSOPInstanceUID,
+      referencedImages.push({
+        ReferencedSOPClassUID,
+        ReferencedSOPInstanceUID,
       });
     }
   });

--- a/extensions/cornerstone-dicom-sr/src/getSopClassHandlerModule.js
+++ b/extensions/cornerstone-dicom-sr/src/getSopClassHandlerModule.js
@@ -16,6 +16,7 @@ const sopClassUids = [
   '1.2.840.10008.5.1.4.1.1.88.11', //BASIC_TEXT_SR:
   '1.2.840.10008.5.1.4.1.1.88.22', //ENHANCED_SR:
   '1.2.840.10008.5.1.4.1.1.88.33', //COMPREHENSIVE_SR:
+  '1.2.840.10008.5.1.4.1.1.88.34', //COMPREHENSIVE_3D_SR:
 ];
 
 const CORNERSTONE_3D_TOOLS_SOURCE_NAME = 'Cornerstone3DTools';
@@ -44,6 +45,7 @@ const CodingSchemeDesignators = {
 
 const RELATIONSHIP_TYPE = {
   INFERRED_FROM: 'INFERRED FROM',
+  CONTAINS: 'CONTAINS',
 };
 
 const CORNERSTONE_FREETEXT_CODE_VALUE = 'CORNERSTONEFREETEXT';
@@ -536,9 +538,12 @@ function _processNonGeometricallyDefinedMeasurement(mergedContentSequence) {
 function _getCoordsFromSCOORDOrSCOORD3D(item) {
   const { ValueType, RelationshipType, GraphicType, GraphicData } = item;
 
-  if (RelationshipType !== RELATIONSHIP_TYPE.INFERRED_FROM) {
+  if (
+    !(RelationshipType == RELATIONSHIP_TYPE.INFERRED_FROM ||
+      RelationshipType == RELATIONSHIP_TYPE.CONTAINS )
+    ) {
     console.warn(
-      `Relationshiptype === ${RelationshipType}. Cannot deal with NON TID-1400 SCOORD group with RelationshipType !== "INFERRED FROM."`
+      `Relationshiptype === ${RelationshipType}. Cannot deal with NON TID-1400 SCOORD group with RelationshipType !== "INFERRED FROM" or "CONTAINS"`
     );
 
     return;
@@ -597,12 +602,23 @@ function _getReferencedImagesList(ImagingMeasurementReportContentSequence) {
 
   _getSequenceAsArray(ImageLibraryGroup.ContentSequence).forEach(item => {
     const { ReferencedSOPSequence } = item;
+    // const {
+    //   ReferencedSOPClassUID,
+    //   ReferencedSOPInstanceUID,
+    // } = ReferencedSOPSequence;
+
+    // referencedImages.push({ ReferencedSOPClassUID, ReferencedSOPInstanceUID });
+    if (item.hasOwnProperty('ReferencedSOPClassUID')) {
     const {
       ReferencedSOPClassUID,
       ReferencedSOPInstanceUID,
-    } = ReferencedSOPSequence;
+      } = ReferencedSOPSequence;
 
-    referencedImages.push({ ReferencedSOPClassUID, ReferencedSOPInstanceUID });
+    referencedImages.push({
+      ReferencedSOPClassUID,
+      ReferencedSOPInstanceUID,
+      });
+    }
   });
 
   return referencedImages;

--- a/extensions/cornerstone-dicom-sr/src/tools/DICOMSRDisplayTool.ts
+++ b/extensions/cornerstone-dicom-sr/src/tools/DICOMSRDisplayTool.ts
@@ -99,7 +99,7 @@ export default class DICOMSRDisplayTool extends AnnotationTool {
       const annotation = filteredAnnotations[i];
       const annotationUID = annotation.annotationUID;
       const { renderableData } = annotation.data.cachedStats;
-      const { label, cachedStats } = annotation.data;
+      const { cachedStats } = annotation.data;
       const { referencedImageId } = annotation.metadata;
 
       styleSpecifier.annotationUID = annotationUID;
@@ -121,22 +121,30 @@ export default class DICOMSRDisplayTool extends AnnotationTool {
         const renderableDataForGraphicType = renderableData[GraphicType];
 
         let renderMethod;
+        let renderTextBox;
+        let canvasCoordinatesAdapter;
 
         switch (GraphicType) {
           case SCOORD_TYPES.POINT:
             renderMethod = this.renderPoint;
+            renderTextBox = this.renderTextBox;
             break;
           case SCOORD_TYPES.MULTIPOINT:
             renderMethod = this.renderMultipoint;
+            renderTextBox = this.renderTextBox;
             break;
           case SCOORD_TYPES.POLYLINE:
             renderMethod = this.renderPolyLine;
             break;
           case SCOORD_TYPES.CIRCLE:
             renderMethod = this.renderEllipse;
+            renderTextBox = this.renderTextBox;
             break;
           case SCOORD_TYPES.ELLIPSE:
             renderMethod = this.renderEllipse;
+            renderTextBox = this.renderTextBox;
+            canvasCoordinatesAdapter =
+              utilities.math.ellipse.getCanvasEllipseCorners;
             break;
           default:
             throw new Error(`Unsupported GraphicType: ${GraphicType}`);
@@ -151,60 +159,18 @@ export default class DICOMSRDisplayTool extends AnnotationTool {
           options
         );
 
-        if (!canvasCoordinates) {
-          return;
-        }
-
-        const textLines = this._getTextBoxLinesFromLabels(label);
-
-        let canvasCornersToUseForTextBox = canvasCoordinates;
-
-        if (GraphicType === SCOORD_TYPES.ELLIPSE) {
-          canvasCornersToUseForTextBox = utilities.math.ellipse.getCanvasEllipseCorners(
-            canvasCoordinates
+        if (typeof renderTextBox === 'function') {
+          renderTextBox.call(
+            this,
+            svgDrawingHelper,
+            viewport,
+            canvasCoordinates,
+            canvasCoordinatesAdapter,
+            annotation,
+            styleSpecifier,
+            options
           );
         }
-
-        const canvasTextBoxCoords = utilities.drawing.getTextBoxCoordsCanvas(
-          canvasCornersToUseForTextBox
-        );
-
-        annotation.data.handles.textBox.worldPosition = viewport.canvasToWorld(
-          canvasTextBoxCoords
-        );
-
-        const textBoxPosition = viewport.worldToCanvas(
-          annotation.data.handles.textBox.worldPosition
-        );
-
-        const textBoxUID = '1';
-        const textBoxOptions = this.getLinkedTextBoxStyle(
-          styleSpecifier,
-          annotation
-        );
-
-        const boundingBox = drawing.drawLinkedTextBox(
-          svgDrawingHelper,
-          annotationUID,
-          textBoxUID,
-          textLines,
-          textBoxPosition,
-          canvasCoordinates,
-          {},
-          {
-            ...textBoxOptions,
-            color,
-          }
-        );
-
-        const { x: left, y: top, width, height } = boundingBox;
-
-        annotation.data.handles.textBox.worldBoundingBox = {
-          topLeft: viewport.canvasToWorld([left, top]),
-          topRight: viewport.canvasToWorld([left + width, top]),
-          bottomLeft: viewport.canvasToWorld([left, top + height]),
-          bottomRight: viewport.canvasToWorld([left + width, top + height]),
-        };
       });
     }
   };
@@ -217,28 +183,32 @@ export default class DICOMSRDisplayTool extends AnnotationTool {
     referencedImageId,
     options
   ) {
-    // Todo: this needs to use the drawPolyLine from cs3D since it is implemented
-    // now, before it was implemented with a loop over drawLine which is hacky
-
+    const drawingOptions = {
+      color: options.color,
+      width: options.lineWidth,
+    };
     let canvasCoordinates;
     renderableData.map((data, index) => {
       canvasCoordinates = data.map(p => viewport.worldToCanvas(p));
 
+      const lineUID = `${index}`;
       if (canvasCoordinates.length === 2) {
-        const lineUID = `${index}`;
         drawing.drawLine(
           svgDrawingHelper,
           annotationUID,
           lineUID,
           canvasCoordinates[0],
           canvasCoordinates[1],
-          {
-            color: options.color,
-            width: options.lineWidth,
-          }
+          drawingOptions
         );
       } else {
-        throw new Error('Drawing polyline for SR not yet implemented');
+        drawing.drawPolyline(
+          svgDrawingHelper,
+          annotationUID,
+          lineUID,
+          canvasCoordinates,
+          drawingOptions
+        );
       }
     });
 
@@ -366,6 +336,71 @@ export default class DICOMSRDisplayTool extends AnnotationTool {
     });
 
     return canvasCoordinates;
+  }
+
+  renderTextBox(
+    svgDrawingHelper,
+    viewport,
+    canvasCoordinates,
+    canvasCoordinatesAdapter,
+    annotation,
+    styleSpecifier,
+    options = {}
+  ) {
+    if (!canvasCoordinates || !annotation) {
+      return;
+    }
+
+    const { annotationUID, data = {} } = annotation;
+    const { label } = data;
+    const { color } = options;
+
+    let adaptedCanvasCoordinates = canvasCoordinates;
+    // adapt coordinates if there is an adapter
+    if (typeof canvasCoordinatesAdapter === 'function') {
+      adaptedCanvasCoordinates = canvasCoordinatesAdapter(canvasCoordinates);
+    }
+    const textLines = this._getTextBoxLinesFromLabels(label);
+    const canvasTextBoxCoords = utilities.drawing.getTextBoxCoordsCanvas(
+      adaptedCanvasCoordinates
+    );
+
+    annotation.data.handles.textBox.worldPosition = viewport.canvasToWorld(
+      canvasTextBoxCoords
+    );
+
+    const textBoxPosition = viewport.worldToCanvas(
+      annotation.data.handles.textBox.worldPosition
+    );
+
+    const textBoxUID = '1';
+    const textBoxOptions = this.getLinkedTextBoxStyle(
+      styleSpecifier,
+      annotation
+    );
+
+    const boundingBox = drawing.drawLinkedTextBox(
+      svgDrawingHelper,
+      annotationUID,
+      textBoxUID,
+      textLines,
+      textBoxPosition,
+      canvasCoordinates,
+      {},
+      {
+        ...textBoxOptions,
+        color,
+      }
+    );
+
+    const { x: left, y: top, width, height } = boundingBox;
+
+    annotation.data.handles.textBox.worldBoundingBox = {
+      topLeft: viewport.canvasToWorld([left, top]),
+      topRight: viewport.canvasToWorld([left + width, top]),
+      bottomLeft: viewport.canvasToWorld([left, top + height]),
+      bottomRight: viewport.canvasToWorld([left + width, top + height]),
+    };
   }
 }
 


### PR DESCRIPTION
### PR Checklist

- [ ] Added support for rendering [TID 1410](https://dicom.nema.org/medical/dicom/current/output/chtml/part16/chapter_A.html#sect_TID_1410) by adding a relationship type. 
- [ ]  Passes pixelmed SR validator:
```
 ./DicomSRValidator.sh ~/Development/github/highdicom/ohif_test.dcm 
Found Comprehensive3DSR IOD
Found Root Template TID_1500 (MeasurementReport)
Root Template Validation Complete
IOD validation complete 
```
- [ ] Can't [render POLYLINE graphic objects](https://github.com/OHIF/Viewers/blob/55a1704e4ae293a3902d0b9d7c6196fb3847fd46/extensions/cornerstone-dicom-sr/src/tools/DICOMSRDisplayTool.ts#L241). So - the demo below will not work until POLYLINES are added back in.


 
The anonymized images were downloaded from [here](https://www.dicomlibrary.com/?manage=02ef8f31ea86a45cfce6eb297c274598).

The DICOM SR was generated by [highdicom](https://github.com/herrmannlab/highdicom) in the 'feat/add_image_library_tid1601' branch.

The attached zip file contains a series from the anonymized MR images and the DICOM SR. As you scroll through the images the rectangle moves down and to the right.

![sr_image_1](https://user-images.githubusercontent.com/517824/191145378-16a00016-b08e-4bc7-b324-5b7108022c93.png)

![sr_image_2](https://user-images.githubusercontent.com/517824/191145389-056201f4-a599-46a1-942d-ecaead6486ec.png)

[mri_images.zip](https://github.com/OHIF/Viewers/files/9603215/mri_images.zip)

<!--
  Links
  -->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
