### PR TITLE
V3 Use HP to prevent viewport trying to display RTPLAN, SR, REG, etc. 

### DIFF
--- a/extensions/default/src/getHangingProtocolModule.js
+++ b/extensions/default/src/getHangingProtocolModule.js
@@ -26,7 +26,33 @@ const defaultProtocol = {
           // Unused currently
           imageMatchingRules: [],
           // Matches displaysets, NOT series
-          seriesMatchingRules: [],
+          seriesMatchingRules: [
+            {
+              id: 'nRl6SgkPMx8HzLDVT',
+              weight: 1,
+              attribute: 'Modality',
+              constraint: {
+                doesNotContain: {
+                  value: 'RT',
+                },
+                doesNotEqual: {
+                  value: 'SR'
+                },
+              },
+              required: true,
+            },
+            {
+              id: 'F7udwbMm9UEtR7aDA',
+              weight: 1,
+              attribute: 'Modality',
+              constraint: {
+                doesNotEqual: {
+                  value: 'REG',
+                }
+              },
+              required: true,
+            },
+          ],
           studyMatchingRules: [],
         },
       ],


### PR DESCRIPTION
When opening a study with series that don't render (such as RTPLAN, RTDOSE, RTSTRUCT, SR, REG) the non-rendering series may be selected for the main viewport so nothing will load there, forcing the use to double click a thumbnail to load the first series rather than doing so by default. 

I've edited the default hanging protocol to address this. There may be a more comprehensive way to do this, either by adding more non-rendering modalities or by using a list of the modalities that will render. I'm open to reformatting/expanding the fix I have started here. 