### PR TITLE
fix: sop class handler isSingleImageModality always undefined

### DIFF
--- a/extensions/default/src/getSopClassHandlerModule.js
+++ b/extensions/default/src/getSopClassHandlerModule.js
@@ -119,7 +119,7 @@ function getDisplaySetsFromSeries(instances) {
         acquisitionDatetime: instance.AcquisitionDateTime,
       });
       displaySets.push(displaySet);
-    } else if (isSingleImageModality(instance.modality)) {
+    } else if (isSingleImageModality(instance.Modality)) {
       displaySet = makeDisplaySet([instance]);
       displaySet.setAttributes({
         sopClassUids,


### PR DESCRIPTION
There is a typo in instance.modality where Modality should be uppercase. Otherwise will always be undefined. This is why Xray with same series are still stacking rather than having separate display sets.