### PR TITLE
feat(hangingProtocol):Compatibility with older hanging protocol definitions

### DIFF
--- a/platform/core/src/extensions/ExtensionManager.js
+++ b/platform/core/src/extensions/ExtensionManager.js
@@ -286,8 +286,17 @@ export default class ExtensionManager {
 
   _initHangingProtocolsModule = (extensionModule, extensionId) => {
     const { HangingProtocolService } = this._servicesManager.services;
-    extensionModule.forEach(({ id, protocol }) => {
-      HangingProtocolService.addProtocol(id, protocol);
+    extensionModule.forEach(({ id, protocol, protocols }) => {
+      if (protocol) {
+        // Only auto-register if protocol specified, otherwise let mode register
+        HangingProtocolService.addProtocol(id, protocol);
+      }
+      // Deal with the older schema where items could be grouped
+      if (protocols) {
+        protocols.forEach(child => {
+          HangingProtocolService.addProtocol(child.id, child);
+        });
+      }
     });
   };
 

--- a/platform/viewer/src/routes/Mode/Mode.tsx
+++ b/platform/viewer/src/routes/Mode/Mode.tsx
@@ -114,9 +114,14 @@ export default function ModeRoute({
     locationRef.current = location;
   }
 
-  const { DisplaySetService } = servicesManager.services;
+  const {
+    DisplaySetService,
+    HangingProtocolService: hangingProtocolService,
+  } = servicesManager.services;
 
   const { extensions, sopClassHandlers, hotkeys, hangingProtocol } = mode;
+  // Allow the mode to specify the active hanging protocols list
+  const { hangingProtocols } = mode;
 
   if (dataSourceName === undefined) {
     dataSourceName = extensionManager.defaultDataSourceName;
@@ -242,6 +247,13 @@ export default function ModeRoute({
       commandsManager,
     });
     mode?.onModeEnter({ servicesManager, extensionManager, commandsManager });
+
+    // Sets the active hanging protocols - if hangingProtocols is undefined,
+    // resets to default.
+    hangingProtocolService.setActiveProtocols(
+      extensionManager,
+      hangingProtocols
+    );
 
     const setupRouteInit = async () => {
       if (route.init) {


### PR DESCRIPTION
This adds backwards compatibility to the hanging protocol mode definitions by adding a "setActiveProtocol(s)", which allows defining the protocols currently active, independent of the full set.  This gets called on mode enter.