### PR TITLE
fix: 2965 Correct Parsing Logic for Qualitative Instance Level SR

### DIFF
--- a/platform/core/src/DICOMSR/SCOORD3D/parseSCOORD3D.js
+++ b/platform/core/src/DICOMSR/SCOORD3D/parseSCOORD3D.js
@@ -1,6 +1,5 @@
 import { ImageSet } from '../../classes';
 import getMeasurements from './utils/getMeasurements';
-import getReferencedImagesList from './utils/getReferencedImagesList';
 import isRehydratable from './utils/isRehydratable';
 import addMeasurement from './utils/addMeasurement';
 
@@ -27,7 +26,6 @@ const parseSCOORD3D = ({ servicesManager, displaySets }) => {
 
     const { ContentSequence } = firstInstance;
 
-    srDisplaySet.referencedImages = getReferencedImagesList(ContentSequence);
     srDisplaySet.measurements = getMeasurements(ContentSequence);
     const mappings = MeasurementService.getSourceMappings(
       'CornerstoneTools',

--- a/platform/core/src/DICOMSR/SCOORD3D/parseSCOORD3D.js
+++ b/platform/core/src/DICOMSR/SCOORD3D/parseSCOORD3D.js
@@ -1,5 +1,6 @@
 import { ImageSet } from '../../classes';
 import getMeasurements from './utils/getMeasurements';
+import getReferencedImagesList from './utils/getReferencedImagesList';
 import isRehydratable from './utils/isRehydratable';
 import addMeasurement from './utils/addMeasurement';
 
@@ -26,6 +27,7 @@ const parseSCOORD3D = ({ servicesManager, displaySets }) => {
 
     const { ContentSequence } = firstInstance;
 
+    srDisplaySet.referencedImages = getReferencedImagesList(ContentSequence);
     srDisplaySet.measurements = getMeasurements(ContentSequence);
     const mappings = MeasurementService.getSourceMappings(
       'CornerstoneTools',

--- a/platform/core/src/DICOMSR/SCOORD3D/utils/getReferencedImagesList.js
+++ b/platform/core/src/DICOMSR/SCOORD3D/utils/getReferencedImagesList.js
@@ -10,7 +10,7 @@ const getReferencedImagesList = ImagingMeasurementReportContentSequence => {
       CodeNameCodeSequenceValues.ImageLibrary
   );
 
-  if (!ImageLibrary.ContentSequence) {
+  if (!ImageLibrary || !ImageLibrary.ContentSequence) {
     return referencedImages;
   }
 
@@ -21,6 +21,10 @@ const getReferencedImagesList = ImagingMeasurementReportContentSequence => {
       item.ConceptNameCodeSequence.CodeValue ===
       CodeNameCodeSequenceValues.ImageLibraryGroup
   );
+
+  if (!ImageLibraryGroup || !ImageLibraryGroup.ContentSequence) {
+    return referencedImages;
+  }
 
   getSequenceAsArray(ImageLibraryGroup.ContentSequence).forEach(item => {
     const { ReferencedSOPSequence } = item;

--- a/platform/core/src/DICOMSR/SCOORD3D/utils/getReferencedImagesList.js
+++ b/platform/core/src/DICOMSR/SCOORD3D/utils/getReferencedImagesList.js
@@ -7,12 +7,10 @@ const getReferencedImagesList = ImagingMeasurementReportContentSequence => {
   const ImageLibrary = ImagingMeasurementReportContentSequence.find(
     item =>
       item.ConceptNameCodeSequence.CodeValue ===
-        CodeNameCodeSequenceValues.ImageLibrary ||
-      item.ConceptNameCodeSequence.CodeValue ===
-        CodeNameCodeSequenceValues.ImagingMeasurements
+      CodeNameCodeSequenceValues.ImageLibrary
   );
 
-  if (!ImageLibrary || !ImageLibrary.ContentSequence) {
+  if (!ImageLibrary.ContentSequence) {
     return referencedImages;
   }
 
@@ -21,14 +19,8 @@ const getReferencedImagesList = ImagingMeasurementReportContentSequence => {
   ).find(
     item =>
       item.ConceptNameCodeSequence.CodeValue ===
-        CodeNameCodeSequenceValues.ImageLibraryGroup ||
-      item.ConceptNameCodeSequence.CodeValue ===
-        CodeNameCodeSequenceValues.MeasurementGroup
+      CodeNameCodeSequenceValues.ImageLibraryGroup
   );
-
-  if (!ImageLibraryGroup || !ImageLibraryGroup.ContentSequence) {
-    return referencedImages;
-  }
 
   getSequenceAsArray(ImageLibraryGroup.ContentSequence).forEach(item => {
     const { ReferencedSOPSequence } = item;


### PR DESCRIPTION
Fix for https://github.com/OHIF/Viewers/issues/2965

Explanation below:
Qualitative slice-level SR annotations are within the Measurement Group container, which is obtained through https://github.com/OHIF/Viewers/blob/7aba01f534b70406ce02e1708004141c7b773904/platform/core/src/DICOMSR/SCOORD3D/parseSCOORD3D.js#L31

This particular dataset did not have any ImageLibrary, hence [getReferenceImagesList()](https://github.com/OHIF/Viewers/blob/7aba01f534b70406ce02e1708004141c7b773904/platform/core/src/DICOMSR/SCOORD3D/parseSCOORD3D.js#L30) was throwing errors. 

I modified [platform/core/src/DICOMSR/SCOORD3D/utils/getReferencedImagesList.js](https://github.com/OHIF/Viewers/blob/7aba01f534b70406ce02e1708004141c7b773904/platform/core/src/DICOMSR/SCOORD3D/utils/getReferencedImagesList.js#L4) as it should not look for CodeValue from ImagingMeasurements.
