### PR TITLE
Multi-frame DICOM support

### DIFF
--- a/extensions/cornerstone-dicom-sr/package.json
+++ b/extensions/cornerstone-dicom-sr/package.json
@@ -34,7 +34,7 @@
   "peerDependencies": {
     "@ohif/core": "^3.0.0",
     "@ohif/ui": "^2.0.0",
-    "dcmjs": "^0.24.5",
+    "dcmjs": "^0.28.1",
     "dicom-parser": "^1.8.9",
     "hammerjs": "^2.0.8",
     "prop-types": "^15.6.2",

--- a/extensions/cornerstone-dicom-sr/src/getSopClassHandlerModule.js
+++ b/extensions/cornerstone-dicom-sr/src/getSopClassHandlerModule.js
@@ -221,11 +221,23 @@ function _checkIfCanAddMeasurementsToDisplaySet(
     const image = images[i];
     const { SOPInstanceUID } = image;
     if (SOPInstanceUIDs.includes(SOPInstanceUID)) {
-      const imageId = imageIdsForDisplaySet[i];
-
       for (let j = unloadedMeasurements.length - 1; j >= 0; j--) {
         const measurement = unloadedMeasurements[j];
         if (_measurementReferencesSOPInstanceUID(measurement, SOPInstanceUID)) {
+          let imageId;
+          if (newDisplaySet.isMultiFrame) {
+            const frameNumber =
+              (measurement.coords[0].ReferencedSOPSequence &&
+                measurement.coords[0].ReferencedSOPSequence
+                  .ReferencedFrameNumber) ||
+              1;
+            imageId =
+              imageIdsForDisplaySet[frameNumber - 1] ||
+              imageIdsForDisplaySet[i];
+          } else {
+            imageId = imageIdsForDisplaySet[i];
+          }
+
           addMeasurement(
             measurement,
             imageId,

--- a/extensions/cornerstone-dicom-sr/src/utils/addMeasurement.ts
+++ b/extensions/cornerstone-dicom-sr/src/utils/addMeasurement.ts
@@ -45,6 +45,12 @@ export default function addMeasurement(
 
   const annotationManager = annotation.state.getDefaultAnnotationManager();
 
+  // Create Cornerstone3D Annotation from measurement
+  const frameNumber =
+    (measurement.coords[0].ReferencedSOPSequence &&
+      measurement.coords[0].ReferencedSOPSequence.ReferencedFrameNumber) ||
+    1;
+
   const SRAnnotation: Types.Annotation = {
     annotationUID: measurement.TrackingUniqueIdentifier,
     metadata: {
@@ -61,6 +67,7 @@ export default function addMeasurement(
         TrackingUniqueIdentifier: measurementData.TrackingUniqueIdentifier,
         renderableData: measurementData.renderableData,
       },
+      frameNumber: frameNumber,
     },
   };
 
@@ -75,6 +82,7 @@ export default function addMeasurement(
   // It'd be super weird if it didn't anyway as a SCOORD.
   measurement.ReferencedSOPInstanceUID =
     measurement.coords[0].ReferencedSOPSequence.ReferencedSOPInstanceUID;
+  measurement.frameNumber = frameNumber;
   delete measurement.coords;
 }
 

--- a/extensions/cornerstone/package.json
+++ b/extensions/cornerstone/package.json
@@ -30,7 +30,7 @@
     "@ohif/core": "^3.0.0",
     "@ohif/ui": "^2.0.0",
     "cornerstone-wado-image-loader": "^4.2.1",
-    "dcmjs": "^0.24.5",
+    "dcmjs": "^0.28.1",
     "dicom-parser": "^1.8.9",
     "hammerjs": "^2.0.8",
     "prop-types": "^15.6.2",

--- a/extensions/cornerstone/src/Viewport/OHIFCornerstoneViewport.tsx
+++ b/extensions/cornerstone/src/Viewport/OHIFCornerstoneViewport.tsx
@@ -237,7 +237,7 @@ const OHIFCornerstoneViewport = React.memo(props => {
         displaySets,
         viewportOptions.viewportType,
         dataSource,
-        (viewportDataLoaded) => {
+        viewportDataLoaded => {
           CornerstoneViewportService.setViewportDisplaySets(
             viewportIndex,
             viewportDataLoaded,
@@ -394,7 +394,7 @@ function _jumpToMeasurement(
   viewportGridService
 ) {
   const targetElement = targetElementRef.current;
-  const { displaySetInstanceUID, SOPInstanceUID } = measurement;
+  const { displaySetInstanceUID, SOPInstanceUID, frameNumber } = measurement;
 
   if (!SOPInstanceUID) {
     console.warn('cannot jump in a non-acquisition plane measurements yet');
@@ -404,9 +404,14 @@ function _jumpToMeasurement(
     displaySetInstanceUID
   );
 
-  const imageIdIndex = referencedDisplaySet.images.findIndex(
+  // For multi-frame files, finding imageID simply by SOPInstanceUID won't work,
+  // as the "referencedDisplaySet.images" will only contain the Frame 1.
+  let imageIdIndex = referencedDisplaySet.images.findIndex(
     i => i.SOPInstanceUID === SOPInstanceUID
   );
+  if (referencedDisplaySet.isMultiFrame && frameNumber > 1) {
+    imageIdIndex = frameNumber - 1;
+  }
 
   // Todo: setCornerstoneMeasurementActive should be handled by the toolGroupManager
   //  to set it properly

--- a/extensions/cornerstone/src/utils/measurementServiceMappings/ArrowAnnotate.js
+++ b/extensions/cornerstone/src/utils/measurementServiceMappings/ArrowAnnotate.js
@@ -69,6 +69,7 @@ const Length = {
       metadata,
       referenceSeriesUID: SeriesInstanceUID,
       referenceStudyUID: StudyInstanceUID,
+      frameNumber: mappedAnnotations[0].frameNumber || 1,
       toolName: metadata.toolName,
       displaySetInstanceUID: displaySet.displaySetInstanceUID,
       label: data.text,
@@ -90,9 +91,11 @@ function getMappedAnnotations(annotation, DisplaySetService) {
 
   const annotations = [];
 
-  const { SOPInstanceUID, SeriesInstanceUID } = getSOPInstanceAttributes(
-    referencedImageId
-  );
+  const {
+    SOPInstanceUID,
+    SeriesInstanceUID,
+    frameNumber,
+  } = getSOPInstanceAttributes(referencedImageId);
 
   const displaySet = DisplaySetService.getDisplaySetForSOPInstanceUID(
     SOPInstanceUID,
@@ -105,6 +108,7 @@ function getMappedAnnotations(annotation, DisplaySetService) {
     SeriesInstanceUID,
     SOPInstanceUID,
     SeriesNumber,
+    frameNumber,
     text,
   });
 
@@ -119,7 +123,7 @@ function getDisplayText(mappedAnnotations, displaySet) {
   const displayText = [];
 
   // Area is the same for all series
-  const { SeriesNumber, SOPInstanceUID } = mappedAnnotations[0];
+  const { SeriesNumber, SOPInstanceUID, frameNumber } = mappedAnnotations[0];
 
   const instance = displaySet.images.find(
     image => image.SOPInstanceUID === SOPInstanceUID
@@ -130,11 +134,10 @@ function getDisplayText(mappedAnnotations, displaySet) {
     InstanceNumber = instance.InstanceNumber;
   }
 
-  displayText.push(
-    InstanceNumber
-      ? `(S: ${SeriesNumber} I: ${InstanceNumber})`
-      : `(S: ${SeriesNumber})`
-  );
+  const instanceText = InstanceNumber ? ` I: ${InstanceNumber}` : '';
+  const frameText = displaySet.isMultiFrame ? ` F: ${frameNumber}` : '';
+
+  displayText.push(`(S: ${SeriesNumber}${instanceText}${frameText})`);
 
   return displayText;
 }

--- a/extensions/cornerstone/src/utils/measurementServiceMappings/Bidirectional.js
+++ b/extensions/cornerstone/src/utils/measurementServiceMappings/Bidirectional.js
@@ -67,6 +67,7 @@ const Bidirectional = {
       metadata,
       referenceSeriesUID: SeriesInstanceUID,
       referenceStudyUID: StudyInstanceUID,
+      frameNumber: mappedAnnotations[0].frameNumber || 1,
       toolName: metadata.toolName,
       displaySetInstanceUID: displaySet.displaySetInstanceUID,
       label: data.label,
@@ -92,30 +93,32 @@ function getMappedAnnotations(annotation, DisplaySetService) {
   Object.keys(cachedStats).forEach(targetId => {
     const targetStats = cachedStats[targetId];
 
-    let displaySet;
-
-    if (referencedImageId) {
-      const { SOPInstanceUID, SeriesInstanceUID } = getSOPInstanceAttributes(
-        referencedImageId
-      );
-
-      displaySet = DisplaySetService.getDisplaySetForSOPInstanceUID(
-        SOPInstanceUID,
-        SeriesInstanceUID
-      );
-    } else {
+    if (!referencedImageId) {
       throw new Error(
         'Non-acquisition plane measurement mapping not supported'
       );
     }
 
-    const { SeriesNumber, SeriesInstanceUID } = displaySet;
+    const {
+      SOPInstanceUID,
+      SeriesInstanceUID,
+      frameNumber,
+    } = getSOPInstanceAttributes(referencedImageId);
+
+    const displaySet = DisplaySetService.getDisplaySetForSOPInstanceUID(
+      SOPInstanceUID,
+      SeriesInstanceUID
+    );
+
+    const { SeriesNumber } = displaySet;
     const { length, width } = targetStats;
     const unit = 'mm';
 
     annotations.push({
       SeriesInstanceUID,
+      SOPInstanceUID,
       SeriesNumber,
+      frameNumber,
       unit,
       length,
       width,
@@ -171,7 +174,13 @@ function getDisplayText(mappedAnnotations, displaySet) {
   const displayText = [];
 
   // Area is the same for all series
-  const { length, width, SeriesNumber, SOPInstanceUID } = mappedAnnotations[0];
+  const {
+    length,
+    width,
+    SeriesNumber,
+    SOPInstanceUID,
+    frameNumber,
+  } = mappedAnnotations[0];
   const roundedLength = utils.roundNumber(length, 2);
   const roundedWidth = utils.roundNumber(width, 2);
 
@@ -184,10 +193,11 @@ function getDisplayText(mappedAnnotations, displaySet) {
     InstanceNumber = instance.InstanceNumber;
   }
 
+  const instanceText = InstanceNumber ? ` I: ${InstanceNumber}` : '';
+  const frameText = displaySet.isMultiFrame ? ` F: ${frameNumber}` : '';
+
   displayText.push(
-    InstanceNumber
-      ? `L: ${roundedLength} mm (S: ${SeriesNumber} I: ${InstanceNumber})`
-      : `L: ${roundedLength} mm (S: ${SeriesNumber})`
+    `L: ${roundedLength} mm (S: ${SeriesNumber}${instanceText}${frameText})`
   );
   displayText.push(`W: ${roundedWidth} mm`);
 

--- a/extensions/cornerstone/src/utils/measurementServiceMappings/EllipticalROI.js
+++ b/extensions/cornerstone/src/utils/measurementServiceMappings/EllipticalROI.js
@@ -66,6 +66,7 @@ const EllipticalROI = {
       metadata,
       referenceSeriesUID: SeriesInstanceUID,
       referenceStudyUID: StudyInstanceUID,
+      frameNumber: mappedAnnotations[0].frameNumber || 1,
       toolName: metadata.toolName,
       displaySetInstanceUID: displaySet.displaySetInstanceUID,
       label: data.label,
@@ -91,31 +92,33 @@ function getMappedAnnotations(annotation, DisplaySetService) {
   Object.keys(cachedStats).forEach(targetId => {
     const targetStats = cachedStats[targetId];
 
-    let displaySet;
-
-    if (referencedImageId) {
-      const { SOPInstanceUID, SeriesInstanceUID } = getSOPInstanceAttributes(
-        referencedImageId
-      );
-
-      displaySet = DisplaySetService.getDisplaySetForSOPInstanceUID(
-        SOPInstanceUID,
-        SeriesInstanceUID
-      );
-    } else {
+    if (!referencedImageId) {
       // Todo: Non-acquisition plane measurement mapping not supported yet
       throw new Error(
         'Non-acquisition plane measurement mapping not supported'
       );
     }
 
-    const { SeriesNumber, SeriesInstanceUID } = displaySet;
+    const {
+      SOPInstanceUID,
+      SeriesInstanceUID,
+      frameNumber,
+    } = getSOPInstanceAttributes(referencedImageId);
+
+    const displaySet = DisplaySetService.getDisplaySetForSOPInstanceUID(
+      SOPInstanceUID,
+      SeriesInstanceUID
+    );
+
+    const { SeriesNumber } = displaySet;
     const { mean, stdDev, max, area, Modality } = targetStats;
     const unit = getModalityUnit(Modality);
 
     annotations.push({
       SeriesInstanceUID,
+      SOPInstanceUID,
       SeriesNumber,
+      frameNumber,
       Modality,
       unit,
       mean,
@@ -184,7 +187,7 @@ function getDisplayText(mappedAnnotations, displaySet) {
   const displayText = [];
 
   // Area is the same for all series
-  const { area, SOPInstanceUID } = mappedAnnotations[0];
+  const { area, SOPInstanceUID, frameNumber } = mappedAnnotations[0];
 
   const instance = displaySet.images.find(
     image => image.SOPInstanceUID === SOPInstanceUID
@@ -195,6 +198,9 @@ function getDisplayText(mappedAnnotations, displaySet) {
     InstanceNumber = instance.InstanceNumber;
   }
 
+  const instanceText = InstanceNumber ? ` I: ${InstanceNumber}` : '';
+  const frameText = displaySet.isMultiFrame ? ` F: ${frameNumber}` : '';
+
   const roundedArea = utils.roundNumber(area, 2);
   displayText.push(`${roundedArea} mm<sup>2</sup>`);
 
@@ -202,14 +208,15 @@ function getDisplayText(mappedAnnotations, displaySet) {
   mappedAnnotations.forEach(mappedAnnotation => {
     const { unit, max, SeriesNumber } = mappedAnnotation;
 
+    let maxStr = '';
     if (max) {
       const roundedMax = utils.roundNumber(max, 2);
+      maxStr = `Max: ${roundedMax} <small>${unit}</small> `;
+    }
 
-      displayText.push(
-        InstanceNumber
-          ? `Max: ${roundedMax} <small>${unit}</small> (S:${SeriesNumber} I:${InstanceNumber})`
-          : `Max: ${roundedMax} <small>${unit}</small> (S:${SeriesNumber})`
-      );
+    const str = `${maxStr}(S:${SeriesNumber}${instanceText}${frameText})`;
+    if (!displayText.includes(str)) {
+      displayText.push(str);
     }
   });
 

--- a/extensions/cornerstone/src/utils/measurementServiceMappings/Length.js
+++ b/extensions/cornerstone/src/utils/measurementServiceMappings/Length.js
@@ -72,6 +72,7 @@ const Length = {
       metadata,
       referenceSeriesUID: SeriesInstanceUID,
       referenceStudyUID: StudyInstanceUID,
+      frameNumber: mappedAnnotations[0].frameNumber || 1,
       toolName: metadata.toolName,
       displaySetInstanceUID: displaySet.displaySetInstanceUID,
       label: data.label,
@@ -97,30 +98,32 @@ function getMappedAnnotations(annotation, DisplaySetService) {
   Object.keys(cachedStats).forEach(targetId => {
     const targetStats = cachedStats[targetId];
 
-    let displaySet;
-
-    if (referencedImageId) {
-      const { SOPInstanceUID, SeriesInstanceUID } = getSOPInstanceAttributes(
-        referencedImageId
-      );
-
-      displaySet = DisplaySetService.getDisplaySetForSOPInstanceUID(
-        SOPInstanceUID,
-        SeriesInstanceUID
-      );
-    } else {
+    if (!referencedImageId) {
       throw new Error(
         'Non-acquisition plane measurement mapping not supported'
       );
     }
 
-    const { SeriesNumber, SeriesInstanceUID } = displaySet;
+    const {
+      SOPInstanceUID,
+      SeriesInstanceUID,
+      frameNumber,
+    } = getSOPInstanceAttributes(referencedImageId);
+
+    const displaySet = DisplaySetService.getDisplaySetForSOPInstanceUID(
+      SOPInstanceUID,
+      SeriesInstanceUID
+    );
+
+    const { SeriesNumber } = displaySet;
     const { length } = targetStats;
     const unit = 'mm';
 
     annotations.push({
       SeriesInstanceUID,
+      SOPInstanceUID,
       SeriesNumber,
+      frameNumber,
       unit,
       length,
     });
@@ -175,7 +178,12 @@ function getDisplayText(mappedAnnotations, displaySet) {
   const displayText = [];
 
   // Area is the same for all series
-  const { length, SeriesNumber, SOPInstanceUID } = mappedAnnotations[0];
+  const {
+    length,
+    SeriesNumber,
+    SOPInstanceUID,
+    frameNumber,
+  } = mappedAnnotations[0];
 
   const instance = displaySet.images.find(
     image => image.SOPInstanceUID === SOPInstanceUID
@@ -186,11 +194,12 @@ function getDisplayText(mappedAnnotations, displaySet) {
     InstanceNumber = instance.InstanceNumber;
   }
 
+  const instanceText = InstanceNumber ? ` I: ${InstanceNumber}` : '';
+  const frameText = displaySet.isMultiFrame ? ` F: ${frameNumber}` : '';
+
   const roundedLength = utils.roundNumber(length, 2);
   displayText.push(
-    InstanceNumber
-      ? `${roundedLength} mm (S: ${SeriesNumber} I: ${InstanceNumber})`
-      : `${roundedLength} mm (S: ${SeriesNumber})`
+    `${roundedLength} mm (S: ${SeriesNumber}${instanceText}${frameText})`
   );
 
   return displayText;

--- a/extensions/cornerstone/src/utils/measurementServiceMappings/utils/getSOPInstanceAttributes.js
+++ b/extensions/cornerstone/src/utils/measurementServiceMappings/utils/getSOPInstanceAttributes.js
@@ -45,6 +45,7 @@ function _getUIDFromImageID(imageId) {
     SOPInstanceUID: instance.SOPInstanceUID,
     SeriesInstanceUID: instance.SeriesInstanceUID,
     StudyInstanceUID: instance.StudyInstanceUID,
+    frameNumber: instance.frameNumber || 1,
   };
 }
 

--- a/extensions/default/package.json
+++ b/extensions/default/package.json
@@ -32,7 +32,7 @@
   "peerDependencies": {
     "@ohif/core": "^3.0.0",
     "@ohif/i18n": "^1.0.0",
-    "dcmjs": "^0.24.5",
+    "dcmjs": "^0.28.1",
     "dicomweb-client": "^0.6.0",
     "prop-types": "^15.6.2",
     "react": "^17.0.2",

--- a/extensions/default/src/DicomWebDataSource/index.js
+++ b/extensions/default/src/DicomWebDataSource/index.js
@@ -494,7 +494,7 @@ function createDicomWebApi(dicomWebConfig, UserAuthenticationService) {
         const NumberOfFrames = instance.NumberOfFrames;
 
         if (NumberOfFrames > 1) {
-          for (let i = 0; i < NumberOfFrames; i++) {
+          for (let i = 1; i <= NumberOfFrames; i++) {
             const imageId = this.getImageIdsForInstance({
               instance,
               frame: i,

--- a/extensions/dicom-pdf/package.json
+++ b/extensions/dicom-pdf/package.json
@@ -30,7 +30,7 @@
   "peerDependencies": {
     "@ohif/core": "^3.0.0",
     "@ohif/ui": "^2.0.0",
-    "dcmjs": "^0.24.5",
+    "dcmjs": "^0.28.1",
     "dicom-parser": "^1.8.9",
     "hammerjs": "^2.0.8",
     "prop-types": "^15.6.2",

--- a/extensions/dicom-video/package.json
+++ b/extensions/dicom-video/package.json
@@ -30,7 +30,7 @@
   "peerDependencies": {
     "@ohif/core": "^3.0.0",
     "@ohif/ui": "^2.0.0",
-    "dcmjs": "^0.24.5",
+    "dcmjs": "^0.28.1",
     "dicom-parser": "^1.8.9",
     "hammerjs": "^2.0.8",
     "prop-types": "^15.6.2",

--- a/extensions/measurement-tracking/package.json
+++ b/extensions/measurement-tracking/package.json
@@ -35,7 +35,7 @@
     "@cornerstonejs/core": "^0.16.1",
     "@cornerstonejs/tools": "^0.24.1",
     "@ohif/extension-cornerstone-dicom-sr": "^3.0.0",
-    "dcmjs": "^0.24.5",
+    "dcmjs": "^0.28.1",
     "prop-types": "^15.6.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/extensions/measurement-tracking/src/panels/PanelMeasurementTableTracking/index.tsx
+++ b/extensions/measurement-tracking/src/panels/PanelMeasurementTableTracking/index.tsx
@@ -17,9 +17,9 @@ const { formatDate } = utils;
 
 const DISPLAY_STUDY_SUMMARY_INITIAL_VALUE = {
   key: undefined, //
-  date: undefined, // '07-Sep-2010',
-  modality: undefined, // 'CT',
-  description: undefined, // 'CHEST/ABD/PELVIS W CONTRAST',
+  date: '', // '07-Sep-2010',
+  modality: '', // 'CT',
+  description: '', // 'CHEST/ABD/PELVIS W CONTRAST',
 };
 
 function PanelMeasurementTableTracking({ servicesManager, extensionManager }) {

--- a/extensions/tmtv/package.json
+++ b/extensions/tmtv/package.json
@@ -30,7 +30,7 @@
   "peerDependencies": {
     "@ohif/core": "^3.0.0",
     "@ohif/ui": "^2.0.0",
-    "dcmjs": "0.22.0",
+    "dcmjs": "0.28.0",
     "dicom-parser": "^1.8.9",
     "hammerjs": "^2.0.8",
     "prop-types": "^15.6.2",

--- a/extensions/tmtv/src/utils/measurementServiceMappings/utils/getSOPInstanceAttributes.js
+++ b/extensions/tmtv/src/utils/measurementServiceMappings/utils/getSOPInstanceAttributes.js
@@ -13,5 +13,6 @@ function _getUIDFromImageID(imageId) {
     SOPInstanceUID: instance.SOPInstanceUID,
     SeriesInstanceUID: instance.SeriesInstanceUID,
     StudyInstanceUID: instance.StudyInstanceUID,
+    frameNumber: instance.frameNumber || 1,
   };
 }

--- a/platform/core/package.json
+++ b/platform/core/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@babel/runtime": "7.16.3",
-    "dcmjs": "^0.24.5",
+    "dcmjs": "^0.28.1",
     "dicomweb-client": "^0.6.0",
     "isomorphic-base64": "^1.0.2",
     "lodash.merge": "^4.6.1",

--- a/platform/core/src/classes/MetadataProvider.js
+++ b/platform/core/src/classes/MetadataProvider.js
@@ -191,14 +191,16 @@ class MetadataProvider {
           rows: toNumber(instance.Rows),
           columns: toNumber(instance.Columns),
           imageOrientationPatient: toNumber(ImageOrientationPatient),
-          rowCosines: toNumber(rowCosines),
-          columnCosines: toNumber(columnCosines),
-          imagePositionPatient: toNumber(instance.ImagePositionPatient),
+          rowCosines: toNumber(rowCosines || [0, 1, 0]),
+          columnCosines: toNumber(columnCosines || [0, 0, -1]),
+          imagePositionPatient: toNumber(
+            instance.ImagePositionPatient || [0, 0, 0]
+          ),
           sliceThickness: toNumber(instance.SliceThickness),
           sliceLocation: toNumber(instance.SliceLocation),
-          pixelSpacing: toNumber(PixelSpacing),
-          rowPixelSpacing: toNumber(rowPixelSpacing),
-          columnPixelSpacing: toNumber(columnPixelSpacing),
+          pixelSpacing: toNumber(PixelSpacing || 1),
+          rowPixelSpacing: toNumber(rowPixelSpacing || 1),
+          columnPixelSpacing: toNumber(columnPixelSpacing || 1),
         };
         break;
       case WADO_IMAGE_LOADER_TAGS.IMAGE_PIXEL_MODULE:

--- a/platform/core/src/services/MeasurementService/MeasurementService.js
+++ b/platform/core/src/services/MeasurementService/MeasurementService.js
@@ -38,6 +38,7 @@ const MEASUREMENT_SCHEMA_KEYS = [
   'FrameOfReferenceUID',
   'referenceStudyUID',
   'referenceSeriesUID',
+  'frameNumber',
   'displaySetInstanceUID',
   'label',
   'description',

--- a/platform/core/src/utils/combineFrameInstance.ts
+++ b/platform/core/src/utils/combineFrameInstance.ts
@@ -12,22 +12,33 @@ const combineFrameInstance = (frame, instance) => {
   const {
     PerFrameFunctionalGroupsSequence,
     SharedFunctionalGroupsSequence,
+    NumberOfFrames,
   } = instance;
-  if (!PerFrameFunctionalGroupsSequence) return instance;
-  const shared = Object.values(SharedFunctionalGroupsSequence[0])
-    .map(it => it[0])
-    .filter(it => it !== undefined && typeof it === 'object');
-  const perFrame = Object.values(
-    PerFrameFunctionalGroupsSequence[(frame || 1) - 1]
-  )
-    .map(it => it[0])
-    .filter(it => it !== undefined && typeof it === 'object');
-  return Object.assign(
-    {},
-    instance,
-    ...Object.values(shared),
-    ...Object.values(perFrame)
-  );
+
+  if (PerFrameFunctionalGroupsSequence || NumberOfFrames > 1) {
+    const frameNumber = Number.parseInt(frame || 1);
+    const shared = (SharedFunctionalGroupsSequence
+      ? Object.values(SharedFunctionalGroupsSequence[0])
+      : []
+    )
+      .map(it => it[0])
+      .filter(it => it !== undefined && typeof it === 'object');
+    const perFrame = (PerFrameFunctionalGroupsSequence
+      ? Object.values(PerFrameFunctionalGroupsSequence[frameNumber - 1])
+      : []
+    )
+      .map(it => it[0])
+      .filter(it => it !== undefined && typeof it === 'object');
+
+    return Object.assign(
+      { frameNumber: frameNumber },
+      instance,
+      ...Object.values(shared),
+      ...Object.values(perFrame)
+    );
+  } else {
+    return instance;
+  }
 };
 
 export default combineFrameInstance;

--- a/platform/ui/src/components/Button/Button.tsx
+++ b/platform/ui/src/components/Button/Button.tsx
@@ -235,6 +235,7 @@ Button.propTypes = {
   ]),
   border: PropTypes.oneOf([
     'none',
+    'light',
     'default',
     'primary',
     'secondary',

--- a/platform/ui/src/components/MeasurementTable/MeasurementItem.tsx
+++ b/platform/ui/src/components/MeasurementTable/MeasurementItem.tsx
@@ -52,9 +52,9 @@ const MeasurementItem = ({
       </div>
       <div className="relative flex flex-col flex-1 px-2 py-1">
         <span className="mb-1 text-base text-primary-light">{label}</span>
-        {displayText.map(line => (
+        {displayText.map((line, i) => (
           <span
-            key={line}
+            key={i}
             className="pl-2 text-base text-white border-l border-primary-light"
             dangerouslySetInnerHTML={{ __html: line }}
           ></span>

--- a/platform/viewer/package.json
+++ b/platform/viewer/package.json
@@ -63,7 +63,7 @@
     "core-js": "^3.16.1",
     "cornerstone-math": "^0.1.9",
     "cornerstone-wado-image-loader": "^4.2.1",
-    "dcmjs": "^0.24.5",
+    "dcmjs": "^0.28.1",
     "detect-gpu": "^4.0.16",
     "dicom-parser": "^1.8.9",
     "dotenv-webpack": "^1.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10033,16 +10033,17 @@ dayjs@^1.10.4:
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.2.tgz#fa0f5223ef0d6724b3d8327134890cfe3d72fbe5"
   integrity sha512-F4LXf1OeU9hrSYRPTTj/6FbO4HTjPKXvEIC1P2kcnFurViINCVk3ZV0xAS3XVx9MkMsXbbqlK6hjseaYbgKEHw==
 
-dcmjs@^0.24.5:
-  version "0.24.6"
-  resolved "https://registry.yarnpkg.com/dcmjs/-/dcmjs-0.24.6.tgz#436d00361fb8d4286e68e2b0cab15939fa3acafb"
-  integrity sha512-ts/DigszrYXMOmYLRVlik4Z6Oq0fb4ykrveFkcIPclTk/uoND0uwbhO4IPMNnuhGGwaVFF6uXQISY+kgbpjn2g==
+dcmjs@^0.28.1:
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/dcmjs/-/dcmjs-0.28.1.tgz#e9b20dddef41fbdbf87c96d0e31531dd6ac93087"
+  integrity sha512-PzlxfdZazOkv9OCFYtp9jWzMt2GnfSvBOQ2SCqnFlDbzZWAiT6kvrfVHx5ux65Lct0P0IGLGoqRdQChtsjzL5A==
   dependencies:
     "@babel/runtime-corejs2" "^7.17.8"
     gl-matrix "^3.1.0"
     lodash.clonedeep "^4.5.0"
     loglevelnext "^3.0.1"
     ndarray "^1.0.19"
+    pako "^2.0.4"
 
 debug-log@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
OHIFv3 lacks the support of annotations and measurements on multi-frame DICOM files particularly when we want to persist and load Measurement SRs on multi-frame DICOM files.

There are several issues being resolved in this PR:
  - Supporting of annotations and measurements on multi-frame files
  - Saving Measurement SRs on multi-frame DICOM files
  - Fixed loading of frames of multi-frame DICOM files : it was not loading the last frame ( loading Frame 1 twice, and not loading the last frame) , as you can guess, it was related to indexing of frames. Frame numbers are 1-based, not 0-based.
  - Fix jumping to the selected measurement/annotation on multi-frame files
  - Show correct instance id and frame number on the "Measurement Tracking" panel
  - Fixed a few "React" errors that was causing error logs in the browser console.

External dependencies:
     This depends on the changes of `dcmjs` library:  https://github.com/dcmjs-org/dcmjs/pull/317
     The changes has been merged and available on version 0.28.1, therefore updated the package.json for dcmjs library.
