### PR TITLE
dcmjs package reference upgraded to 0.28.3

### DIFF
--- a/extensions/cornerstone-dicom-sr/package.json
+++ b/extensions/cornerstone-dicom-sr/package.json
@@ -34,7 +34,7 @@
   "peerDependencies": {
     "@ohif/core": "^3.0.0",
     "@ohif/ui": "^2.0.0",
-    "dcmjs": "^0.28.1",
+    "dcmjs": "^0.28.3",
     "dicom-parser": "^1.8.9",
     "hammerjs": "^2.0.8",
     "prop-types": "^15.6.2",

--- a/extensions/cornerstone/package.json
+++ b/extensions/cornerstone/package.json
@@ -30,7 +30,7 @@
     "@ohif/core": "^3.0.0",
     "@ohif/ui": "^2.0.0",
     "cornerstone-wado-image-loader": "^4.2.1",
-    "dcmjs": "^0.28.1",
+    "dcmjs": "^0.28.3",
     "dicom-parser": "^1.8.9",
     "hammerjs": "^2.0.8",
     "prop-types": "^15.6.2",

--- a/extensions/default/package.json
+++ b/extensions/default/package.json
@@ -32,7 +32,7 @@
   "peerDependencies": {
     "@ohif/core": "^3.0.0",
     "@ohif/i18n": "^1.0.0",
-    "dcmjs": "^0.28.1",
+    "dcmjs": "^0.28.3",
     "dicomweb-client": "^0.6.0",
     "prop-types": "^15.6.2",
     "react": "^17.0.2",

--- a/extensions/dicom-pdf/package.json
+++ b/extensions/dicom-pdf/package.json
@@ -30,7 +30,7 @@
   "peerDependencies": {
     "@ohif/core": "^3.0.0",
     "@ohif/ui": "^2.0.0",
-    "dcmjs": "^0.28.1",
+    "dcmjs": "^0.28.3",
     "dicom-parser": "^1.8.9",
     "hammerjs": "^2.0.8",
     "prop-types": "^15.6.2",

--- a/extensions/dicom-video/package.json
+++ b/extensions/dicom-video/package.json
@@ -30,7 +30,7 @@
   "peerDependencies": {
     "@ohif/core": "^3.0.0",
     "@ohif/ui": "^2.0.0",
-    "dcmjs": "^0.28.1",
+    "dcmjs": "^0.28.3",
     "dicom-parser": "^1.8.9",
     "hammerjs": "^2.0.8",
     "prop-types": "^15.6.2",

--- a/extensions/measurement-tracking/package.json
+++ b/extensions/measurement-tracking/package.json
@@ -35,7 +35,7 @@
     "@cornerstonejs/core": "^0.16.1",
     "@cornerstonejs/tools": "^0.24.1",
     "@ohif/extension-cornerstone-dicom-sr": "^3.0.0",
-    "dcmjs": "^0.28.1",
+    "dcmjs": "^0.28.3",
     "prop-types": "^15.6.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/extensions/tmtv/package.json
+++ b/extensions/tmtv/package.json
@@ -30,7 +30,7 @@
   "peerDependencies": {
     "@ohif/core": "^3.0.0",
     "@ohif/ui": "^2.0.0",
-    "dcmjs": "0.28.0",
+    "dcmjs": "^0.28.3",
     "dicom-parser": "^1.8.9",
     "hammerjs": "^2.0.8",
     "prop-types": "^15.6.2",

--- a/platform/core/package.json
+++ b/platform/core/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@babel/runtime": "7.16.3",
-    "dcmjs": "^0.28.1",
+    "dcmjs": "^0.28.3",
     "dicomweb-client": "^0.6.0",
     "isomorphic-base64": "^1.0.2",
     "lodash.merge": "^4.6.1",

--- a/platform/viewer/package.json
+++ b/platform/viewer/package.json
@@ -63,7 +63,7 @@
     "core-js": "^3.16.1",
     "cornerstone-math": "^0.1.9",
     "cornerstone-wado-image-loader": "^4.2.1",
-    "dcmjs": "^0.28.1",
+    "dcmjs": "^0.28.3",
     "detect-gpu": "^4.0.16",
     "dicom-parser": "^1.8.9",
     "dotenv-webpack": "^1.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10033,10 +10033,10 @@ dayjs@^1.10.4:
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.2.tgz#fa0f5223ef0d6724b3d8327134890cfe3d72fbe5"
   integrity sha512-F4LXf1OeU9hrSYRPTTj/6FbO4HTjPKXvEIC1P2kcnFurViINCVk3ZV0xAS3XVx9MkMsXbbqlK6hjseaYbgKEHw==
 
-dcmjs@^0.28.1:
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/dcmjs/-/dcmjs-0.28.1.tgz#e9b20dddef41fbdbf87c96d0e31531dd6ac93087"
-  integrity sha512-PzlxfdZazOkv9OCFYtp9jWzMt2GnfSvBOQ2SCqnFlDbzZWAiT6kvrfVHx5ux65Lct0P0IGLGoqRdQChtsjzL5A==
+dcmjs@^0.28.3:
+  version "0.28.3"
+  resolved "https://registry.yarnpkg.com/dcmjs/-/dcmjs-0.28.3.tgz#a756ab4b02363d12545c9830b8f97b5141723727"
+  integrity sha512-GZOu+CtNvdWsPv8ga9Ywm/1YadEqT/+FhwcpgsbDAmKDUKe+6uNH+8KbEsRcaN1V5WFQEMwRbF9IRTl2qOoZvA==
   dependencies:
     "@babel/runtime-corejs2" "^7.17.8"
     gl-matrix "^3.1.0"


### PR DESCRIPTION
Simple upgrade of dcmjs package reference.
This PR can be considered as a follow-up of https://github.com/OHIF/Viewers/pull/2973

An important feature addition for dcmjs is available from v0.28.3
https://github.com/dcmjs-org/dcmjs/pull/320


This is about supporting annotations and measurements on multi-frame DICOM files.

In previous versions, when saving measurement SRs, the "Cornerstone3D - dcmjs connector" which is now included in the dcmjs package, will decide whether to treat it as a multi-frame or not by checking "SopClassUID" against the limited list of supported UIDs.
This was causing bugs when creating SRs on many multi-frame files ( annotations / measurements were saved without frame information they were attached to ).

With the above fixes, this should be resolved, because, as of now, it will check NumberOfFrames of the DICOM instance instead.



