### PR TITLE
upgrade cornerstonjs core 0.16.8

### DIFF
--- a/extensions/cornerstone-dicom-sr/package.json
+++ b/extensions/cornerstone-dicom-sr/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "@babel/runtime": "7.16.3",
     "classnames": "^2.2.6",
-    "@cornerstonejs/core": "^0.16.1",
+    "@cornerstonejs/core": "^0.16.8",
     "@cornerstonejs/tools": "^0.24.1"
   }
 }

--- a/extensions/cornerstone/package.json
+++ b/extensions/cornerstone/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@babel/runtime": "7.17.9",
-    "@cornerstonejs/core": "^0.16.1",
+    "@cornerstonejs/core": "^0.16.8",
     "@cornerstonejs/streaming-image-volume-loader": "^0.4.23",
     "@cornerstonejs/tools": "^0.24.1",
     "@kitware/vtk.js": "^24.18.7",

--- a/extensions/measurement-tracking/package.json
+++ b/extensions/measurement-tracking/package.json
@@ -32,7 +32,7 @@
   "peerDependencies": {
     "@ohif/core": "^3.0.0",
     "classnames": "^2.2.6",
-    "@cornerstonejs/core": "^0.16.1",
+    "@cornerstonejs/core": "^0.16.8",
     "@cornerstonejs/tools": "^0.24.1",
     "@ohif/extension-cornerstone-dicom-sr": "^3.0.0",
     "dcmjs": "^0.28.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2314,6 +2314,14 @@
     detect-gpu "^4.0.7"
     lodash.clonedeep "4.5.0"
 
+"@cornerstonejs/core@^0.16.8":
+  version "0.16.8"
+  resolved "https://registry.yarnpkg.com/@cornerstonejs/core/-/core-0.16.8.tgz#084f24a3736b6b562eba6f6b4934b327cec06e13"
+  integrity sha512-V5h0VrynBmjQzviXt12bmtudj8eLv37Ycj7vgDHCi4U0xUezDHzV8FP8CEoesYdAvSXJOMLFG4iZn/cSftMEQg==
+  dependencies:
+    detect-gpu "^4.0.7"
+    lodash.clonedeep "4.5.0"
+
 "@cornerstonejs/streaming-image-volume-loader@^0.4.23":
   version "0.4.23"
   resolved "https://registry.npmjs.org/@cornerstonejs/streaming-image-volume-loader/-/streaming-image-volume-loader-0.4.23.tgz#77d8d0de03ea7343ff73af7b98ec2035212c1215"


### PR DESCRIPTION
Upgrade @cornerstonjs/core to 0.16.8 to benefit from fixes

https://github.com/cornerstonejs/cornerstone3D-beta/pull/241 fixes the bug that multi-frame files sometimes have whitening noise on the frames other than the first frame.