### PR TITLE
Fix spelling of continuous in documentation

### DIFF
--- a/platform/docs/docs/development/continous-integration.md
+++ b/platform/docs/docs/development/continous-integration.md
@@ -1,11 +1,11 @@
 ---
 sidebar_position: 7
-sidebar_label: Continuos Integration
+sidebar_label: Continuous Integration
 ---
 
-# Continuos Integration (CI)
+# Continuous Integration (CI)
 
-This repository uses `CircleCI` and `Netlify` for Continuos integration.
+This repository uses `CircleCI` and `Netlify` for Continuous integration.
 
 ## Deploy Previews
 


### PR DESCRIPTION
I've left the file name as it as to not break and existing URL's

### PR Checklist

- [X] Brief description of changes: **Just quick typo fix up.**
- [ ] Links to any relevant issues
- [ ] Required status checks are passing
- [ ] User cases if changes impact the user's experience
- [ ] `@mention` a maintainer to request a review

<!--
  Links
  -->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
