### PR TITLE
docker compose and build update for orthanc-keycloak-recipe

### DIFF
--- a/platform/viewer/.recipes/OpenResty-Orthanc-Keycloak/docker-compose.yml
+++ b/platform/viewer/.recipes/OpenResty-Orthanc-Keycloak/docker-compose.yml
@@ -67,7 +67,8 @@ services:
       # Keycloak
       KEYCLOAK_USER: admin
       KEYCLOAK_PASSWORD: password
-      KEYCLOAK_IMPORT: /tmp/ohif-keycloak-realm.json
+      # Key cloak upload from scriptsis DISABLED by default now,.must force active else wont import from file
+      KEYCLOAK_IMPORT: /tmp/ohif-keycloak-realm.json  -Dkeycloak.profile.feature.upload_scripts=enabled
       # KEYCLOAK_WELCOME_THEME: <theme-name>
       # KEYCLOAK_DEFAULT_THEME: <theme-name>
       # KEYCLOAK_HOSTNAME: (recommended in prod)
@@ -83,6 +84,7 @@ services:
     hostname: postgres
     container_name: postgres
     volumes:
+       # Remember one can point the posgres db data to a mount on host machine also
       - postgres_data:/var/lib/postgresql/data
     environment:
       POSTGRES_DB: keycloak

--- a/platform/viewer/.recipes/OpenResty-Orthanc-Keycloak/dockerfile
+++ b/platform/viewer/.recipes/OpenResty-Orthanc-Keycloak/dockerfile
@@ -25,7 +25,9 @@
 # Stage 1: Build the application
 
 # Needs to be pinned at 16.x for now because of https://github.com/webpack/webpack/issues/14532
-FROM node:lts-slim as builder
+# Force the pin to 16.x as higher level gives build errors when used (https://github.com/webpack/webpack/issues/14532) 
+# If still have build issues, consider removing all cypress entries as per - https://github.com/OHIF/Viewers/issues/2655
+FROM node:16-slim as builder
 
 RUN mkdir /usr/src/app
 WORKDIR /usr/src/app
@@ -59,7 +61,8 @@ RUN luarocks install lua-resty-session
 RUN luarocks install lua-resty-http
 # !!!
 RUN luarocks install lua-resty-openidc
-RUN luarocks install luacrypto
+# Remove due to build errors when trying to install crypto, add if really need, works standard without it
+# RUN luarocks install luacrypto
 
 # Copy build output to image
 COPY --from=builder /usr/src/app/platform/viewer/dist /var/www/html


### PR DESCRIPTION
Recipe updates due to errors when building with latest versions. All fixed made based on current experience on Oct 2022
a) Node version fixed to version 16 
b) Keycloak load from source forced to be enabled (default is false now)

Changes made based on issues found when trying to setup from recipe (thus no link to issues)

No User Experience of main product affected, just docker build and compose

### PR Checklist

- [ X] Brief description of changes
- [ ] Links to any relevant issues
- [ ] Required status checks are passing
- [ ] User cases if changes impact the user's experience
- [ ] `@mention` a maintainer to request a review

<!--
  Links
  -->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
