### PR TITLE
Display series specified by URL query parameters in viewer

### DIFF
--- a/extensions/default/src/DicomWebDataSource/utils/StaticWadoClient.js
+++ b/extensions/default/src/DicomWebDataSource/utils/StaticWadoClient.js
@@ -41,8 +41,17 @@ export default class StaticWadoClient extends api.DICOMwebClient {
     const { queryParams } = options;
     if (!queryParams) return searchResult;
     const filtered = searchResult.filter(study => {
-      for (const key of Object.keys(StaticWadoClient.studyFilterKeys)) {
-        if (!this.filterItem(key, queryParams, study)) return false;
+      for (const key of Object.keys(StaticWadoClient.seriesFilterKeys)) {
+        if (
+          !this.filterItem(
+            key,
+            queryParams,
+            study,
+            StaticWadoClient.studyFilterKeys
+          )
+        ) {
+          return false;
+        }
       }
       return true;
     });
@@ -56,8 +65,17 @@ export default class StaticWadoClient extends api.DICOMwebClient {
     const { queryParams } = options;
     if (!queryParams) return searchResult;
     const filtered = searchResult.filter(study => {
-      for (const key of Object.keys(StaticWadoClient.studyFilterKeys)) {
-        if (!this.filterItem(key, queryParams, study)) return false;
+      for (const key of Object.keys(StaticWadoClient.seriesFilterKeys)) {
+        if (
+          !this.filterItem(
+            key,
+            queryParams,
+            study,
+            StaticWadoClient.seriesFilterKeys
+          )
+        ) {
+          return false;
+        }
       }
       return true;
     });
@@ -121,10 +139,11 @@ export default class StaticWadoClient extends api.DICOMwebClient {
    * @param {*} key
    * @param {*} queryParams
    * @param {*} study
+   * @param {*} sourceFilterMap
    * @returns
    */
-  filterItem(key, queryParams, study) {
-    const altKey = StaticWadoClient.studyFilterKeys[key] || key;
+  filterItem(key, queryParams, study, sourceFilterMap) {
+    const altKey = sourceFilterMap[key] || key;
     if (!queryParams) return true;
     const testValue = queryParams[key] || queryParams[altKey];
     if (!testValue) return true;


### PR DESCRIPTION
This change allow the filtering passed by the query parameter being made only over the OHIF client without need any change on the static-dicomweb to make it works. The user can pass through the URL the following query parameter: seriesInstaceUID or SeriesInstanceUID, retrieve the study information, and based on the series requested by the URL, it will only do the request regarding the series applied. This change was requests by @Zaid-Safadi and it's working as expected. If you take a look on the code, the only issue was on the filter option, what was using the wrong value to make it works.
