### PR TITLE
fix: revert the quotation inclusion for accept header to be off by de…

### DIFF
--- a/extensions/cornerstone/src/initWADOImageLoader.js
+++ b/extensions/cornerstone/src/initWADOImageLoader.js
@@ -52,7 +52,7 @@ export default function initWADOImageLoader(
       // we should set this flag to false.
       convertFloatPixelDataToInt: false,
     },
-    beforeSend: function (xhr) {
+    beforeSend: function(xhr) {
       const headers = UserAuthenticationService.getAuthorizationHeader();
 
       // Request:
@@ -61,7 +61,9 @@ export default function initWADOImageLoader(
       // For now we use image/jls and image/x-jls because some servers still use the old type
       // http://dicom.nema.org/medical/dicom/current/output/html/part18.html
       const xhrRequestHeaders = {
-        Accept: (appConfig.ommitQuotationFromMultipartRequest) ? 'multipart/related; type=application/octet-stream' : 'multipart/related; type="application/octet-stream"'
+        Accept: appConfig.keepQuotationForMultipartRequest
+          ? 'multipart/related; type="application/octet-stream"'
+          : 'multipart/related; type=application/octet-stream',
         // 'multipart/related; type="image/x-jls", multipart/related; type="image/jls"; transfer-syntax="1.2.840.10008.1.2.4.80", multipart/related; type="image/x-jls", multipart/related; type="application/octet-stream"; transfer-syntax=*',
       };
 

--- a/extensions/cornerstone/src/initWADOImageLoader.js
+++ b/extensions/cornerstone/src/initWADOImageLoader.js
@@ -61,9 +61,9 @@ export default function initWADOImageLoader(
       // For now we use image/jls and image/x-jls because some servers still use the old type
       // http://dicom.nema.org/medical/dicom/current/output/html/part18.html
       const xhrRequestHeaders = {
-        Accept: appConfig.keepQuotationForMultipartRequest
-          ? 'multipart/related; type="application/octet-stream"'
-          : 'multipart/related; type=application/octet-stream',
+        Accept: appConfig.omitQuotationForMultipartRequest
+          ? 'multipart/related; type=application/octet-stream'
+          : 'multipart/related; type="application/octet-stream"',
         // 'multipart/related; type="image/x-jls", multipart/related; type="image/jls"; transfer-syntax="1.2.840.10008.1.2.4.80", multipart/related; type="image/x-jls", multipart/related; type="application/octet-stream"; transfer-syntax=*',
       };
 

--- a/platform/viewer/public/config/aws.js
+++ b/platform/viewer/public/config/aws.js
@@ -4,6 +4,8 @@ window.config = {
   extensions: [],
   modes: [],
   showStudyList: true,
+  // below flag is for performance reasons, but it might not work for all servers
+  omitQuotationForMultipartRequest: true,
   // filterQueryParam: false,
   dataSources: [
     {

--- a/platform/viewer/public/config/default.js
+++ b/platform/viewer/public/config/default.js
@@ -5,6 +5,8 @@ window.config = {
   modes: [],
   showStudyList: true,
   maxNumberOfWebWorkers: 3,
+  // below flag is for performance reasons, but it might not work for all servers
+  omitQuotationForMultipartRequest: true,
   maxNumRequests: {
     interaction: 100,
     thumbnail: 75,

--- a/platform/viewer/public/config/demo.js
+++ b/platform/viewer/public/config/demo.js
@@ -2,6 +2,8 @@ window.config = {
   routerBasename: '/',
   extensions: [],
   showStudyList: true,
+  // below flag is for performance reasons, but it might not work for all servers
+  omitQuotationForMultipartRequest: true,
   servers: {
     dicomWeb: [
       {

--- a/platform/viewer/public/config/dicomweb-server.js
+++ b/platform/viewer/public/config/dicomweb-server.js
@@ -4,6 +4,8 @@ window.config = {
   extensions: [],
   modes: [],
   showStudyList: true,
+  // below flag is for performance reasons, but it might not work for all servers
+  omitQuotationForMultipartRequest: true,
   // filterQueryParam: false,
   dataSources: [
     {

--- a/platform/viewer/public/config/dicomweb_relative.js
+++ b/platform/viewer/public/config/dicomweb_relative.js
@@ -5,6 +5,8 @@ window.config = {
   modes: [],
   showStudyList: true,
   maxNumberOfWebWorkers: 3,
+  // below flag is for performance reasons, but it might not work for all servers
+  omitQuotationForMultipartRequest: true,
   // filterQueryParam: false,
   dataSources: [
     {

--- a/platform/viewer/public/config/docker_nginx-orthanc.js
+++ b/platform/viewer/public/config/docker_nginx-orthanc.js
@@ -3,6 +3,8 @@ window.config = {
   showStudyList: true,
   extensions: [],
   modes: [],
+  // below flag is for performance reasons, but it might not work for all servers
+  omitQuotationForMultipartRequest: true,
   dataSources: [
     {
       friendlyName: 'Orthanc Server',

--- a/platform/viewer/public/config/docker_openresty-orthanc-keycloak.js
+++ b/platform/viewer/public/config/docker_openresty-orthanc-keycloak.js
@@ -1,6 +1,8 @@
 window.config = {
   routerBasename: '/',
   showStudyList: true,
+  // below flag is for performance reasons, but it might not work for all servers
+  omitQuotationForMultipartRequest: true,
   servers: {
     // This is an array, but we'll only use the first entry for now
     dicomWeb: [

--- a/platform/viewer/public/config/docker_openresty-orthanc.js
+++ b/platform/viewer/public/config/docker_openresty-orthanc.js
@@ -3,6 +3,8 @@ window.config = {
   showStudyList: true,
   extensions: [],
   modes: [],
+  // below flag is for performance reasons, but it might not work for all servers
+  omitQuotationForMultipartRequest: true,
   dataSources: [
     {
       friendlyName: 'Orthanc Server',

--- a/platform/viewer/public/config/e2e.js
+++ b/platform/viewer/public/config/e2e.js
@@ -4,6 +4,8 @@ window.config = {
   extensions: [],
   modes: [],
   showStudyList: true,
+  // below flag is for performance reasons, but it might not work for all servers
+  omitQuotationForMultipartRequest: true,
   // filterQueryParam: false,
   dataSources: [
     {

--- a/platform/viewer/public/config/google.js
+++ b/platform/viewer/public/config/google.js
@@ -1,6 +1,8 @@
 window.config = {
   routerBasename: '/',
   enableGoogleCloudAdapter: false,
+  // below flag is for performance reasons, but it might not work for all servers
+  omitQuotationForMultipartRequest: true,
   // This is an array, but we'll only use the first entry for now
   oidc: [
     {

--- a/platform/viewer/public/config/idc.js
+++ b/platform/viewer/public/config/idc.js
@@ -1,6 +1,8 @@
 window.config = {
   routerBasename: '/',
   enableGoogleCloudAdapter: true,
+  // below flag is for performance reasons, but it might not work for all servers
+  omitQuotationForMultipartRequest: true,
   servers: {
     // This is an array, but we'll only use the first entry for now
     dicomWeb: [],

--- a/platform/viewer/public/config/local_dcm4chee.js
+++ b/platform/viewer/public/config/local_dcm4chee.js
@@ -3,6 +3,8 @@ window.config = {
   showStudyList: true,
   extensions: [],
   modes: [],
+  // below flag is for performance reasons, but it might not work for all servers
+  omitQuotationForMultipartRequest: true,
   dataSources: [
     {
       friendlyName: 'DCM4CHEE Server',

--- a/platform/viewer/public/config/local_static.js
+++ b/platform/viewer/public/config/local_static.js
@@ -5,6 +5,8 @@ window.config = {
   modes: [],
   showStudyList: true,
   maxNumberOfWebWorkers: 3,
+  // below flag is for performance reasons, but it might not work for all servers
+  omitQuotationForMultipartRequest: true,
   // filterQueryParam: false,
   dataSources: [
     {

--- a/platform/viewer/public/config/netlify.js
+++ b/platform/viewer/public/config/netlify.js
@@ -4,6 +4,8 @@ window.config = {
   extensions: [],
   modes: [],
   showStudyList: true,
+  // below flag is for performance reasons, but it might not work for all servers
+  omitQuotationForMultipartRequest: true,
   // filterQueryParam: false,
   dataSources: [
     {

--- a/platform/viewer/public/config/public_dicomweb.js
+++ b/platform/viewer/public/config/public_dicomweb.js
@@ -1,6 +1,8 @@
 window.config = {
   routerBasename: '/',
   showStudyList: true,
+  // below flag is for performance reasons, but it might not work for all servers
+  omitQuotationForMultipartRequest: true,
   servers: {
     dicomWeb: [
       {


### PR DESCRIPTION
…fault

Some backends require to have content type quoted, and throws error if not. By default we have put the content type as quoted and if that is not a requirement `omitQuotationForMultipartRequest` flag in the config _might_ have performance gain
