### PR TITLE
fix: Add support for showStudyList configuration setting

### DIFF
--- a/extensions/default/src/ViewerLayout/index.tsx
+++ b/extensions/default/src/ViewerLayout/index.tsx
@@ -202,6 +202,7 @@ function ViewerLayout({
     <div>
       <Header
         menuOptions={menuOptions}
+        isReturnEnabled={!!appConfig.showStudyList}
         onClickReturnButton={onClickReturnButton}
         WhiteLabeling={appConfig.whiteLabeling}
       >

--- a/platform/viewer/src/App.tsx
+++ b/platform/viewer/src/App.tsx
@@ -50,7 +50,13 @@ function App({ config, defaultExtensions, defaultModes }) {
 
   // Set appConfig
   const appConfigState = init.appConfig;
-  const { routerBasename, modes, dataSources, oidc } = appConfigState;
+  const {
+    routerBasename,
+    modes,
+    dataSources,
+    oidc,
+    showStudyList,
+  } = appConfigState;
 
   const {
     UIDialogService,
@@ -92,6 +98,7 @@ function App({ config, defaultExtensions, defaultModes }) {
     commandsManager,
     hotkeysManager,
     routerBasename,
+    showStudyList,
   });
 
   if (oidc) {

--- a/platform/viewer/src/routes/NotFound/NotFound.tsx
+++ b/platform/viewer/src/routes/NotFound/NotFound.tsx
@@ -2,15 +2,20 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 
+import { useAppConfig } from '@state';
+
 const NotFound = ({
   message = 'Sorry, this page does not exist.',
   showGoBackButton = true,
 }) => {
+  const [appConfig] = useAppConfig();
+  const { showStudyList } = appConfig;
+
   return (
     <div className="w-full h-full flex justify-center items-center text-white">
       <div>
         <h4>{message}</h4>
-        {showGoBackButton && (
+        {showGoBackButton && showStudyList && (
           <h5>
             <Link to={'/'}>Go back to the Study List</Link>
           </h5>

--- a/platform/viewer/src/routes/index.tsx
+++ b/platform/viewer/src/routes/index.tsx
@@ -14,12 +14,6 @@ import PrivateRoute from './PrivateRoute';
 const bakedInRoutes = [
   // WORK LIST
   {
-    path: '/',
-    children: DataSourceWrapper,
-    private: true,
-    props: { children: WorkList },
-  },
-  {
     path: '/local',
     children: Local,
   },
@@ -27,6 +21,12 @@ const bakedInRoutes = [
 
 // NOT FOUND (404)
 const notFoundRoute = { component: NotFound };
+const WorkListRoute = {
+  path: '/',
+  children: DataSourceWrapper,
+  private: true,
+  props: { children: WorkList },
+};
 
 const createRoutes = ({
   modes,
@@ -36,6 +36,7 @@ const createRoutes = ({
   commandsManager,
   hotkeysManager,
   routerBasename,
+  showStudyList,
 }) => {
   const routes =
     buildModeRoutes({
@@ -54,6 +55,7 @@ const createRoutes = ({
   );
   const allRoutes = [
     ...routes,
+    ...(showStudyList ? [WorkListRoute] : []),
     ...(customRoutes?.routes || []),
     ...bakedInRoutes,
     customRoutes?.notFoundRoute || notFoundRoute,


### PR DESCRIPTION
I followed suit with how it was implemented in the v2 branch, on the 404 page I just hid the link back to the study list if we're not configured to display it. See PR #2131

However I don't think the 404 page is being rendered correctly on `v3-stable`? I had the slightest poke but couldn't see what was going wrong there so left it alone.

### PR Checklist

- [x] Brief description of changes
- [ ] Links to any relevant issues
- [ ] Required status checks are passing
- [ ] User cases if changes impact the user's experience
- [X] `@mention` a maintainer to request a review

@sedghi tagging you as you seem to do most the reviews in this repo :slightly_smiling_face: 

<!--
  Links
  -->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
