### PR TITLE
Fix #3020 - Elliptical Annotations not being added/tracked when created outside the actual image area

### DIFF
--- a/extensions/cornerstone/src/utils/measurementServiceMappings/EllipticalROI.js
+++ b/extensions/cornerstone/src/utils/measurementServiceMappings/EllipticalROI.js
@@ -202,7 +202,8 @@ function getDisplayText(mappedAnnotations, displaySet) {
   const instanceText = InstanceNumber ? ` I: ${InstanceNumber}` : '';
   const frameText = displaySet.isMultiFrame ? ` F: ${frameNumber}` : '';
 
-  const roundedArea = utils.roundNumber(area, 2);
+  // Area sometimes becomes undefined if `preventHandleOutsideImage` is off.
+  const roundedArea = utils.roundNumber(area || 0, 2);
   displayText.push(`${roundedArea} mm<sup>2</sup>`);
 
   // Todo: we need a better UI for displaying all these information


### PR DESCRIPTION
The easiest fix for the issue would be handling of the cases where "area" becomes "undefined"