### PR TITLE
fix: Correctly ignore directories in CopyWebpackPlugin in webpack config

### DIFF
--- a/platform/viewer/.webpack/webpack.pwa.js
+++ b/platform/viewer/.webpack/webpack.pwa.js
@@ -87,7 +87,7 @@ module.exports = (env, argv) => {
             globOptions: {
               // Ignore our HtmlWebpackPlugin template file
               // Ignore our configuration files
-              ignore: ['config/*', 'html-templates/*', '.DS_Store'],
+              ignore: ['**/config/**', '**/html-templates/**', '.DS_Store'],
             },
           },
           // Short term solution to make sure GCloud config is available in output


### PR DESCRIPTION
Previously, the `config/` and `html-templates/` directories were copied to the `dist/` folder when building because of an incorrect reference in the webpack config.