### PR TITLE
feat(datasource):Support querying different data sources

### DIFF
--- a/extensions/default/src/ViewerLayout/index.tsx
+++ b/extensions/default/src/ViewerLayout/index.tsx
@@ -2,6 +2,8 @@ import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { useLocation } from 'react-router';
+
 import {
   SidePanel,
   ErrorBoundary,
@@ -11,7 +13,6 @@ import {
   useModal,
   LoadingIndicatorProgress,
 } from '@ohif/ui';
-
 import i18n from '@ohif/i18n';
 import { hotkeys } from '@ohif/core';
 import { useAppConfig } from '@state';
@@ -35,9 +36,19 @@ function ViewerLayout({
 }) {
   const [appConfig] = useAppConfig();
   const navigate = useNavigate();
+  const location = useLocation();
 
   const onClickReturnButton = () => {
-    navigate('/');
+    const { pathname } = location;
+    const dataSourceIdx = pathname.indexOf('/', 1);
+    const search =
+      dataSourceIdx === -1
+        ? undefined
+        : `datasourcename=${pathname.substring(dataSourceIdx + 1)}`;
+    navigate({
+      pathname: '/',
+      search,
+    });
   };
 
   const { t } = useTranslation();

--- a/platform/viewer/.webpack/webpack.pwa.js
+++ b/platform/viewer/.webpack/webpack.pwa.js
@@ -143,6 +143,9 @@ module.exports = (env, argv) => {
       client: {
         overlay: { errors: true, warnings: false },
       },
+      proxy: {
+        '/dicomweb': 'http://localhost:5000',
+      },
       'static': [
         {
           directory: '../../testdata',

--- a/platform/viewer/public/config/multiple.js
+++ b/platform/viewer/public/config/multiple.js
@@ -1,10 +1,11 @@
 window.config = {
   routerBasename: '/',
-  // whiteLabelling: {},
+  customizationService: [
+  ],
   extensions: [],
   modes: [],
   showStudyList: true,
-  maxNumberOfWebWorkers: 3,
+  maxNumberOfWebWorkers: 4,
   // below flag is for performance reasons, but it might not work for all servers
   omitQuotationForMultipartRequest: true,
   showLoadingIndicator: true,
@@ -13,7 +14,7 @@ window.config = {
     {
       friendlyName: 'Static WADO Local Data',
       namespace: '@ohif/extension-default.dataSourcesModule.dicomweb',
-      sourceName: 'dicomweb',
+      sourceName: 'default',
       configuration: {
         name: 'DCM4CHEE',
         qidoRoot: '/dicomweb',
@@ -27,6 +28,45 @@ window.config = {
         supportsWildcard: true,
         staticWado: true,
         singlepart: 'bulkdata,video,pdf',
+      },
+    },
+    {
+      friendlyName: 'AWS S3 OHIF',
+      namespace: '@ohif/extension-default.dataSourcesModule.dicomweb',
+      sourceName: 'aws',
+      configuration: {
+        name: 'aws',
+        qidoRoot: 'https://viewer.flexview.ai/dicomweb',
+        wadoRoot: 'https://viewer.flexview.ai/dicomweb',
+        qidoSupportsIncludeField: false,
+        supportsReject: false,
+        imageRendering: 'wadors',
+        thumbnailRendering: 'wadors',
+        enableStudyLazyLoad: true,
+        supportsFuzzyMatching: false,
+        supportsWildcard: true,
+        staticWado: true,
+        singlepart: 'bulkdata,video,pdf',
+      },
+    },
+    {
+      friendlyName: 'E2E Test Data',
+      namespace: '@ohif/extension-default.dataSourcesModule.dicomweb',
+      sourceName: 'e2e',
+      configuration: {
+        name: 'DCM4CHEE',
+        wadoUriRoot: '/viewer-testdata',
+        qidoRoot: '/viewer-testdata',
+        wadoRoot: '/viewer-testdata',
+        qidoSupportsIncludeField: false,
+        supportsReject: false,
+        imageRendering: 'wadors',
+        thumbnailRendering: 'wadors',
+        enableStudyLazyLoad: true,
+        supportsFuzzyMatching: false,
+        supportsWildcard: true,
+        staticWado: true,
+        singlepart: 'video,thumbnail,pdf',
       },
     },
     {
@@ -51,26 +91,7 @@ window.config = {
     // Could use services manager here to bring up a dialog/modal if needed.
     console.warn('test, navigate to https://ohif.org/');
   },
-  // whiteLabeling: {
-  //   /* Optional: Should return a React component to be rendered in the "Logo" section of the application's Top Navigation bar */
-  //   createLogoComponentFn: function (React) {
-  //     return React.createElement(
-  //       'a',
-  //       {
-  //         target: '_self',
-  //         rel: 'noopener noreferrer',
-  //         className: 'text-purple-600 line-through',
-  //         href: '/',
-  //       },
-  //       React.createElement('img',
-  //         {
-  //           src: './customLogo.svg',
-  //           className: 'w-8 h-8',
-  //         }
-  //       ))
-  //   },
-  // },
-  defaultDataSourceName: 'dicomweb',
+  defaultDataSourceName: 'default',
   hotkeys: [
     {
       commandName: 'incrementActiveViewport',

--- a/platform/viewer/src/routes/WorkList/WorkList.tsx
+++ b/platform/viewer/src/routes/WorkList/WorkList.tsx
@@ -46,6 +46,7 @@ function WorkList({
   isLoadingData,
   dataSource,
   hotkeysManager,
+  dataPath,
 }) {
   const { hotkeyDefinitions, hotkeyDefaults } = hotkeysManager;
   const { show, hide } = useModal();
@@ -346,7 +347,8 @@ function WorkList({
             return (
               <Link
                 key={i}
-                to={`${mode.routeName}?StudyInstanceUIDs=${studyInstanceUid}`}
+                to={`${dataPath ? '../../' : ''}${mode.routeName}${dataPath ||
+                  ''}?StudyInstanceUIDs=${studyInstanceUid}`}
                 // to={`${mode.routeName}/dicomweb?StudyInstanceUIDs=${studyInstanceUid}`}
               >
                 <Button
@@ -496,6 +498,7 @@ const defaultFilterValues = {
   sortDirection: 'none',
   pageNumber: 1,
   resultsPerPage: 25,
+  datasourcename: '',
 };
 
 function _tryParseInt(str, defaultValue) {
@@ -527,6 +530,7 @@ function _getQueryFilterValues(query) {
     sortDirection: query.get('sortDirection'),
     pageNumber: _tryParseInt(query.get('pageNumber'), undefined),
     resultsPerPage: _tryParseInt(query.get('resultsPerPage'), undefined),
+    datasourcename: query.get('datasourcename'),
   };
 
   // Delete null/undefined keys


### PR DESCRIPTION
This change adds the ability to show the worklist against different data sources by using a path /:datasourcename.  It also fixes the various sub-paths so that they return to the correct parent data source name.  For example, in the multiple.js configuration, there are data sources:  default, aws and e2e.  Then, one can query three different back ends with:
http://localhost:3000/search/default
http://localhost:3000/search/aws
http://localhost:3000/search/e2e
You can pull/try those three examples (assuming you have a dicomweb instance on port 5000 running).