### PR TITLE
[Draft] feat: switch to oidc-client-ts since our current oidc-client is deprecated

### DIFF
--- a/.webpack/webpack.base.js
+++ b/.webpack/webpack.base.js
@@ -146,7 +146,7 @@ module.exports = (env, argv, { SRC_DIR, DIST_DIR }) => {
         ),
       }),
       // Uncomment to generate bundle analyzer
-      new BundleAnalyzerPlugin(),
+      // new BundleAnalyzerPlugin(),
     ],
   };
 

--- a/.webpack/webpack.base.js
+++ b/.webpack/webpack.base.js
@@ -146,7 +146,7 @@ module.exports = (env, argv, { SRC_DIR, DIST_DIR }) => {
         ),
       }),
       // Uncomment to generate bundle analyzer
-      // new BundleAnalyzerPlugin(),
+      new BundleAnalyzerPlugin(),
     ],
   };
 

--- a/platform/viewer/package.json
+++ b/platform/viewer/package.json
@@ -74,7 +74,7 @@
     "i18next-browser-languagedetector": "^3.0.1",
     "lodash.isequal": "4.5.0",
     "moment": "^2.24.0",
-    "oidc-client": "1.11.5",
+    "oidc-client-ts": "^2.1.0",
     "prop-types": "^15.7.2",
     "query-string": "^6.12.1",
     "react": "^17.0.2",

--- a/platform/viewer/public/config/google.js
+++ b/platform/viewer/public/config/google.js
@@ -12,8 +12,9 @@ window.config = {
       authority: 'https://accounts.google.com',
       client_id:
         '723928408739-k9k9r3i44j32rhu69vlnibipmmk9i57p.apps.googleusercontent.com',
+      client_secret: 'my_client_secret',
       redirect_uri: '/callback',
-      response_type: 'id_token token',
+      response_type: 'code',
       scope:
         'email profile openid https://www.googleapis.com/auth/cloudplatformprojects.readonly https://www.googleapis.com/auth/cloud-healthcare', // email profile openid
       // ~ OPTIONAL

--- a/platform/viewer/public/silent-refresh.html
+++ b/platform/viewer/public/silent-refresh.html
@@ -1,16 +1,15 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
+  <head>
+    <meta charset="UTF-8" />
     <title>Silent OpenID Connect Token Refresh Page</title>
-</head>
-<body>
+  </head>
+  <body>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/es5-shim/4.5.7/es5-shim.min.js"></script>
-    <script type="text/javascript" src='es6-shim.min.js'></script>
-    <script type="text/javascript" src="oidc-client.min.js"></script>
-    <script type="text/javascript" src='polyfill.min.js'></script>
+    <script type="text/javascript" src="es6-shim.min.js"></script>
+    <script type="text/javascript" src="polyfill.min.js"></script>
     <script type="text/javascript">
       new UserManager().signinSilentCallback().catch(console.error);
     </script>
-</body>
+  </body>
 </html>

--- a/platform/viewer/src/utils/OpenIdConnectRoutes.tsx
+++ b/platform/viewer/src/utils/OpenIdConnectRoutes.tsx
@@ -111,9 +111,11 @@ function OpenIdConnectRoutes({
   const getAuthorizationHeader = () => {
     const user = UserAuthenticationService.getUser();
 
-    return {
-      Authorization: `Bearer ${user.access_token}`,
-    };
+    if (user && user.access_token) {
+      return {
+        Authorization: `Bearer ${user.access_token}`,
+      };
+    }
   };
 
   const handleUnauthenticated = () => {
@@ -158,11 +160,11 @@ function OpenIdConnectRoutes({
   const location = useLocation();
   const { pathname, search } = location;
 
-  const redirect_uri = new URL(userManager.settings._redirect_uri).pathname; //.replace(routerBasename,'')
-  const silent_refresh_uri = new URL(userManager.settings._silent_redirect_uri)
+  const redirect_uri = new URL(userManager.settings.redirect_uri).pathname; //.replace(routerBasename,'')
+  const silent_refresh_uri = new URL(userManager.settings.silent_redirect_uri)
     .pathname; //.replace(routerBasename,'')
   const post_logout_redirect_uri = new URL(
-    userManager.settings._post_logout_redirect_uri
+    userManager.settings.post_logout_redirect_uri
   ).pathname; //.replace(routerBasename,'');
 
   // const pathnameRelative = pathname.replace(routerBasename,'');

--- a/platform/viewer/src/utils/getUserManagerForOpenIdConnectClient.js
+++ b/platform/viewer/src/utils/getUserManagerForOpenIdConnectClient.js
@@ -1,16 +1,15 @@
-import { UserManager } from 'oidc-client';
+import { UserManager } from 'oidc-client-ts';
 
 /**
  * Creates a userManager from oidcSettings
- * LINK: https://github.com/IdentityModel/oidc-client-js/wiki#configuration
  *
  * @param {Object} oidcSettings
- * @param {string} oidcSettings.authServerUrl,
- * @param {string} oidcSettings.clientId,
- * @param {string} oidcSettings.authRedirectUri,
- * @param {string} oidcSettings.postLogoutRedirectUri,
- * @param {string} oidcSettings.responseType,
- * @param {string} oidcSettings.extraQueryParams,
+ * @param {string} oidcSettings.redirect_uri,
+ * @param {string} oidcSettings.silent_redirect_uri,
+ * @param {string} oidcSettings.post_logout_redirect_uri,
+ * @param {string} oidcSettings.authority,
+ * @param {string} oidcSettings.client_id,
+ *
  */
 export default function getUserManagerForOpenIdConnectClient(oidcSettings) {
   if (!oidcSettings) {
@@ -20,7 +19,7 @@ export default function getUserManagerForOpenIdConnectClient(oidcSettings) {
   const settings = {
     ...oidcSettings,
     automaticSilentRenew: true,
-    revokeAccessTokenOnSignout: true,
+    revokeTokenOnSignout: true,
     filterProtocolClaims: true,
     loadUserInfo: true,
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -7917,7 +7917,7 @@ base64-arraybuffer@^1.0.2:
   resolved "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz#1c37589a7c4b0746e34bd1feb951da2df01c1bdc"
   integrity sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==
 
-base64-js@^1.0.2, base64-js@^1.3.1, base64-js@^1.5.1:
+base64-js@^1.0.2, base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
@@ -9465,7 +9465,7 @@ core-js@^2.4.1, core-js@^2.5.7, core-js@^2.6.12:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.12.tgz#d9333dfa7b065e347cc5682219d6f690859cc2ec"
   integrity sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
 
-core-js@^3.0.4, core-js@^3.16.1, core-js@^3.2.1, core-js@^3.6.5, core-js@^3.8.2, core-js@^3.8.3:
+core-js@^3.0.4, core-js@^3.16.1, core-js@^3.2.1, core-js@^3.6.5, core-js@^3.8.2:
   version "3.22.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.22.7.tgz#8d6c37f630f6139b8732d10f2c114c3f1d00024f"
   integrity sha512-Jt8SReuDKVNZnZEzyEQT5eK6T2RRCXkfTq7Lo09kpm+fHjgGewSbNjV+Wt4yZMhPDdzz2x1ulI5z/w4nxpBseg==
@@ -9672,9 +9672,9 @@ crypto-browserify@^3.11.0:
     randombytes "^2.0.0"
     randomfill "^1.0.3"
 
-crypto-js@^4.0.0:
+crypto-js@^4.1.1:
   version "4.1.1"
-  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-4.1.1.tgz#9e485bcf03521041bd85844786b83fb7619736cf"
+  resolved "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz#9e485bcf03521041bd85844786b83fb7619736cf"
   integrity sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw==
 
 crypto-random-string@^2.0.0:
@@ -15300,6 +15300,11 @@ junk@^3.1.0:
   resolved "https://registry.yarnpkg.com/junk/-/junk-3.1.0.tgz#31499098d902b7e98c5d9b9c80f43457a88abfa1"
   integrity sha512-pBxcB3LFc8QVgdggvZWyeys+hnrNWg4OcZIU/1X59k5jQdLBlCsYGRQaz234SqoRLTCgMH00fY0xRJH+F9METQ==
 
+jwt-decode@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz#3fb319f3675a2df0c2895c8f5e9fa4b67b04ed59"
+  integrity sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==
+
 keyv@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/keyv/-/keyv-3.1.0.tgz#ecc228486f69991e49e9476485a5be1e8fc5c4d9"
@@ -17122,16 +17127,13 @@ octokit-pagination-methods@^1.1.0:
   resolved "https://registry.yarnpkg.com/octokit-pagination-methods/-/octokit-pagination-methods-1.1.0.tgz#cf472edc9d551055f9ef73f6e42b4dbb4c80bea4"
   integrity sha512-fZ4qZdQ2nxJvtcasX7Ghl+WlWS/d9IgnBIwFZXVNNZUmzpno91SX5bc5vuxiuKoCtK78XxGGNuSCrDC7xYB3OQ==
 
-oidc-client@1.11.5:
-  version "1.11.5"
-  resolved "https://registry.yarnpkg.com/oidc-client/-/oidc-client-1.11.5.tgz#020aa193d68a3e1f87a24fcbf50073b738de92bb"
-  integrity sha512-LcKrKC8Av0m/KD/4EFmo9Sg8fSQ+WFJWBrmtWd+tZkNn3WT/sQG3REmPANE9tzzhbjW6VkTNy4xhAXCfPApAOg==
+oidc-client-ts@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/oidc-client-ts/-/oidc-client-ts-2.1.0.tgz#903b6d9c94a45f6f6eaa3c0aac7c6953a0f3905b"
+  integrity sha512-Rmfl/10g7tTLy8cXezn0Ek+Wa3bKwNnW7oRzLB/hU5EK/DC1D/W1d0GCjGf23WYd6b4Ifa8ud/NzgsMOnbNp8Q==
   dependencies:
-    acorn "^7.4.1"
-    base64-js "^1.5.1"
-    core-js "^3.8.3"
-    crypto-js "^4.0.0"
-    serialize-javascript "^4.0.0"
+    crypto-js "^4.1.1"
+    jwt-decode "^3.1.2"
 
 on-finished@2.4.1:
   version "2.4.1"


### PR DESCRIPTION
switch to oidc-client-ts since the oidc-client is deprecated. It significantly reduces the bundle size as well. However, it seems like it only supports `response_type` of `code` and for our current `id_token token` we need to add `client_secret` as well


https://github.com/authts/oidc-client-ts/blob/main/docs/migration.md
https://github.com/perarnborg/vuex-oidc/pull/187
https://github.com/authts/oidc-client-ts/issues/152
https://github.com/authts/oidc-client-ts/issues/571

Old client in build analyzer
![image](https://user-images.githubusercontent.com/7490180/203880079-b263b7fa-4a51-4991-b852-ddbb75aec06f.png)


