### PR TITLE
Fix: handle undefined instance object

### DIFF
--- a/extensions/cornerstone/src/services/SegmentationService/SegmentationService.ts
+++ b/extensions/cornerstone/src/services/SegmentationService/SegmentationService.ts
@@ -1332,9 +1332,7 @@ class SegmentationService {
       segDisplaySetInstanceUID
     );
 
-    const {
-      FrameOfReferenceUID: segFrameOfReferenceUID,
-    } = segDisplaySet.instance;
+    const segFrameOfReferenceUID = segDisplaySet.instance?.FrameOfReferenceUID;
 
     viewportDisplaySetInstanceUIDs.forEach(displaySetInstanceUID => {
       // check if the displaySet is sharing the same frameOfReferenceUID


### PR DESCRIPTION
Some DisplaySets don't have an `instance` property, thus throwing an error at this location. 

This change fixes this issue.

@sedghi Do you think this can be merged? :)

### PR Checklist

- [x] Brief description of changes
- [ ] Links to any relevant issues
- [ ] Required status checks are passing
- [ ] User cases if changes impact the user's experience
- [x] `@mention` a maintainer to request a review

<!--
  Links
  -->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
