### PR TITLE
Add CT volume in PET ROI Thresholding

### DIFF
--- a/extensions/tmtv/src/Panels/PanelROIThresholdSegmentation/PanelROIThresholdSegmentation.tsx
+++ b/extensions/tmtv/src/Panels/PanelROIThresholdSegmentation/PanelROIThresholdSegmentation.tsx
@@ -10,14 +10,16 @@ import ROIThresholdConfiguration, {
   ROI_STAT,
 } from './ROIThresholdConfiguration';
 
-const LOWER_THRESHOLD_DEFAULT = 0;
-const UPPER_THRESHOLD_DEFAULT = 100;
+const LOWER_CT_THRESHOLD_DEFAULT = -100;
+const UPPER_CT_THRESHOLD_DEFAULT = 50;
+const LOWER_PT_THRESHOLD_DEFAULT = 0;
+const UPPER_PT_THRESHOLD_DEFAULT = 5;
 const WEIGHT_DEFAULT = 0.41; // a default weight for suv max often used in the literature
 const DEFAULT_STRATEGY = ROI_STAT;
 
 function reducer(state, action) {
   const { payload } = action;
-  const { strategy, lower, upper, weight } = payload;
+  const { strategy, ctLower, ctUpper, ptLower, ptUpper, weight } = payload;
 
   switch (action.type) {
     case 'setStrategy':
@@ -28,8 +30,10 @@ function reducer(state, action) {
     case 'setThreshold':
       return {
         ...state,
-        lower: lower ? lower : state.lower,
-        upper: upper ? upper : state.upper,
+        ctLower: ctLower ? ctLower : state.ctLower,
+        ctUpper: ctUpper ? ctUpper : state.ctUpper,
+        ptLower: ptLower ? ptLower : state.ptLower,
+        ptUpper: ptUpper ? ptUpper : state.ptUpper,
       };
     case 'setWeight':
       return {
@@ -57,8 +61,10 @@ export default function PanelRoiThresholdSegmentation({
 
   const [config, dispatch] = useReducer(reducer, {
     strategy: DEFAULT_STRATEGY,
-    lower: LOWER_THRESHOLD_DEFAULT,
-    upper: UPPER_THRESHOLD_DEFAULT,
+    ctLower: LOWER_CT_THRESHOLD_DEFAULT,
+    ctUpper: UPPER_CT_THRESHOLD_DEFAULT,
+    ptLower: LOWER_PT_THRESHOLD_DEFAULT,
+    ptUpper: UPPER_PT_THRESHOLD_DEFAULT,
     weight: WEIGHT_DEFAULT,
   });
 

--- a/extensions/tmtv/src/Panels/PanelROIThresholdSegmentation/ROIThresholdConfiguration.tsx
+++ b/extensions/tmtv/src/Panels/PanelROIThresholdSegmentation/ROIThresholdConfiguration.tsx
@@ -79,74 +79,104 @@ function ROIThresholdConfiguration({ config, dispatch, runCommand }) {
       )}
       {config.strategy !== ROI_STAT && (
         <>
-          <div className="flex justify-between">
-            <Input
-              label={t('CT Lower')}
-              labelClassName="text-white"
-              className="mt-2 bg-black border-primary-main"
-              type="text"
-              containerClassName="mr-2"
-              value={config.ctLower}
-              onChange={e => {
-                dispatch({
-                  type: 'setThreshold',
-                  payload: {
-                    ctLower: e.target.value,
-                  },
-                });
-              }}
-            />
-            <Input
-              label={t('Upper')}
-              labelClassName="text-white"
-              className="mt-2 bg-black border-primary-main"
-              type="text"
-              containerClassName="mr-2"
-              value={config.ctUpper}
-              onChange={e => {
-                dispatch({
-                  type: 'setThreshold',
-                  payload: {
-                    ctUpper: e.target.value,
-                  },
-                });
-              }}
-            />
-          </div>
-          <div className="flex justify-between">
-            <Input
-              label={t('PT Lower')}
-              labelClassName="text-white"
-              className="mt-2 bg-black border-primary-main"
-              type="text"
-              containerClassName="mr-2"
-              value={config.ptLower}
-              onChange={e => {
-                dispatch({
-                  type: 'setThreshold',
-                  payload: {
-                    ptLower: e.target.value,
-                  },
-                });
-              }}
-            />
-            <Input
-              label={t('Upper')}
-              labelClassName="text-white"
-              className="mt-2 bg-black border-primary-main"
-              type="text"
-              containerClassName="mr-2"
-              value={config.ptUpper}
-              onChange={e => {
-                dispatch({
-                  type: 'setThreshold',
-                  payload: {
-                    ptUpper: e.target.value,
-                  },
-                });
-              }}
-            />
-          </div>
+          <table>
+            <tr>
+              <th
+                className="text-white"
+                style={{
+                  textAlign: 'center',
+                  width: '50px',
+                  verticalAlign: 'bottom',
+                }}
+              >
+                CT
+              </th>
+              <td>
+                <div className="flex justify-between">
+                  <Input
+                    label={t('Lower')}
+                    labelClassName="text-white"
+                    className="mt-2 bg-black border-primary-main"
+                    type="text"
+                    containerClassName="mr-2"
+                    value={config.ctLower}
+                    onChange={e => {
+                      dispatch({
+                        type: 'setThreshold',
+                        payload: {
+                          ctLower: e.target.value,
+                        },
+                      });
+                    }}
+                  />
+                  <Input
+                    label={t('Upper')}
+                    labelClassName="text-white"
+                    className="mt-2 bg-black border-primary-main"
+                    type="text"
+                    containerClassName="mr-2"
+                    value={config.ctUpper}
+                    onChange={e => {
+                      dispatch({
+                        type: 'setThreshold',
+                        payload: {
+                          ctUpper: e.target.value,
+                        },
+                      });
+                    }}
+                  />
+                </div>
+              </td>
+            </tr>
+            <tr>
+              <th
+                className="text-white"
+                style={{
+                  textAlign: 'center',
+                  width: '50px',
+                  verticalAlign: 'bottom',
+                }}
+              >
+                PT
+              </th>
+              <td>
+                <div className="flex justify-between">
+                  <Input
+                    label={t('Lower')}
+                    labelClassName="text-white"
+                    className="mt-2 bg-black border-primary-main"
+                    type="text"
+                    containerClassName="mr-2"
+                    value={config.ptLower}
+                    onChange={e => {
+                      dispatch({
+                        type: 'setThreshold',
+                        payload: {
+                          ptLower: e.target.value,
+                        },
+                      });
+                    }}
+                  />
+                  <Input
+                    label={t('Upper')}
+                    labelClassName="text-white"
+                    className="mt-2 bg-black border-primary-main"
+                    type="text"
+                    containerClassName="mr-2"
+                    value={config.ptUpper}
+                    onChange={e => {
+                      dispatch({
+                        type: 'setThreshold',
+                        payload: {
+                          ptUpper: e.target.value,
+                        },
+                      });
+                    }}
+                  />
+                </div>
+              </td>
+            </tr>
+          </table>
         </>
       )}
     </div>

--- a/extensions/tmtv/src/Panels/PanelROIThresholdSegmentation/ROIThresholdConfiguration.tsx
+++ b/extensions/tmtv/src/Panels/PanelROIThresholdSegmentation/ROIThresholdConfiguration.tsx
@@ -78,40 +78,76 @@ function ROIThresholdConfiguration({ config, dispatch, runCommand }) {
         />
       )}
       {config.strategy !== ROI_STAT && (
-        <div className="flex justify-between">
-          <Input
-            label={t('Lower')}
-            labelClassName="text-white"
-            className="mt-2 bg-black border-primary-main"
-            type="text"
-            containerClassName="mr-2"
-            value={config.lower}
-            onChange={e => {
-              dispatch({
-                type: 'setThreshold',
-                payload: {
-                  lower: e.target.value,
-                },
-              });
-            }}
-          />
-          <Input
-            label={t('Upper')}
-            labelClassName="text-white"
-            className="mt-2 bg-black border-primary-main"
-            type="text"
-            containerClassName="mr-2"
-            value={config.upper}
-            onChange={e => {
-              dispatch({
-                type: 'setThreshold',
-                payload: {
-                  upper: e.target.value,
-                },
-              });
-            }}
-          />
-        </div>
+        <>
+          <div className="flex justify-between">
+            <Input
+              label={t('CT Lower')}
+              labelClassName="text-white"
+              className="mt-2 bg-black border-primary-main"
+              type="text"
+              containerClassName="mr-2"
+              value={config.ctLower}
+              onChange={e => {
+                dispatch({
+                  type: 'setThreshold',
+                  payload: {
+                    ctLower: e.target.value,
+                  },
+                });
+              }}
+            />
+            <Input
+              label={t('Upper')}
+              labelClassName="text-white"
+              className="mt-2 bg-black border-primary-main"
+              type="text"
+              containerClassName="mr-2"
+              value={config.ctUpper}
+              onChange={e => {
+                dispatch({
+                  type: 'setThreshold',
+                  payload: {
+                    ctUpper: e.target.value,
+                  },
+                });
+              }}
+            />
+          </div>
+          <div className="flex justify-between">
+            <Input
+              label={t('PT Lower')}
+              labelClassName="text-white"
+              className="mt-2 bg-black border-primary-main"
+              type="text"
+              containerClassName="mr-2"
+              value={config.ptLower}
+              onChange={e => {
+                dispatch({
+                  type: 'setThreshold',
+                  payload: {
+                    ptLower: e.target.value,
+                  },
+                });
+              }}
+            />
+            <Input
+              label={t('Upper')}
+              labelClassName="text-white"
+              className="mt-2 bg-black border-primary-main"
+              type="text"
+              containerClassName="mr-2"
+              value={config.ptUpper}
+              onChange={e => {
+                dispatch({
+                  type: 'setThreshold',
+                  payload: {
+                    ptUpper: e.target.value,
+                  },
+                });
+              }}
+            />
+          </div>
+        </>
       )}
     </div>
   );

--- a/extensions/tmtv/src/Panels/PanelROIThresholdSegmentation/ROIThresholdConfiguration.tsx
+++ b/extensions/tmtv/src/Panels/PanelROIThresholdSegmentation/ROIThresholdConfiguration.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Input, Select, Button, ButtonGroup } from '@ohif/ui';
+import { Input, Label, Select, Button, ButtonGroup } from '@ohif/ui';
 import { useTranslation } from 'react-i18next';
 
 export const ROI_STAT = 'roi_stat';
@@ -81,16 +81,15 @@ function ROIThresholdConfiguration({ config, dispatch, runCommand }) {
         <>
           <table>
             <tr>
-              <th
-                className="text-white"
+              <td
                 style={{
-                  textAlign: 'center',
+                  textAlign: 'left',
                   width: '50px',
                   verticalAlign: 'bottom',
                 }}
               >
-                CT
-              </th>
+                <Label className="text-white" text="CT"></Label>
+              </td>
               <td>
                 <div className="flex justify-between">
                   <Input
@@ -129,20 +128,19 @@ function ROIThresholdConfiguration({ config, dispatch, runCommand }) {
               </td>
             </tr>
             <tr>
-              <th
-                className="text-white"
+              <td
                 style={{
-                  textAlign: 'center',
+                  textAlign: 'left',
                   width: '50px',
                   verticalAlign: 'bottom',
                 }}
               >
-                PT
-              </th>
+                <Label className="text-white" text="PT"></Label>
+              </td>
               <td>
                 <div className="flex justify-between">
                   <Input
-                    label={t('Lower')}
+                    label={t('')}
                     labelClassName="text-white"
                     className="mt-2 bg-black border-primary-main"
                     type="text"
@@ -158,7 +156,7 @@ function ROIThresholdConfiguration({ config, dispatch, runCommand }) {
                     }}
                   />
                   <Input
-                    label={t('Upper')}
+                    label={t('')}
                     labelClassName="text-white"
                     className="mt-2 bg-black border-primary-main"
                     type="text"

--- a/extensions/tmtv/src/commandsModule.js
+++ b/extensions/tmtv/src/commandsModule.js
@@ -173,12 +173,21 @@ const commandsModule = ({
       );
 
       const { representationData } = segmentation;
-      const { volumeId: segVolumeId } = representationData[LABELMAP];
+      const {
+        displaySetMatchDetails: matchDetails,
+      } = HangingProtocolService.getMatchDetails();
+      console.log(matchDetails);
+      const volumeLoaderScheme = 'cornerstoneStreamingImageVolume'; // Loader id which defines which volume loader to use
 
+      const ctDisplaySet = matchDetails.get('ctDisplaySet');
+      const ctVolumeId = `${volumeLoaderScheme}:${ctDisplaySet.displaySetInstanceUID}`; // VolumeId with loader id + volume id
+
+      const { volumeId: segVolumeId } = representationData[LABELMAP];
       const { referencedVolumeId } = cs.cache.getVolume(segVolumeId);
 
       const labelmapVolume = cs.cache.getVolume(segmentationId);
       const referencedVolume = cs.cache.getVolume(referencedVolumeId);
+      const ctReferencedVolume = cs.cache.getVolume(ctVolumeId);
 
       if (!referencedVolume) {
         throw new Error('No Reference volume found');
@@ -201,23 +210,20 @@ const commandsModule = ({
         return;
       }
 
-      const { lower, upper } = getThresholdValues(
+      const { ptLower, ptUpper, ctLower, ctUpper } = getThresholdValues(
         annotationUIDs,
-        referencedVolume,
+        [referencedVolume, ctReferencedVolume],
         config
       );
-
-      const configToUse = {
-        lower,
-        upper,
-        overwrite: true,
-      };
 
       return csTools.utilities.segmentation.rectangleROIThresholdVolumeByRange(
         annotationUIDs,
         labelmapVolume,
-        [referencedVolume],
-        configToUse
+        [
+          { volume: referencedVolume, lower: ptLower, upper: ptUpper },
+          { volume: ctReferencedVolume, lower: ctLower, upper: ctUpper },
+        ],
+        { overwrite: true }
       );
     },
     calculateSuvPeak: ({ labelmap }) => {

--- a/extensions/tmtv/src/utils/getThresholdValue.ts
+++ b/extensions/tmtv/src/utils/getThresholdValue.ts
@@ -1,19 +1,7 @@
 import * as csTools from '@cornerstonejs/tools';
 
-function getThresholdValues(
-  annotationUIDs,
-  referencedVolume,
-  config
-): { lower: number; upper: number } {
-  if (config.strategy === 'range') {
-    return {
-      lower: Number(config.lower),
-      upper: Number(config.upper),
-    };
-  }
-
+function getRoiStats(referencedVolume, annotations) {
   // roiStats
-  const { weight } = config;
   const { imageData } = referencedVolume;
   const values = imageData
     .getPointData()
@@ -23,10 +11,6 @@ function getThresholdValues(
   // Todo: add support for other strategies
   const { fn, baseValue } = _getStrategyFn('max');
   let value = baseValue;
-
-  const annotations = annotationUIDs.map(annotationUID =>
-    csTools.annotation.state.getAnnotation(annotationUID)
-  );
 
   const boundsIJK = csTools.utilities.rectangleROITool.getBoundsIJKFromRectangleAnnotations(
     annotations,
@@ -43,10 +27,36 @@ function getThresholdValues(
       }
     }
   }
+  return value;
+}
+
+function getThresholdValues(
+  annotationUIDs,
+  referencedVolumes,
+  config
+): { ptLower: number; ptUpper: number; ctLower: number; ctUpper: number } {
+  if (config.strategy === 'range') {
+    return {
+      ptLower: Number(config.ptLower),
+      ptUpper: Number(config.ptUpper),
+      ctLower: Number(config.ctLower),
+      ctUpper: Number(config.ctUpper),
+    };
+  }
+
+  const { weight } = config;
+  const annotations = annotationUIDs.map(annotationUID =>
+    csTools.annotation.state.getAnnotation(annotationUID)
+  );
+
+  const ptValue = getRoiStats(referencedVolumes[0], annotations);
+  const ctValue = getRoiStats(referencedVolumes[1], annotations);
 
   return {
-    lower: weight * value,
-    upper: +Infinity,
+    ctLower: weight * ctValue,
+    ctUpper: +Infinity,
+    ptLower: weight * ptValue,
+    ptUpper: +Infinity,
   };
 }
 


### PR DESCRIPTION
### PR Checklist
- Adds the CT volume data in ROI Thresholding
- Adds a new line in ROI Threshold panel to configure CT ranges

- This PR enables the user to create REOI by filtering both CT and PET data, facilitating the creation of roi in anatomical body parts with specific CT intensity ranges

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
