### PR TITLE
Fix Dicom Tag Browser slider doesn't update when series changed

### DIFF
--- a/extensions/default/src/DicomTagBrowser/DicomTagBrowser.tsx
+++ b/extensions/default/src/DicomTagBrowser/DicomTagBrowser.tsx
@@ -82,6 +82,7 @@ const DicomTagBrowser = ({ displaySets, displaySetInstanceUID }) => {
           <div className="w-1/2">
             <InputRange
               value={instanceNumber}
+              key={selectedDisplaySetInstanceUID}
               onChange={value => {
                 setInstanceNumber(parseInt(value));
               }}


### PR DESCRIPTION
In the Dicom Tag Browser if you move the instance slider and then change series, the slider won't update to the first position even though the new series displayed will start with the first instance. 

I've fixed this by giving the slider the displaySetInstanceUID as a key to force it to re-render when the series changes. I'm open to other solutions to the bug.

@sedghi Tagging you for review