### PR TITLE
Hp image matching

### DIFF
--- a/extensions/cornerstone/src/Viewport/OHIFCornerstoneViewport.tsx
+++ b/extensions/cornerstone/src/Viewport/OHIFCornerstoneViewport.tsx
@@ -105,6 +105,7 @@ const OHIFCornerstoneViewport = React.memo(props => {
     servicesManager,
     onElementEnabled,
     onElementDisabled,
+    needsRerendering,
     // Note: you SHOULD NOT use the initialImageIdOrIndex for manipulation
     // of the imageData in the OHIFCornerstoneViewport. This prop is used
     // to set the initial state of the viewport's first image to render
@@ -278,6 +279,25 @@ const OHIFCornerstoneViewport = React.memo(props => {
     // handle the default viewportType to be stack
     if (!viewportOptions.viewportType) {
       viewportOptions.viewportType = STACK;
+    }
+
+    if (needsRerendering) {
+      displaySets.forEach(displaySet => {
+        const viewportInfo = CornerstoneViewportService.getViewportInfoByIndex(
+          viewportIndex
+        );
+
+        if (viewportInfo.hasDisplaySet(displaySet.displaySetInstanceUID)) {
+          const viewportData = viewportInfo.getViewportData();
+          const currentViewportData = (viewportData) ? viewportData : { viewportType: STACK };
+          CornerstoneCacheService.invalidateViewportData(currentViewportData,
+            displaySet.displaySetInstanceUID,
+            dataSource,
+            DisplaySetService);
+
+          displaySet.needsRerendering = false;
+        }
+      });
     }
 
     const loadViewportData = async () => {

--- a/extensions/cornerstone/src/initWADOImageLoader.js
+++ b/extensions/cornerstone/src/initWADOImageLoader.js
@@ -54,7 +54,7 @@ export default function initWADOImageLoader(
       // we should set this flag to false.
       convertFloatPixelDataToInt: false,
     },
-    beforeSend: function(xhr) {
+    beforeSend: function (xhr, imagId) {
       const headers = UserAuthenticationService.getAuthorizationHeader();
 
       // Request:
@@ -62,12 +62,12 @@ export default function initWADOImageLoader(
       // whatever transfer-syntax the origin server provides.
       // For now we use image/jls and image/x-jls because some servers still use the old type
       // http://dicom.nema.org/medical/dicom/current/output/html/part18.html
-      const xhrRequestHeaders = {
+      const xhrRequestHeaders = isWadoRs(imagId) ? {
         Accept: appConfig.omitQuotationForMultipartRequest
           ? 'multipart/related; type=application/octet-stream'
           : 'multipart/related; type="application/octet-stream"',
         // 'multipart/related; type="image/x-jls", multipart/related; type="image/jls"; transfer-syntax="1.2.840.10008.1.2.4.80", multipart/related; type="image/x-jls", multipart/related; type="application/octet-stream"; transfer-syntax=*',
-      };
+      } : {};
 
       if (headers && headers.Authorization) {
         xhrRequestHeaders.Authorization = headers.Authorization;
@@ -81,6 +81,10 @@ export default function initWADOImageLoader(
   });
 
   initWebWorkers(appConfig);
+}
+
+function isWadoRs(imageId) {
+  return imageId.indexOf('wadors:') == 0;
 }
 
 export function destroy() {

--- a/extensions/cornerstone/src/initWADOImageLoader.js
+++ b/extensions/cornerstone/src/initWADOImageLoader.js
@@ -62,6 +62,9 @@ export default function initWADOImageLoader(
       // whatever transfer-syntax the origin server provides.
       // For now we use image/jls and image/x-jls because some servers still use the old type
       // http://dicom.nema.org/medical/dicom/current/output/html/part18.html
+      // The Accept header should only be set to a multipart/related type in
+      // wado-rs request. Other requests (e.g. wado-uri) that don't support
+      // this value in the accept header may cause the server to reject the request as unacceptable.
       const xhrRequestHeaders = isWadoRs(imagId) ? {
         Accept: appConfig.omitQuotationForMultipartRequest
           ? 'multipart/related; type=application/octet-stream'
@@ -84,7 +87,7 @@ export default function initWADOImageLoader(
 }
 
 function isWadoRs(imageId) {
-  return imageId.indexOf('wadors:') == 0;
+  return imageId.indexOf('wadors:') === 0;
 }
 
 export function destroy() {

--- a/extensions/cornerstone/src/services/CornerstoneCacheService/CornerstoneCacheService.ts
+++ b/extensions/cornerstone/src/services/CornerstoneCacheService/CornerstoneCacheService.ts
@@ -3,7 +3,6 @@ import { utils } from '@ohif/core';
 
 import getCornerstoneViewportType from '../../utils/getCornerstoneViewportType';
 import {
-  StackData,
   StackViewportData,
   VolumeViewportData,
 } from '../../types/CornerstoneCacheService';
@@ -12,8 +11,8 @@ const VOLUME_IMAGE_LOADER_SCHEME = 'streaming-wadors';
 const VOLUME_LOADER_SCHEME = 'cornerstoneStreamingImageVolume';
 
 class CornerstoneCacheService {
-  stackImageIds: Map<string, string[]> = new Map();
-  volumeImageIds: Map<string, string[]> = new Map();
+  stackImageIdsMap: Map<string, string[]> = new Map();
+  volumeImageIdsMap: Map<string, string[]> = new Map();
 
   constructor(servicesManager) {
     this.servicesManager = servicesManager;
@@ -68,15 +67,15 @@ class CornerstoneCacheService {
   }
 
   public async invalidateViewportData(
-    viewportData: StackData | VolumeViewportData,
+    viewportData: StackViewportData | VolumeViewportData,
     invalidatedDisplaySetInstanceUID: string,
     dataSource,
     DisplaySetService
   ) {
     if (viewportData.viewportType === Enums.ViewportType.STACK) {
       const displaySet = DisplaySetService.getDisplaySetByUID(invalidatedDisplaySetInstanceUID)
-      if (this.stackImageIds.has(invalidatedDisplaySetInstanceUID)) {
-        this.stackImageIds.delete(invalidatedDisplaySetInstanceUID);
+      if (this.stackImageIdsMap.has(invalidatedDisplaySetInstanceUID)) {
+        this.stackImageIdsMap.delete(invalidatedDisplaySetInstanceUID);
         return await this._getStackViewportData(
           dataSource,
           [displaySet],
@@ -114,13 +113,13 @@ class CornerstoneCacheService {
     // For Stack Viewport we don't have fusion currently
     const displaySet = displaySets[0];
 
-    let stackImageIds = this.stackImageIds.get(
+    let stackImageIds = this.stackImageIdsMap.get(
       displaySet.displaySetInstanceUID
     );
 
     if (!stackImageIds) {
       stackImageIds = this._getCornerstoneStackImageIds(displaySet, dataSource);
-      this.stackImageIds.set(displaySet.displaySetInstanceUID, stackImageIds);
+      this.stackImageIdsMap.set(displaySet.displaySetInstanceUID, stackImageIds);
     }
 
     const { displaySetInstanceUID, StudyInstanceUID } = displaySet;
@@ -175,7 +174,7 @@ class CornerstoneCacheService {
 
       const volumeId = `${volumeLoaderSchema}:${displaySet.displaySetInstanceUID}`;
 
-      let volumeImageIds = this.volumeImageIds.get(
+      let volumeImageIds = this.volumeImageIdsMap.get(
         displaySet.displaySetInstanceUID
       );
 
@@ -191,7 +190,7 @@ class CornerstoneCacheService {
           imageIds: volumeImageIds,
         });
 
-        this.volumeImageIds.set(
+        this.volumeImageIdsMap.set(
           displaySet.displaySetInstanceUID,
           volumeImageIds
         );

--- a/extensions/cornerstone/src/services/ViewportService/Viewport.ts
+++ b/extensions/cornerstone/src/services/ViewportService/Viewport.ts
@@ -152,6 +152,8 @@ class ViewportInfo {
     // via cornerstoneViewportService
     let viewportData = this.getViewportData();
 
+    if (!viewportData) return false;
+
     if (viewportData.viewportType === Enums.ViewportType.ORTHOGRAPHIC) {
       viewportData = viewportData as VolumeViewportData;
       return viewportData.data.some(

--- a/extensions/default/src/getHangingProtocolModule.js
+++ b/extensions/default/src/getHangingProtocolModule.js
@@ -12,7 +12,7 @@ const defaultProtocol = {
   displaySetSelectors: {
     defaultDisplaySetId: {
       // Unused currently
-      imageMatchingRules: [],
+      instanceMatchingRules: [],
       // Matches displaysets, NOT series
       seriesMatchingRules: [
         // Try to match series with images by default, to prevent weird display

--- a/platform/core/src/classes/MetadataProvider.js
+++ b/platform/core/src/classes/MetadataProvider.js
@@ -443,17 +443,7 @@ class MetadataProvider {
       };
     }
 
-    // Maybe its a non-standard imageId
-    // check if the imageId starts with http:// or https:// using regex
-    // Todo: handle non http imageIds
-    let imageURI;
-    const urlRegex = /^(http|https):\/\//;
-    if (urlRegex.test(imageId)) {
-      imageURI = imageId;
-    } else {
-      imageURI = imageIdToURI(imageId);
-    }
-
+    const imageURI = imageIdToURI(imageId);
     const uids = this.imageURIToUIDs.get(imageURI);
     const frameNumber = imageId.split(/\/frames\//)[1];
 

--- a/platform/core/src/services/DisplaySetService/EVENTS.js
+++ b/platform/core/src/services/DisplaySetService/EVENTS.js
@@ -4,6 +4,7 @@ const EVENTS = {
   DISPLAY_SETS_REMOVED: 'event::displaySetService:displaySetsRemoved',
   DISPLAY_SET_SERIES_METADATA_INVALIDATED:
     'event::displaySetService:displaySetSeriesMetadataInvalidated',
+  DISPLAY_SETS_FILTERED: 'event::displaySetService:displaySetsFiltered',
 };
 
 export default EVENTS;

--- a/platform/core/src/services/HangingProtocolService/HangingProtocolService.test.js
+++ b/platform/core/src/services/HangingProtocolService/HangingProtocolService.test.js
@@ -125,6 +125,7 @@ describe('HangingProtocolService', () => {
     expect(hps.getProtocols().length).toBe(1);
   });
 
+  //TODO: add a unit test for the imageMatchingRules
   describe('run', () => {
     it('matches best image match', () => {
       hps.run({ studies: [studyMatch], displaySets: studyMatchDisplaySets });

--- a/platform/core/src/services/HangingProtocolService/HangingProtocolService.test.js
+++ b/platform/core/src/services/HangingProtocolService/HangingProtocolService.test.js
@@ -1,4 +1,6 @@
 import HangingProtocolServiceClass from './HangingProtocolService';
+import ServicesManager from '../ServicesManager.js';
+import DisplaySetService from '../DisplaySetService';
 
 const testProtocol = {
   id: 'test',
@@ -14,6 +16,7 @@ const testProtocol = {
   ],
   displaySetSelectors: {
     displaySetSelector: {
+      imageMatchingRules: [],
       seriesMatchingRules: [
         {
           weight: 1,
@@ -109,7 +112,9 @@ const studyMatchDisplaySets = [displaySet3, displaySet2, displaySet1];
 
 describe('HangingProtocolService', () => {
   const commandsManager = {};
-  const hps = new HangingProtocolServiceClass(commandsManager);
+  const servicesManager = new ServicesManager(commandsManager);
+  servicesManager.registerService(DisplaySetService);
+  const hps = new HangingProtocolServiceClass(commandsManager, servicesManager);
   let initialScaling;
 
   beforeAll(() => {

--- a/platform/core/src/services/HangingProtocolService/HangingProtocolService.test.js
+++ b/platform/core/src/services/HangingProtocolService/HangingProtocolService.test.js
@@ -16,7 +16,7 @@ const testProtocol = {
   ],
   displaySetSelectors: {
     displaySetSelector: {
-      imageMatchingRules: [],
+      instanceMatchingRules: [],
       seriesMatchingRules: [
         {
           weight: 1,
@@ -125,7 +125,7 @@ describe('HangingProtocolService', () => {
     expect(hps.getProtocols().length).toBe(1);
   });
 
-  //TODO: add a unit test for the imageMatchingRules
+  //TODO: add a unit test for the instanceMatchingRules
   describe('run', () => {
     it('matches best image match', () => {
       hps.run({ studies: [studyMatch], displaySets: studyMatchDisplaySets });

--- a/platform/core/src/services/HangingProtocolService/HangingProtocolService.ts
+++ b/platform/core/src/services/HangingProtocolService/HangingProtocolService.ts
@@ -1174,7 +1174,7 @@ class HangingProtocolService {
 
     // Todo: handle fusion viewports by not taking the first displaySet rule for the viewport
     const { DisplaySetService } = this._servicesManager.services;
-    const { studyMatchingRules = [], seriesMatchingRules, imageMatchingRules } = displaySetRules;
+    const { studyMatchingRules = [], seriesMatchingRules, instanceMatchingRules } = displaySetRules;
     const matchingScores = [];
     let highestStudyMatchingScore = 0;
     let highestSeriesMatchingScore = 0;
@@ -1238,14 +1238,14 @@ class HangingProtocolService {
           highestSeriesMatchingScore
         );
 
-        if (imageMatchingRules && imageMatchingRules.length) {
+        if (instanceMatchingRules && instanceMatchingRules.length) {
           const instances = displaySet.images || displaySet.others || [];
           const filteredInstances = [];
           for (let instanceIndex = instances.length - 1; instanceIndex >= 0; instanceIndex--) {
             const instance = instances[instanceIndex];
             const imagesMatchDetails = this.protocolEngine.findMatch(
               instance,
-              imageMatchingRules,
+              instanceMatchingRules,
               { instances }
             );
 

--- a/platform/core/src/services/HangingProtocolService/HangingProtocolService.ts
+++ b/platform/core/src/services/HangingProtocolService/HangingProtocolService.ts
@@ -193,7 +193,7 @@ class HangingProtocolService {
         );
       }
     } else {
-      return protocol;
+      return this._validateProtocol(protocol);;
     }
   }
 
@@ -593,30 +593,13 @@ class HangingProtocolService {
     options = {} as HangingProtocol.SetProtocolOptions,
     errorCallback = null
   ): void {
-    const foundProtocol = this.protocols.get(protocolId);
+    const protocol = this.getProtocolById(protocolId);
 
-    if (!foundProtocol) {
+    if (!protocol) {
       console.warn(
         `ProtocolEngine::setProtocol - Protocol with id ${protocolId} not found - you should register it first via addProtocol`
       );
       return;
-    }
-
-    let protocol;
-    if (foundProtocol instanceof Function) {
-      try {
-        ({ protocol } = this._getProtocolFromGenerator(
-          foundProtocol
-        ));
-      } catch (error) {
-        console.warn(
-          `HangingProtocolService::setProtocol - protocol ${protocolId} failed to execute`,
-          error
-        );
-        return;
-      }
-    } else {
-      protocol = this._validateProtocol(foundProtocol);
     }
 
     if (options) {

--- a/platform/core/src/types/HangingProtocol.ts
+++ b/platform/core/src/types/HangingProtocol.ts
@@ -75,9 +75,9 @@ type ViewportStructure = {
  * it won't be selected.
  */
 type DisplaySetSelector = {
-  // The image matching rule (not currently implemented) selects which image to
-  // display initially, only for stack views.
-  imageMatchingRules?: MatchingRule[];
+  // The instance matching rules selects which instance to
+  // display, only for stack views.
+  instanceMatchingRules?: MatchingRule[];
   // The matching rules to choose the display sets at the series level
   seriesMatchingRules: MatchingRule[];
   studyMatchingRules?: MatchingRule[];

--- a/platform/core/src/types/HangingProtocol.ts
+++ b/platform/core/src/types/HangingProtocol.ts
@@ -92,7 +92,7 @@ type SyncGroup = {
 
 type initialImageOptions = {
   index?: number;
-  preset? : string; // todo: type more
+  preset?: string; // todo: type more
 }
 
 type ViewportOptions = {
@@ -151,8 +151,12 @@ type Protocol = {
   syncDataForViewports?: boolean;
 };
 
+type ProtocolGenerator = ({ servicesManager: any, commandsManager: any }) => {
+  protocol: Protocol;
+};
 
 export type {
+  ProtocolGenerator,
   SetProtocolOptions,
   ViewportOptions,
   ViewportMatchDetails,

--- a/platform/docs/docs/development/ohif-cli.md
+++ b/platform/docs/docs/development/ohif-cli.md
@@ -136,6 +136,20 @@ command will utilize `yarn link` to achieve so.
 yarn run cli link-extension <extensionDir>
 ```
 
+To resolve dependencies for your extension, update webpack configuration with
+the path to your dependencies folder:
+
+https://github.com/OHIF/Viewers/blob/v3-stable/.webpack/webpack.base.js#L111
+```js
+      modules: [
+        // Modules specific to this package
+        // Add this line, replace [extensionName] with your extension directory
+        path.resolve(__dirname, '../node_modules/[extensionName]/node_modules'),
+        ,
+      ],
+
+```
+
 ### unlink-extension
 
 There might be situations where you want to unlink an extension from the Viewer
@@ -154,6 +168,20 @@ OHIF mode to the Viewer.
 
 ```bash
 yarn run cli link-mode <modeDir>
+```
+
+To resolve dependencies for your mode, update webpack configuration with
+the path to your dependencies folder:
+
+https://github.com/OHIF/Viewers/blob/v3-stable/.webpack/webpack.base.js#L111
+```js
+      modules: [
+        // Modules specific to this package
+        // Add this line, replace [modeName] with your mode directory
+        path.resolve(__dirname, '../node_modules/[modeName]/node_modules'),
+        ,
+      ],
+
 ```
 
 ### unlink-mode
@@ -292,7 +320,7 @@ are currently being used by the viewer.
 
 ## Private NPM Repos
 
-For the `yarn cli` to view private NPM repos, create a read-only token with the 
+For the `yarn cli` to view private NPM repos, create a read-only token with the
 following steps and export it as an environmental variable. You may also export
 an existing npm token.
 ```

--- a/platform/docs/docs/platform/extensions/modules/hpModule.md
+++ b/platform/docs/docs/platform/extensions/modules/hpModule.md
@@ -329,6 +329,35 @@ The ptDisplaySet will match against all the series that are PT and reconstructab
 As you see each selector is composed of an `id` as the key and a set of `seriesMatchingRules` (displaySetMatchingRules) which gives score to the displaySet
 based on the matching rules. The displaySet with the highest score will be used for the `id`.
 
+
+#### Instance Matching Rules
+The `HangingProtocolService` supports matching at the instance level in a displaySet. This lets you define conditions
+in the protocol for what instances (e.g. images) should be displayed based on an attribute value at the instance level.
+For example, in the HandingProtocol you can define a rule to only display the instance with InstanceNumber = 1:
+
+```js
+
+      displaySetSelectors: {
+        defaultDisplaySetId: {
+          instanceMatchingRules:[
+            {
+              weight: 1,
+              attribute: 'InstanceNumber',
+              constraint: {
+                equals: {
+                  value: 1,
+                },
+              },
+              required: true,
+            },
+          ],
+          seriesMatchingRules: [],
+          studyMatchingRules: [],
+        },
+      },
+
+  ```
+
 ### stages
 Each protocol can define one or more stages. Each stage defines a certain layout and viewport rules. Therefore, the `stages` property is array of objects, each object being one stage.
 

--- a/platform/docs/docs/platform/services/data/DisplaySetService.md
+++ b/platform/docs/docs/platform/services/data/DisplaySetService.md
@@ -17,11 +17,12 @@ There are three events that get broadcasted in `DisplaySetService`:
 
 
 
-| Event                | Description                                          |
-| -------------------- | ---------------------------------------------------- |
-| DISPLAY_SETS_ADDED   | Fires a displayset is added to the displaysets cache |
-| DISPLAY_SETS_CHANGED | Fires when a displayset is changed                   |
-| DISPLAY_SETS_REMOVED | Fires when a displayset is removed                   |
+| Event                 | Description                                           |
+| --------------------- | ----------------------------------------------------- |
+| DISPLAY_SETS_ADDED    | Fires a displayset is added to the displaysets cache  |
+| DISPLAY_SETS_CHANGED  | Fires when a displayset is changed                    |
+| DISPLAY_SETS_REMOVED  | Fires when a displayset is removed                    |
+| DISPLAY_SETS_FILTERED | Fires when a displayset filtered instances is changed |
 
 
 
@@ -49,3 +50,19 @@ Let's find out about the public API for `DisplaySetService`.
 - `getActiveDisplaySets`: Returns the active displaySets
 
 - `deleteDisplaySet`: Deletes the displaySets from the displaySets cache
+
+- `filterDisplaySetInstances`: Updates the displaySet to include only the provided 'filteredInstances' for rendering.
+
+- `clearDisplaySetFilters`: Clears the filtered instances from the displaySet so all instances will be rendered
+
+- `clearAllDisplaySetsFilters`: Clears any filtering to the instances from all displaySets
+
+## Filtering
+The DisplaySetService enables applying filtered set of instances to the displaySet using the methods
+`filterDisplaySetInstances`, `clearDisplaySetFilters` and `clearAllDisplaySetsFilters`. These instances could be
+images that matched a run-time condition and you want to update the displaySet to only show these images.
+
+The `HangingProtocolService` uses these methods to implement the ability to apply instance level matching to the
+displaySet. You can see an example of this capability in the [HangingProtocol Module](../../extensions/modules/hpModule.md)
+under `displaySetSelectors` --> `Instance Matching Rules`
+.

--- a/platform/viewer/public/config/default.js
+++ b/platform/viewer/public/config/default.js
@@ -17,9 +17,6 @@ window.config = {
     thumbnail: 75,
     prefetch: 10,
   },
-  videoViewport: {
-    autoPlay: true
-  },
   // filterQueryParam: false,
   dataSources: [
     {

--- a/platform/viewer/public/config/default.js
+++ b/platform/viewer/public/config/default.js
@@ -17,6 +17,9 @@ window.config = {
     thumbnail: 75,
     prefetch: 10,
   },
+  videoViewport: {
+    autoPlay: true
+  },
   // filterQueryParam: false,
   dataSources: [
     {


### PR DESCRIPTION
### PR Checklist

- [X] Brief description of changes
The main change is to enable the hanging protocol to consider the "imageMatchingRules" by filtering out images from the displayset that don't match the rules.
In addition, the following changes has been made:
1. support autoplay in video viewport
2. fix loading resources with http/https url

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
