### PR TITLE
fix: v3-stable Docker build and run are not working

### DIFF
--- a/.docker/Viewer-v3.x/default.conf.template
+++ b/.docker/Viewer-v3.x/default.conf.template
@@ -1,6 +1,5 @@
 server {
   listen ${PORT};
-  # listen 3000;
   location / {
     root   /usr/share/nginx/html;
     index  index.html index.htm;

--- a/.docker/Viewer-v3.x/entrypoint.sh
+++ b/.docker/Viewer-v3.x/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-envsubst `${PORT}` < /usr/src/default.conf.template > /etc/nginx/conf.d/default.conf
+envsubst '${PORT}' < /usr/src/default.conf.template > /etc/nginx/conf.d/default.conf
 
 if [ -n "$CLIENT_ID" ] || [ -n "$HEALTHCARE_API_ENDPOINT" ]
   then

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,11 +63,10 @@ RUN yarn run build
 # which runs Nginx using Alpine Linux
 FROM nginxinc/nginx-unprivileged:1.23.1-alpine as final
 #RUN apk add --no-cache bash
-ENV PORT=3000
+ENV PORT=80
 RUN rm /etc/nginx/conf.d/default.conf
 USER nginx
 COPY --chown=nginx:nginx .docker/Viewer-v3.x /usr/src
-RUN envsubst `${PORT}` < /usr/src/default.conf.template > /etc/nginx/conf.d/default.conf
 RUN chmod 777 /usr/src/entrypoint.sh
 COPY --from=builder /usr/src/app/platform/viewer/dist /usr/share/nginx/html
 ENTRYPOINT ["/usr/src/entrypoint.sh"]

--- a/platform/docs/docs/deployment/docker.md
+++ b/platform/docs/docs/deployment/docker.md
@@ -17,7 +17,7 @@ The machine on which to build and run the Docker container must have:
 3. [Docker](https://docs.docker.com/get-docker/) installed.
 
 ## Building the Docker Image
-The docker image can built from a terminal window as such:
+The docker image can be built from a terminal window as such:
 1. Switch to the OHIF Viewer code root directory.
 2. Issue the following docker command. Note that what follows `-t` flag is the `{name}:{tag}` for the Docker image and is arbitrary when creating a local Docker image.
 
@@ -26,11 +26,11 @@ The docker image can built from a terminal window as such:
     ```
 
 ## Running the Docker Container
-Once the Docker image has been built, it can be run as a container again from the command line as in the block below. Note that the last argument to the command is the name of the Docker image and the table below describes the other arguments.
+Once the Docker image has been built, it can be run as a container from the command line as in the block below. Note that the last argument to the command is the name of the Docker image and the table below describes the other arguments.
 
 |Flag|Description|
 |----|-----------|
-|-d|Run the container in the background and print container ID|
+|-d|Run the container in the background and print the container ID|
 |-p {host-port}:{nginx-port}/tcp|Publish the `nginx` listen port on the given host port|
 |--name|An arbitrary name for the container.|
 

--- a/platform/docs/docs/deployment/docker.md
+++ b/platform/docs/docs/deployment/docker.md
@@ -1,0 +1,48 @@
+---
+sidebar_position: 4
+---
+
+# Docker
+
+The OHIF source code provides a Dockerfile to create and run a Docker image that containerizes an [nginx](https://www.nginx.com/) web server serving the OHIF Viewer.
+
+:::info Good to Know
+The OHIF Viewer Docker image for the `v3-stable` branch is not yet published. The available image in [Docker Hub](https://hub.docker.com/r/ohif/viewer) is based on the `master` branch.
+:::
+
+## Prequisites
+The machine on which to build and run the Docker container must have:
+1. All of the [requirements](./build-for-production.md#build-for-production) for building a production version of OHIF.
+2. A checked out branch of the OHIF Viewer.
+3. [Docker](https://docs.docker.com/get-docker/) installed.
+
+## Building the Docker Image
+The docker image can built from a terminal window as such:
+1. Switch to the OHIF Viewer code root directory.
+2. Issue the following docker command. Note that what follows `-t` flag is the `{name}:{tag}` for the Docker image and is arbitrary when creating a local Docker image.
+
+    ```sh
+    docker build . -t ohif-viewer-image
+    ```
+
+## Running the Docker Container
+Once the Docker image has been built, it can be run as a container again from the command line as in the block below. Note that the last argument to the command is the name of the Docker image and the table below describes the other arguments.
+
+|Flag|Description|
+|----|-----------|
+|-d|Run the container in the background and print container ID|
+|-p {host-port}:{nginx-port}/tcp|Publish the `nginx` listen port on the given host port|
+|--name|An arbitrary name for the container.|
+
+
+```sh
+docker run -d -p 3000:80/tcp --name ohif-viewer-container ohif-viewer-image
+```
+
+### Configuring the `nginx` Listen Port
+
+The Dockerfile and entry point use the `${PORT}` environment variable as the port that the `nginx` server uses to serve the web server. The default value for `${PORT}` is `80`. One way to set this environment variable is to use the `-e` switch when running the container with `docker run`. The block below gives an example where the listen port is set to `8080` and publised on the host as `3000`.
+
+```sh
+docker run -d -e PORT=8080 -p 3000:8080/tcp --name ohif-viewer-container ohif-viewer-image
+```

--- a/platform/docs/docs/deployment/google-cloud-healthcare.md
+++ b/platform/docs/docs/deployment/google-cloud-healthcare.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 7
 ---
 
 # Google Cloud Healthcare

--- a/platform/docs/docs/deployment/nginx--image-archive.md
+++ b/platform/docs/docs/deployment/nginx--image-archive.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 5
 ---
 
 # Nginx + Image Archive

--- a/platform/docs/docs/deployment/user-account-control.md
+++ b/platform/docs/docs/deployment/user-account-control.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 6
 ---
 
 # User Account Control


### PR DESCRIPTION
fix: Use single quotes instead of backticks when specifying the environment variable that should be substituted for the envsubst command.
GitHub issue: #3079
Removed duplicate calls to envsubst.
Default nginx listen port is now 80.
Added markdown documentation.

### PR Checklist

- [x] Brief description of changes
- [x] Links to any relevant issues
- [x] Required status checks are passing

### Links
https://github.com/OHIF/Viewers/issues/3079

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
