### PR TITLE
fix: build:package-all command

### DIFF
--- a/extensions/cornerstone-dicom-seg/.webpack/webpack.dev.js
+++ b/extensions/cornerstone-dicom-seg/.webpack/webpack.dev.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const webpackCommon = require('./../../../.webpack/webpack.commonjs.js');
+const webpackCommon = require('./../../../.webpack/webpack.base.js');
 const SRC_DIR = path.join(__dirname, '../src');
 const DIST_DIR = path.join(__dirname, '../dist');
 

--- a/extensions/cornerstone-dicom-seg/.webpack/webpack.prod.js
+++ b/extensions/cornerstone-dicom-seg/.webpack/webpack.prod.js
@@ -55,7 +55,7 @@ const config = {
     ],
   },
   resolve: {
-    modules: [path.resolve('./node_modules'), path.resolve('./src')],
+    modules: [path.resolve('./node_modules'), path.resolve('./src'), path.resolve('../../node_modules')],
     extensions: ['.json', '.js', '.jsx', '.tsx', '.ts'],
   },
 };

--- a/extensions/cornerstone-dicom-seg/package.json
+++ b/extensions/cornerstone-dicom-seg/package.json
@@ -4,7 +4,7 @@
   "description": "DICOM SEG read workflow",
   "author": "OHIF",
   "license": "MIT",
-  "main": "dist/umd/@ohif/dicom-seg/index.umd.js",
+  "main": "dist/umd/@ohif/extension-cornerstone-dicom-seg/index.umd.js",
   "module": "src/index.tsx",
   "files": [
     "dist/**",

--- a/extensions/cornerstone-dicom-sr/.webpack/webpack.prod.js
+++ b/extensions/cornerstone-dicom-sr/.webpack/webpack.prod.js
@@ -9,11 +9,15 @@ const webpackCommon = require('./../../../.webpack/webpack.base.js');
 const ROOT_DIR = path.join(__dirname, './../');
 const SRC_DIR = path.join(__dirname, '../src');
 const DIST_DIR = path.join(__dirname, '../dist');
+const ENTRYPOINT = path.join(__dirname, '../', pkg.module);
 
 module.exports = (env, argv) => {
   const commonConfig = webpackCommon(env, argv, { SRC_DIR, DIST_DIR });
 
   return merge(commonConfig, {
+    entry: {
+      app: ENTRYPOINT,
+    },
     stats: {
       colors: true,
       hash: true,

--- a/extensions/cornerstone/.webpack/webpack.dev.js
+++ b/extensions/cornerstone/.webpack/webpack.dev.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const webpackCommon = require('./../../../.webpack/webpack.commonjs.js');
+const webpackCommon = require('./../../../.webpack/webpack.base.js');
 const SRC_DIR = path.join(__dirname, '../src');
 const DIST_DIR = path.join(__dirname, '../dist');
 

--- a/extensions/cornerstone/.webpack/webpack.prod.js
+++ b/extensions/cornerstone/.webpack/webpack.prod.js
@@ -7,11 +7,15 @@ const pkg = require('./../package.json');
 const ROOT_DIR = path.join(__dirname, './..');
 const SRC_DIR = path.join(__dirname, '../src');
 const DIST_DIR = path.join(__dirname, '../dist');
+const ENTRYPOINT = path.join(__dirname, '../', pkg.module);
 
 module.exports = (env, argv) => {
   const commonConfig = webpackCommon(env, argv, { SRC_DIR, DIST_DIR });
 
   return merge(commonConfig, {
+    entry: {
+      app: ENTRYPOINT,
+    },
     stats: {
       colors: true,
       hash: true,

--- a/extensions/cornerstone/.webpack/webpack.prod.js
+++ b/extensions/cornerstone/.webpack/webpack.prod.js
@@ -1,7 +1,7 @@
 const webpack = require('webpack');
 const merge = require('webpack-merge');
 const path = require('path');
-const webpackCommon = require('./../../../.webpack/webpack.commonjs.js');
+const webpackCommon = require('./../../../.webpack/webpack.base.js');
 const pkg = require('./../package.json');
 
 const ROOT_DIR = path.join(__dirname, './..');

--- a/extensions/cornerstone/.webpack/webpack.prod.js
+++ b/extensions/cornerstone/.webpack/webpack.prod.js
@@ -2,6 +2,7 @@ const webpack = require('webpack');
 const { merge } = require('webpack-merge');
 const path = require('path');
 const webpackCommon = require('./../../../.webpack/webpack.base.js');
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const pkg = require('./../package.json');
 
 const ROOT_DIR = path.join(__dirname, './..');
@@ -41,6 +42,10 @@ module.exports = (env, argv) => {
     plugins: [
       new webpack.optimize.LimitChunkCountPlugin({
         maxChunks: 1,
+      }),
+      new MiniCssExtractPlugin({
+        filename: './dist/[name].css',
+        chunkFilename: './dist/[id].css',
       }),
     ],
   });

--- a/extensions/cornerstone/.webpack/webpack.prod.js
+++ b/extensions/cornerstone/.webpack/webpack.prod.js
@@ -1,5 +1,5 @@
 const webpack = require('webpack');
-const merge = require('webpack-merge');
+const { merge } = require('webpack-merge');
 const path = require('path');
 const webpackCommon = require('./../../../.webpack/webpack.base.js');
 const pkg = require('./../package.json');

--- a/extensions/dicom-pdf/.webpack/webpack.dev.js
+++ b/extensions/dicom-pdf/.webpack/webpack.dev.js
@@ -1,0 +1,8 @@
+const path = require('path');
+const webpackCommon = require('./../../../.webpack/webpack.base.js');
+const SRC_DIR = path.join(__dirname, '../src');
+const DIST_DIR = path.join(__dirname, '../dist');
+
+module.exports = (env, argv) => {
+  return webpackCommon(env, argv, { SRC_DIR, DIST_DIR });
+};

--- a/extensions/dicom-pdf/.webpack/webpack.prod.js
+++ b/extensions/dicom-pdf/.webpack/webpack.prod.js
@@ -1,0 +1,52 @@
+const webpack = require('webpack');
+const { merge } = require('webpack-merge');
+const path = require('path');
+const webpackCommon = require('./../../../.webpack/webpack.base.js');
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+
+const pkg = require('./../package.json');
+const ROOT_DIR = path.join(__dirname, './../');
+const SRC_DIR = path.join(__dirname, '../src');
+const DIST_DIR = path.join(__dirname, '../dist');
+const ENTRYPOINT = path.join(__dirname, '../', pkg.module);
+
+module.exports = (env, argv) => {
+  const commonConfig = webpackCommon(env, argv, { SRC_DIR, DIST_DIR });
+
+  return merge(commonConfig, {
+    entry: {
+      app: ENTRYPOINT,
+    },
+    stats: {
+      colors: true,
+      hash: true,
+      timings: true,
+      assets: true,
+      chunks: false,
+      chunkModules: false,
+      modules: false,
+      children: false,
+      warnings: true,
+    },
+    optimization: {
+      minimize: true,
+      sideEffects: true,
+    },
+    output: {
+      path: ROOT_DIR,
+      library: 'OHIFExtCornerstone',
+      libraryTarget: 'umd',
+      libraryExport: 'default',
+      filename: pkg.main,
+    },
+    plugins: [
+      new webpack.optimize.LimitChunkCountPlugin({
+        maxChunks: 1,
+      }),
+      new MiniCssExtractPlugin({
+        filename: './dist/[name].css',
+        chunkFilename: './dist/[id].css',
+      }),
+    ],
+  });
+};

--- a/extensions/dicom-video/.webpack/webpack.dev.js
+++ b/extensions/dicom-video/.webpack/webpack.dev.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const webpackCommon = require('./../../../.webpack/webpack.commonjs.js');
+const webpackCommon = require('./../../../.webpack/webpack.base.js');
 const SRC_DIR = path.join(__dirname, '../src');
 const DIST_DIR = path.join(__dirname, '../dist');
 

--- a/extensions/dicom-video/.webpack/webpack.prod.js
+++ b/extensions/dicom-video/.webpack/webpack.prod.js
@@ -7,11 +7,15 @@ const pkg = require('./../package.json');
 const ROOT_DIR = path.join(__dirname, './..');
 const SRC_DIR = path.join(__dirname, '../src');
 const DIST_DIR = path.join(__dirname, '../dist');
+const ENTRYPOINT = path.join(__dirname, '../', pkg.module);
 
 module.exports = (env, argv) => {
   const commonConfig = webpackCommon(env, argv, { SRC_DIR, DIST_DIR });
 
   return merge(commonConfig, {
+    entry: {
+      app: ENTRYPOINT,
+    },
     stats: {
       colors: true,
       hash: true,

--- a/extensions/dicom-video/.webpack/webpack.prod.js
+++ b/extensions/dicom-video/.webpack/webpack.prod.js
@@ -1,5 +1,5 @@
 const webpack = require('webpack');
-const merge = require('webpack-merge');
+const { merge } = require('webpack-merge');
 const path = require('path');
 const webpackCommon = require('./../../../.webpack/webpack.base.js');
 const pkg = require('./../package.json');

--- a/extensions/measurement-tracking/.webpack/webpack.prod.js
+++ b/extensions/measurement-tracking/.webpack/webpack.prod.js
@@ -9,11 +9,15 @@ const webpackCommon = require('./../../../.webpack/webpack.base.js');
 const ROOT_DIR = path.join(__dirname, './../');
 const SRC_DIR = path.join(__dirname, '../src');
 const DIST_DIR = path.join(__dirname, '../dist');
+const ENTRYPOINT = path.join(__dirname, '../', pkg.module);
 
 module.exports = (env, argv) => {
   const commonConfig = webpackCommon(env, argv, { SRC_DIR, DIST_DIR });
 
   return merge(commonConfig, {
+    entry: {
+      app: ENTRYPOINT,
+    },
     stats: {
       colors: true,
       hash: true,

--- a/extensions/tmtv/.webpack/webpack.dev.js
+++ b/extensions/tmtv/.webpack/webpack.dev.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const webpackCommon = require('./../../../.webpack/webpack.commonjs.js');
+const webpackCommon = require('./../../../.webpack/webpack.base.js');
 const SRC_DIR = path.join(__dirname, '../src');
 const DIST_DIR = path.join(__dirname, '../dist');
 

--- a/extensions/tmtv/.webpack/webpack.prod.js
+++ b/extensions/tmtv/.webpack/webpack.prod.js
@@ -7,11 +7,15 @@ const pkg = require('./../package.json');
 const ROOT_DIR = path.join(__dirname, './..');
 const SRC_DIR = path.join(__dirname, '../src');
 const DIST_DIR = path.join(__dirname, '../dist');
+const ENTRYPOINT = path.join(__dirname, '../', pkg.module);
 
 module.exports = (env, argv) => {
   const commonConfig = webpackCommon(env, argv, { SRC_DIR, DIST_DIR });
 
   return merge(commonConfig, {
+    entry: {
+      app: ENTRYPOINT,
+    },
     stats: {
       colors: true,
       hash: true,

--- a/extensions/tmtv/.webpack/webpack.prod.js
+++ b/extensions/tmtv/.webpack/webpack.prod.js
@@ -2,6 +2,7 @@ const webpack = require('webpack');
 const { merge } = require('webpack-merge');
 const path = require('path');
 const webpackCommon = require('./../../../.webpack/webpack.base.js');
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const pkg = require('./../package.json');
 
 const ROOT_DIR = path.join(__dirname, './..');
@@ -41,6 +42,10 @@ module.exports = (env, argv) => {
     plugins: [
       new webpack.optimize.LimitChunkCountPlugin({
         maxChunks: 1,
+      }),
+      new MiniCssExtractPlugin({
+        filename: './dist/[name].css',
+        chunkFilename: './dist/[id].css',
       }),
     ],
   });

--- a/extensions/tmtv/.webpack/webpack.prod.js
+++ b/extensions/tmtv/.webpack/webpack.prod.js
@@ -1,5 +1,5 @@
 const webpack = require('webpack');
-const merge = require('webpack-merge');
+const { merge } = require('webpack-merge');
 const path = require('path');
 const webpackCommon = require('./../../../.webpack/webpack.base.js');
 const pkg = require('./../package.json');

--- a/modes/basic-dev-mode/.webpack/webpack.dev.js
+++ b/modes/basic-dev-mode/.webpack/webpack.dev.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const webpackCommon = require('./../../../.webpack/webpack.commonjs.js');
+const webpackCommon = require('./../../../.webpack/webpack.base.js');
 const SRC_DIR = path.join(__dirname, '../src');
 const DIST_DIR = path.join(__dirname, '../dist');
 

--- a/modes/basic-dev-mode/.webpack/webpack.prod.js
+++ b/modes/basic-dev-mode/.webpack/webpack.prod.js
@@ -1,5 +1,5 @@
 const webpack = require('webpack');
-const merge = require('webpack-merge');
+const { merge } = require('webpack-merge');
 const path = require('path');
 const webpackCommon = require('./../../../.webpack/webpack.base.js');
 const pkg = require('./../package.json');

--- a/modes/basic-dev-mode/.webpack/webpack.prod.js
+++ b/modes/basic-dev-mode/.webpack/webpack.prod.js
@@ -2,6 +2,7 @@ const webpack = require('webpack');
 const { merge } = require('webpack-merge');
 const path = require('path');
 const webpackCommon = require('./../../../.webpack/webpack.base.js');
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const pkg = require('./../package.json');
 
 const ROOT_DIR = path.join(__dirname, './..');
@@ -37,6 +38,10 @@ module.exports = (env, argv) => {
     plugins: [
       new webpack.optimize.LimitChunkCountPlugin({
         maxChunks: 1,
+      }),
+      new MiniCssExtractPlugin({
+        filename: './dist/[name].css',
+        chunkFilename: './dist/[id].css',
       }),
     ],
   });

--- a/platform/core/.webpack/webpack.prod.js
+++ b/platform/core/.webpack/webpack.prod.js
@@ -6,11 +6,14 @@ const pkg = require('./../package.json');
 const ROOT_DIR = path.join(__dirname, './../');
 const SRC_DIR = path.join(__dirname, '../src');
 const DIST_DIR = path.join(__dirname, '../dist');
+const ENTRYPOINT = path.join(__dirname, '../', pkg.module);
 
 module.exports = (env, argv) => {
   const commonConfig = webpackCommon(env, argv, { SRC_DIR, DIST_DIR });
-
   return merge(commonConfig, {
+    entry: {
+      app: ENTRYPOINT,
+    },
     stats: {
       colors: true,
       hash: true,

--- a/platform/i18n/.webpack/webpack.prod.js
+++ b/platform/i18n/.webpack/webpack.prod.js
@@ -7,11 +7,15 @@ const pkg = require('./../package.json');
 const ROOT_DIR = path.join(__dirname, './..');
 const SRC_DIR = path.join(__dirname, '../src');
 const DIST_DIR = path.join(__dirname, '../dist');
+const ENTRYPOINT = path.join(__dirname, '../', pkg.module);
 
 module.exports = (env, argv) => {
   const commonConfig = webpackCommon(env, argv, { SRC_DIR, DIST_DIR });
 
   return merge(commonConfig, {
+    entry: {
+      app: ENTRYPOINT,
+    },
     stats: {
       colors: true,
       hash: true,

--- a/platform/ui/.webpack/webpack.prod.js
+++ b/platform/ui/.webpack/webpack.prod.js
@@ -8,11 +8,15 @@ const pkg = require('./../package.json');
 const ROOT_DIR = path.join(__dirname, './..');
 const SRC_DIR = path.join(__dirname, '../src');
 const DIST_DIR = path.join(__dirname, '../dist');
+const ENTRYPOINT = path.join(__dirname, '../', pkg.module);
 
 module.exports = (env, argv) => {
   const commonConfig = webpackCommon(env, argv, { SRC_DIR, DIST_DIR });
 
   return merge(commonConfig, {
+    entry: {
+      app: ENTRYPOINT,
+    },
     stats: {
       colors: true,
       hash: true,


### PR DESCRIPTION
### Description of changes
While trying to build individual packages, I noticed that the `yarn build:package-all` command was failing on `v3-stable`. This PR fixes the following issues:
- Update any references to `webpack.commonjs.js` to `webpack.base.js`
- Use `package.json` to get the correct filepath for `app.entry` (the base config is assuming `index.js` but several packages use `index.ts[x]` now).
- Explicitely add `mini-css-extract` plugin where it was missing
- Add the default webpack config for the `dicom-pdf` extension (expected `.webpack` folder was missing)
- Fix how `webpack-merge` is imported
- Fix a missing module resolution path on the `dicom-seg` extension (it was not resolving packages from the root workspace)
- Update the `main` path on the `dicom-seg` extension.

Following these changes, packages can be compiled individually, and using `yarn build:package-all`.
I have very little experience with webpack, any suggestion is welcome.

### PR Checklist

- [x] Brief description of changes
- [ ] Required status checks are passing
- [ ] User cases if changes impact the user's experience
- [ ] Links to any relevant issues
- [ ] `@mention` a maintainer to request a review

<!--
  Links
  -->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
