### PR TITLE
fix: multiframe image prefetch logic

### DIFF
--- a/platform/core/src/classes/StudyPrefetcher.js
+++ b/platform/core/src/classes/StudyPrefetcher.js
@@ -494,7 +494,7 @@ export class StudyPrefetcher {
 
     // TODO: This duplicates work done by the stack manager
     displaySet.images.forEach(image => {
-      const numFrames = image.numFrames;
+      const numFrames = image.getData().metadata.NumberOfFrames;
       if (numFrames > 1) {
         for (let i = 0; i < numFrames; i++) {
           let imageId = getImageId(image, i);

--- a/platform/core/src/classes/metadata/OHIFInstanceMetadata.js
+++ b/platform/core/src/classes/metadata/OHIFInstanceMetadata.js
@@ -86,7 +86,12 @@ export class OHIFInstanceMetadata extends InstanceMetadata {
   }
 
   // Override
-  getImageId(frame, thumbnail) {
+  getImageId(frame = undefined, thumbnail = undefined) {
+    if (frame !== undefined || thumbnail !== undefined) {
+      // Always recompute this if arguments are specified, as using the cached id would break multiframe images
+      return getImageId(this.getData(), frame, thumbnail);
+    }
+
     // If _imageID is not cached, create it
     if (this._imageId === null) {
       this._imageId = getImageId(this.getData(), frame, thumbnail);

--- a/platform/core/src/utils/getImageId.js
+++ b/platform/core/src/utils/getImageId.js
@@ -25,7 +25,7 @@ export default function getImageId(instance, frame, thumbnail = false) {
   }
 
   if (typeof instance.getImageId === 'function') {
-    return instance.getImageId();
+    return instance.getImageId(frame, thumbnail);
   }
 
   if (instance.url) {


### PR DESCRIPTION
When the StudyPrefetcher is enabled, it prefetches the images of the current stack (and a prop is passed to react-cornerstone-viewport to stop it from prefetching).

Unfortunately, the code in StudyPrefetcher that computed which imageIds should be fetched was broken for multiframe images. As a result, nothing except the current image got loaded (triggering a load on every stack scroll, which is not great).

The first issue was that StudyPrefetcher used a non existent property `numFrames`, which made it think all images have a single frame (`undefined > 1` is false).
The second issue was that the getImageId standalone function delegates to InstanceMetadata#getImageId, but without passing along its arguments (the `frame` argument, in particular).
The third issue was that InstanceMetadata#getImageId cached its return value, but that's not ok to do when the frame argument can vary.