### PR TITLE
Re IDC #3088: Fix seg toggle visibility logic

### DIFF
--- a/extensions/dicom-segmentation/src/components/SegmentationPanel/SegmentationPanel.js
+++ b/extensions/dicom-segmentation/src/components/SegmentationPanel/SegmentationPanel.js
@@ -630,25 +630,17 @@ const SegmentationPanel = ({
 
   const onVisibilityChangeHandler = isVisible => {
     let segmentsHidden = [];
+    const labelmap3D = getActiveLabelMaps3D();
+
     state.segmentNumbers.forEach(segmentNumber => {
       if (isVTK()) {
         onSegmentVisibilityChange(segmentNumber, isVisible);
       }
 
-      /** Get all labelmaps with this segmentNumber (overlapping segments) */
-      const { labelmaps3D } = getBrushStackState();
-      const possibleLabelMaps3D = labelmaps3D.filter(({ labelmaps2D }) => {
-        return labelmaps2D.some(({ segmentsOnLabelmap }) =>
-          segmentsOnLabelmap.includes(segmentNumber)
-        );
-      });
-
-      possibleLabelMaps3D.forEach(labelmap3D => {
-        labelmap3D.segmentsHidden[segmentNumber] = !isVisible;
-        segmentsHidden = [
-          ...new Set([...segmentsHidden, ...labelmap3D.segmentsHidden]),
-        ];
-      });
+      labelmap3D.segmentsHidden[segmentNumber] = !isVisible;
+      segmentsHidden = [
+        ...new Set([...segmentsHidden, ...labelmap3D.segmentsHidden]),
+      ];
     });
 
     setState(state => ({ ...state, segmentsHidden }));


### PR DESCRIPTION
Fixes https://github.com/OHIF/Viewers/issues/3088

Segments visibility toggle should display/hide all segment items of only the selected/active segmentation.
The previous logic was impacting the visibility of n segment items across all segmentations , where n = no. of segment items in the active segmentation.


https://user-images.githubusercontent.com/112136540/211079104-8882321e-8aad-4e21-8aa3-cd5128372179.mp4

Test results with another dataset of non-overlapping segs in multiple seg series
Before fix:

https://user-images.githubusercontent.com/112136540/211080359-0c870259-3841-4abf-8a2f-3519a9c424cc.mp4

After fix:

https://user-images.githubusercontent.com/112136540/211080556-a3349b73-7160-45cc-bae5-671540c8b2b7.mp4

Test result with another dataset of overlapping segments from same series



https://user-images.githubusercontent.com/112136540/211081041-d83b72cc-d9a0-4f28-89dc-0964414ecab4.mp4

