### PR TITLE
fix: OHIF-386 Disable Export and Create Report buttons if there are no tracked measurements

### DIFF
--- a/extensions/measurement-tracking/src/panels/PanelMeasurementTableTracking/ActionButtons.tsx
+++ b/extensions/measurement-tracking/src/panels/PanelMeasurementTableTracking/ActionButtons.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 
 import { Button, ButtonGroup } from '@ohif/ui';
 
-function ActionButtons({ onExportClick, onCreateReportClick }) {
+function ActionButtons({ onExportClick, onCreateReportClick, disabled }) {
   const { t } = useTranslation('MeasurementTable');
 
   return (
@@ -12,20 +12,22 @@ function ActionButtons({ onExportClick, onCreateReportClick }) {
       <Button
         className="text-base px-2 py-2"
         size="initial"
-        variant="outlined"
-        color="default"
-        border="secondary"
+        variant={disabled ? 'disabled' : 'outlined'}
+        color="black"
+        border="primaryActive"
         onClick={onExportClick}
+        disabled={disabled}
       >
         {t('Export')}
       </Button>
       <Button
         className="ml-2 px-2 text-base"
-        variant="outlined"
+        variant={disabled ? 'disabled' : 'outlined'}
         size="initial"
         color="black"
-        border="secondary"
+        border="primaryActive"
         onClick={onCreateReportClick}
+        disabled={disabled}
       >
         {t('Create Report')}
       </Button>
@@ -36,11 +38,13 @@ function ActionButtons({ onExportClick, onCreateReportClick }) {
 ActionButtons.propTypes = {
   onExportClick: PropTypes.func,
   onCreateReportClick: PropTypes.func,
+  disabled: PropTypes.bool,
 };
 
 ActionButtons.defaultProps = {
   onExportClick: () => alert('Export'),
   onCreateReportClick: () => alert('Create Report'),
+  disabled: false,
 };
 
 export default ActionButtons;

--- a/extensions/measurement-tracking/src/panels/PanelMeasurementTableTracking/index.tsx
+++ b/extensions/measurement-tracking/src/panels/PanelMeasurementTableTracking/index.tsx
@@ -273,6 +273,10 @@ function PanelMeasurementTableTracking({ servicesManager, extensionManager }) {
               isBackupSave: true,
             });
           }}
+          disabled={
+            additionalFindings.length === 0 &&
+            displayMeasurementsWithoutFindings.length === 0
+          }
         />
       </div>
     </>


### PR DESCRIPTION
Use the disabled Button component variant when no tracked measurements are present. Made the buttons look as per the spec.

### PR Checklist

- [x] Brief description of changes
- [x] Links to any relevant issues
- [ ] Required status checks are passing
- [x] User cases if changes impact the user's experience
- [x] `@mention` a maintainer to request a review

<!--
  Links
  -->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
