### PR TITLE
fix: Require all instances to have an ImagePositionPatient attribute

### DIFF
--- a/platform/core/src/utils/isDisplaySetReconstructable.js
+++ b/platform/core/src/utils/isDisplaySetReconstructable.js
@@ -29,6 +29,11 @@ export default function isDisplaySetReconstructable(instances) {
     return { value: false };
   }
 
+  // Can't reconstruct if all instances don't have the ImagePositionPatient.
+  if (!instances.every(instance => !!instance.ImagePositionPatient)) {
+    return { value: false };
+  }
+
   const sortedInstances = sortInstancesByPosition(instances);
 
   if (isMultiframe) {


### PR DESCRIPTION
This fixes cases where some instances don't have this attribute, which would break on platform/core/src/utils/sortInstancesByPosition.ts:52

### PR Checklist

- [ ] Brief description of changes
- [ ] Links to any relevant issues
- [ ] Required status checks are passing
- [ ] User cases if changes impact the user's experience
- [ ] `@mention` a maintainer to request a review

<!--
  Links
  -->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
