### PR TITLE
fix(Panels): dicom seg panel sizing issue

### DIFF
--- a/extensions/cornerstone-dicom-seg/src/panels/PanelSegmentation.tsx
+++ b/extensions/cornerstone-dicom-seg/src/panels/PanelSegmentation.tsx
@@ -196,7 +196,7 @@ export default function PanelSegmentation({
   );
 
   return (
-    <div className="flex flex-col justify-between mt-1">
+    <div className="flex flex-col flex-auto min-h-0 justify-between mt-1">
       {/* show segmentation table */}
       {segmentations?.length ? (
         <SegmentationGroupTable

--- a/platform/ui/src/components/SegmentationGroupTable/SegmentationGroup.tsx
+++ b/platform/ui/src/components/SegmentationGroupTable/SegmentationGroup.tsx
@@ -58,7 +58,7 @@ const SegmentGroupHeader = ({
   return (
     <div
       className={classnames(
-        'flex items-center pr-2 pl-[3px] h-[27px] gap-2 rounded-t-md border-b border-secondary-light cursor-pointer text-[12px]',
+        'flex flex-static items-center pr-2 pl-[3px] h-[27px] gap-2 rounded-t-md border-b border-secondary-light cursor-pointer text-[12px]',
         {
           'bg-secondary-main': isActive,
           'bg-secondary-dark': !isActive,
@@ -149,7 +149,7 @@ const SegmentationGroup = ({
   onSegmentEdit,
 }) => {
   return (
-    <div className="flex flex-col">
+    <div className="flex flex-col flex-auto min-h-0">
       <SegmentGroupHeader
         id={id}
         label={label}
@@ -162,7 +162,7 @@ const SegmentationGroup = ({
         onSegmentationDelete={onSegmentationDelete}
       />
       {!isMinimized && (
-        <div className="">
+        <div className="flex flex-col flex-auto min-h-0">
           <AddNewSegmentRow
             onConfigChange={onSegmentationConfigChange}
             onSegmentAdd={onSegmentAdd}
@@ -172,8 +172,7 @@ const SegmentationGroup = ({
             showAddSegment={showAddSegment}
           />
           <div
-            className="ohif-scrollbar overflow-y-hidden"
-            style={{ maxHeight: '40rem' }}
+            className="flex flex-col min-h-0 ohif-scrollbar overflow-y-hidden"
           >
             {!!segments.length &&
               segments.map(segment => {

--- a/platform/ui/src/components/SegmentationGroupTable/SegmentationGroupTable.tsx
+++ b/platform/ui/src/components/SegmentationGroupTable/SegmentationGroupTable.tsx
@@ -55,7 +55,7 @@ const SegmentationGroupTable = ({
   setRenderOutline,
 }) => {
   return (
-    <div className="font-inter font-[300]">
+    <div className="flex flex-col min-h-0 font-inter font-[300]">
       <GetSegmentationConfig
         // showAddSegmentation={showAddSegmentation}
         // onSegmentationAdd={onSegmentationAdd}
@@ -68,7 +68,7 @@ const SegmentationGroupTable = ({
         setRenderInactiveSegmentations={setRenderInactiveSegmentations}
         setRenderOutline={setRenderOutline}
       />
-      <div className="flex flex-col pr-[1px] mt-1">
+      <div className="flex flex-col min-h-0 pr-[1px] mt-1">
         {!!segmentations.length &&
           segmentations.map((segmentation, index) => {
             const {
@@ -82,7 +82,6 @@ const SegmentationGroupTable = ({
               activeSegmentIndex,
             } = segmentation;
             return (
-              <>
                 <SegmentationGroup
                   id={id}
                   label={label}
@@ -107,8 +106,6 @@ const SegmentationGroupTable = ({
                   onSegmentAdd={onSegmentAdd}
                   showSegmentDelete={false}
                 />
-                <div className="h-2 bg-black"></div>
-              </>
             );
           })}
       </div>

--- a/platform/ui/src/components/SidePanel/SidePanel.tsx
+++ b/platform/ui/src/components/SidePanel/SidePanel.tsx
@@ -176,7 +176,7 @@ const SidePanel = ({
           {/** Panel Header with Arrow and Close Actions */}
           <div
             className={classnames(
-              'px-[10px] bg-primary-dark h-9 cursor-pointer flex shrink-0',
+              'flex flex-static px-[10px] bg-primary-dark h-9 cursor-pointer',
               tabs.length === 1 && 'mb-1'
             )}
             onClick={() => {
@@ -190,7 +190,7 @@ const SidePanel = ({
               color="inherit"
               border="none"
               rounded="none"
-              className="flex flex-row items-center px-3 relative w-full"
+              className="flex flex-row flex-static items-center px-3 relative w-full"
               name={tabs.length === 1 ? `${tabs[activeTabIndex].name}` : ''}
             >
               <Icon
@@ -278,7 +278,7 @@ function _getMoreThanOneTabLayout(
 ) {
   return (
     <div
-      className="collapse-sidebar relative"
+      className="flex-static collapse-sidebar relative"
       style={{
         backgroundColor: '#06081f',
       }}

--- a/platform/ui/tailwind.config.js
+++ b/platform/ui/tailwind.config.js
@@ -230,6 +230,7 @@ module.exports = {
       auto: '1 1 auto',
       initial: '0 1 auto',
       none: 'none',
+      static: '0 0 auto',
     },
     flexGrow: {
       '0': '0',

--- a/platform/viewer/tailwind.config.js
+++ b/platform/viewer/tailwind.config.js
@@ -238,6 +238,7 @@ module.exports = {
       auto: '1 1 auto',
       initial: '0 1 auto',
       none: 'none',
+      static: '0 0 auto',
     },
     flexGrow: {
       '0': '0',
@@ -302,6 +303,7 @@ module.exports = {
       ...theme('spacing'),
       full: '100%',
       screen: '100vh',
+      inherit: 'inherit',
     }),
     inset: {
       '0': '0',
@@ -365,12 +367,6 @@ module.exports = {
       full: '100%',
       ...breakpoints(theme('screens')),
       ...theme('spacing'),
-    }),
-    minHeight: theme => ({
-      ...theme('spacing'),
-      '0': '0',
-      full: '100%',
-      screen: '100vh',
     }),
     minWidth: theme => ({
       ...theme('spacing'),

--- a/platform/viewer/tailwind.config.js
+++ b/platform/viewer/tailwind.config.js
@@ -313,6 +313,12 @@ module.exports = {
       '1/2': '50%',
       'viewport-scrollbar': '1.3rem',
     },
+    minHeight: theme => ({
+      ...theme('spacing'),
+      '0': '0',
+      full: '100%',
+      screen: '100vh',
+    }),
     letterSpacing: {
       tighter: '-0.05em',
       tight: '-0.025em',


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://v3-docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context
Dicom Seg Panel Sizing is incorrect. The panel is being cut when there are too many items

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results
The changes applied were to fix the flex layout sizing for the entire right panel + seg panel.
The seg panel had a fixed height but instead its height should be the remaining flex space. The strategy applied were:
- Avoid grow/shrink of some items, but ensure it for panel seg and its direct parents. Also who put min-height:0 for such items which will ensure there is a initial minimum value allowing it to grow as needed.

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->
Before
<img width="1392" alt="Screen Shot 2023-01-20 at 2 55 36 PM" src="https://user-images.githubusercontent.com/39910206/213773003-2e1ba548-eedf-4f2a-a039-c60bc38578dc.png">

After (observe on Seg Panel we can see the last items)
<img width="1392" alt="Screen Shot 2023-01-20 at 2 58 26 PM" src="https://user-images.githubusercontent.com/39910206/213773188-f4b281bb-98d5-4707-82ec-78e8baea30cb.png">

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://v3-docs.ohif.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
