### PR TITLE
fix(Hotkeys): add firstImage and lastImage commands referenced by 'home' and 'end' hotkeys

### DIFF
--- a/extensions/cornerstone/src/commandsModule.ts
+++ b/extensions/cornerstone/src/commandsModule.ts
@@ -322,6 +322,14 @@ const commandsModule = ({ servicesManager }) => {
       }
       const { viewport } = enabledElement;
 
+      // Check viewport is supported
+      if (
+        viewport! instanceof StackViewport &&
+        viewport! instanceof VolumeViewport
+      ) {
+        throw new Error('Unsupported viewport type');
+      }
+
       // Set slice to first slice
       const options = { imageIndex: 0 };
       cstUtils.jumpToSlice(viewport.element, options);

--- a/extensions/cornerstone/src/commandsModule.ts
+++ b/extensions/cornerstone/src/commandsModule.ts
@@ -1,6 +1,7 @@
 import {
   getEnabledElement,
   StackViewport,
+  VolumeViewport,
   utilities as csUtils,
 } from '@cornerstonejs/core';
 import {
@@ -313,6 +314,43 @@ const commandsModule = ({ servicesManager }) => {
         }
       }
     },
+    firstImage: () => {
+      const enabledElement = _getActiveViewportEnabledElement();
+
+      if (!enabledElement) {
+        return;
+      }
+
+      const { viewport } = enabledElement;
+      const options = { imageIndex: 0 };
+
+      cstUtils.jumpToSlice(viewport.element, options);
+    },
+    lastImage: () => {
+      const enabledElement = _getActiveViewportEnabledElement();
+
+      if (!enabledElement) {
+        return;
+      }
+
+      const { viewport } = enabledElement;
+
+      // Copied from cornerstone3D jumpToSlice\_getImageSliceData()
+      let numberOfSlices = 0;
+
+      if (viewport instanceof StackViewport) {
+        numberOfSlices = viewport.getImageIds().length;
+      } else if (viewport instanceof VolumeViewport) {
+        numberOfSlices = csUtils.getImageSliceDataForVolumeViewport(viewport)
+          .numberOfSlices;
+      } else {
+        throw new Error('Unsupported viewport type');
+      }
+
+      const options = { imageIndex: numberOfSlices - 1 };
+
+      cstUtils.jumpToSlice(viewport.element, options);
+    },
     scroll: ({ direction }) => {
       const enabledElement = _getActiveViewportEnabledElement();
 
@@ -474,6 +512,16 @@ const commandsModule = ({ servicesManager }) => {
       commandFn: actions.scroll,
       storeContexts: [],
       options: { direction: -1 },
+    },
+    firstImage: {
+      commandFn: actions.firstImage,
+      storeContexts: [],
+      options: {},
+    },
+    lastImage: {
+      commandFn: actions.lastImage,
+      storeContexts: [],
+      options: {},
     },
     showDownloadViewportModal: {
       commandFn: actions.showDownloadViewportModal,

--- a/extensions/cornerstone/src/commandsModule.ts
+++ b/extensions/cornerstone/src/commandsModule.ts
@@ -315,27 +315,27 @@ const commandsModule = ({ servicesManager }) => {
       }
     },
     firstImage: () => {
+      // Get current active viewport (return if none active)
       const enabledElement = _getActiveViewportEnabledElement();
-
       if (!enabledElement) {
         return;
       }
-
       const { viewport } = enabledElement;
-      const options = { imageIndex: 0 };
 
+      // Set slice to first slice
+      const options = { imageIndex: 0 };
       cstUtils.jumpToSlice(viewport.element, options);
     },
     lastImage: () => {
+      // Get current active viewport (return if none active)
       const enabledElement = _getActiveViewportEnabledElement();
-
       if (!enabledElement) {
         return;
       }
-
       const { viewport } = enabledElement;
 
-      // Copied from cornerstone3D jumpToSlice\_getImageSliceData()
+      // Get number of slices
+      // -> Copied from cornerstone3D jumpToSlice\_getImageSliceData()
       let numberOfSlices = 0;
 
       if (viewport instanceof StackViewport) {
@@ -347,8 +347,8 @@ const commandsModule = ({ servicesManager }) => {
         throw new Error('Unsupported viewport type');
       }
 
+      // Set slice to last slice
       const options = { imageIndex: numberOfSlices - 1 };
-
       cstUtils.jumpToSlice(viewport.element, options);
     },
     scroll: ({ direction }) => {


### PR DESCRIPTION
  ->implement firstImage lastImage commands

<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://v3-docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context
'home' and 'end' hotkeys call firstImage and lastImage commands. These commands were missing and have been added in extension/cornerstone/src/commandsModule.ts
<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results
- Added firstImage and lastImage commands referred by default 'home' and 'end' hotkeys
- 'home' and 'end' hotkeys now bring active viewport image to first and last slice respectively
<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing
Basic:
1. Load study with image set containing multiple slices
2. Hit 'end' key -> check viewport has changed to last slice
3. Hit 'home' key -> check viewport has changed to first image slice

Multiple
1. Load study with image set containing multiple slices
2. Change layout to 2x1 grid
3. Load image in both viewports
4. Change active to viewport 1
5. Hit 'end' key -> check viewport 1 has changed to last slice
6. Hit 'home' key -> check viewport 1 has changed to first slice
7. Change active to viewport 2
8. Hit 'end' key -> check viewport 2 has changed to last slice
9. Hit 'home' key -> check viewport 2 has changed to last slice
<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://v3-docs.ohif.org/ -->
(N/A)
- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] "OS: Windows 10<!--[e.g. Windows 10, macOS 10.15.4]"-->
- [x] "Node version: 16.15.1<!--[e.g. 16.14.0]"-->
- [x] "Browser: Chrome 109.0.5414.75
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
