### PR TITLE
fix(SR): fix Length and Bidirectional tools

### DIFF
--- a/.docker/Nginx-Orthanc/docker-compose.yml
+++ b/.docker/Nginx-Orthanc/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.5'
 
 services:
   orthanc:
-    image: jodogne/orthanc-plugins:1.5.6
+    image: jodogne/orthanc-plugins:1.5.7
     hostname: orthanc
     volumes:
       # Config
@@ -13,3 +13,11 @@ services:
       - '4242:4242' # DICOM
       - '8042:8042' # Web
     restart: unless-stopped
+  nginx:
+    image: nginx:latest
+    volumes:
+      - ./config/nginx.conf:/etc/nginx/nginx.conf
+    ports:
+      - '80:80' #ngnix proxy
+    depends_on:
+      - orthanc

--- a/extensions/cornerstone-dicom-sr/src/getSopClassHandlerModule.js
+++ b/extensions/cornerstone-dicom-sr/src/getSopClassHandlerModule.js
@@ -597,7 +597,7 @@ function _getLabelFromMeasuredValueSequence(
   const { CodeValue } = MeasurementUnitsCodeSequence;
 
   const formatedNumericValue = NumericValue
-    ? Number(NumericValue).toFixed(1)
+    ? Number(NumericValue).toFixed(2)
     : '';
 
   return {

--- a/extensions/cornerstone-dicom-sr/src/tools/DICOMSRDisplayTool.ts
+++ b/extensions/cornerstone-dicom-sr/src/tools/DICOMSRDisplayTool.ts
@@ -121,28 +121,23 @@ export default class DICOMSRDisplayTool extends AnnotationTool {
         const renderableDataForGraphicType = renderableData[GraphicType];
 
         let renderMethod;
-        let renderTextBox;
         let canvasCoordinatesAdapter;
 
         switch (GraphicType) {
           case SCOORD_TYPES.POINT:
             renderMethod = this.renderPoint;
-            renderTextBox = this.renderTextBox;
             break;
           case SCOORD_TYPES.MULTIPOINT:
             renderMethod = this.renderMultipoint;
-            renderTextBox = this.renderTextBox;
             break;
           case SCOORD_TYPES.POLYLINE:
             renderMethod = this.renderPolyLine;
             break;
           case SCOORD_TYPES.CIRCLE:
             renderMethod = this.renderEllipse;
-            renderTextBox = this.renderTextBox;
             break;
           case SCOORD_TYPES.ELLIPSE:
             renderMethod = this.renderEllipse;
-            renderTextBox = this.renderTextBox;
             canvasCoordinatesAdapter =
               utilities.math.ellipse.getCanvasEllipseCorners;
             break;
@@ -159,18 +154,15 @@ export default class DICOMSRDisplayTool extends AnnotationTool {
           options
         );
 
-        if (typeof renderTextBox === 'function') {
-          renderTextBox.call(
-            this,
-            svgDrawingHelper,
-            viewport,
-            canvasCoordinates,
-            canvasCoordinatesAdapter,
-            annotation,
-            styleSpecifier,
-            options
-          );
-        }
+        this.renderTextBox(
+          svgDrawingHelper,
+          viewport,
+          canvasCoordinates,
+          canvasCoordinatesAdapter,
+          annotation,
+          styleSpecifier,
+          options
+        );
       });
     }
   };
@@ -187,11 +179,11 @@ export default class DICOMSRDisplayTool extends AnnotationTool {
       color: options.color,
       width: options.lineWidth,
     };
-    let canvasCoordinates;
+    let allCanvasCoordinates = [];
     renderableData.map((data, index) => {
-      canvasCoordinates = data.map(p => viewport.worldToCanvas(p));
-
+      const canvasCoordinates = data.map(p => viewport.worldToCanvas(p));
       const lineUID = `${index}`;
+
       if (canvasCoordinates.length === 2) {
         drawing.drawLine(
           svgDrawingHelper,
@@ -210,9 +202,11 @@ export default class DICOMSRDisplayTool extends AnnotationTool {
           drawingOptions
         );
       }
+
+      allCanvasCoordinates = allCanvasCoordinates.concat(canvasCoordinates);
     });
 
-    return canvasCoordinates; // used for drawing textBox
+    return allCanvasCoordinates; // used for drawing textBox
   }
 
   renderMultipoint(
@@ -405,9 +399,9 @@ export default class DICOMSRDisplayTool extends AnnotationTool {
 }
 
 const SHORT_HAND_MAP = {
-  'Short Axis': 'W ',
-  'Long Axis': 'L ',
-  AREA: 'Area ',
+  'Short Axis': 'W: ',
+  'Long Axis': 'L: ',
+  AREA: 'Area: ',
   Length: '',
   CORNERSTONEFREETEXT: '',
 };

--- a/extensions/measurement-tracking/src/contexts/TrackedMeasurementsContext/promptHydrateStructuredReport.js
+++ b/extensions/measurement-tracking/src/contexts/TrackedMeasurementsContext/promptHydrateStructuredReport.js
@@ -1,4 +1,4 @@
-import hydrateStructuredReport from '@ohif/extension-cornerstone-dicom-sr';
+import { hydrateStructuredReport } from '@ohif/extension-cornerstone-dicom-sr';
 
 const RESPONSE = {
   NO_NEVER: -1,


### PR DESCRIPTION
### Context

Annotations are not rendered properly after loading a SR and enabling measurements tracking (OHIF-341).

### Changes & Results

- Changed how Length and Bidirectional annotations are rendered to make it similar to the original annotation added by the user before saving the SR.
- SRs does not support labels that were moved to different location
- No changes pushed to ellipse and arrow annotations

### Testing

- Add some Length and/or Bidirectional annotations
- Create a SR
- Load the SR created
- Once SR is loaded enable measurements tracking
- Compare how annotations were rendered before saving the SR, after loading the SR and after enabling measurements tracking.
