### PR TITLE
fix(cypress test): remove the click at beginning of the window level test

### DIFF
--- a/platform/viewer/cypress/integration/measurement-tracking/OHIFCornerstoneToolbar.spec.js
+++ b/platform/viewer/cypress/integration/measurement-tracking/OHIFCornerstoneToolbar.spec.js
@@ -84,7 +84,6 @@ describe('OHIF Cornerstone Toolbar', () => {
 
     //drags the mouse inside the viewport to be able to interact with series
     cy.get('@viewport')
-      .click({ force: true })
       .trigger('mousedown', 'center', { buttons: 1 })
       // Since we have scrollbar on the right side of the viewport, we need to
       // force the mousemove since it goes to another element


### PR DESCRIPTION
The test in question:

'OHIF Cornerstone Toolbar'.'checks if Levels tool will change the window width and center of an image'.

Issue #3157 

<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://v3-docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

The cypress test 'checks if Levels tool will change the window width and center of an image' in OHIFCornerstoneToolbar.spec.js is failing because of the double click detection changes that were made in cornerstone3D.

### Changes & Results

The test in question was performing a click near the beginning of the test that was not necessary and was throwing off the timing of the test because it was triggering an unnecessary double click detection. The click was removed.

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

1. Set up and run end-to-end tests as described [here](https://v3-docs.ohif.org/development/testing/).
2. Run the OHIF Cornerstone Toolbar test. It should pass.

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://v3-docs.ohif.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] "OS: Windows 11<!--[e.g. Windows 10, macOS 10.15.4]"-->
- [x] "Node version: 18.10.0<!--[e.g. 16.14.0]"-->
- [x] "Browser: Chrome 110.0.5481.78  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->
- [x] "Cypress 9.7.0"  

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
