### PR TITLE
chore: update vtk js to 26.4.0

### DIFF
--- a/extensions/cornerstone/package.json
+++ b/extensions/cornerstone/package.json
@@ -47,7 +47,7 @@
     "@cornerstonejs/core": "0.30.1",
     "@cornerstonejs/streaming-image-volume-loader": "^0.11.2",
     "@cornerstonejs/tools": "0.39.0",
-    "@kitware/vtk.js": "25.9.0",
+    "@kitware/vtk.js": "26.4.0",
     "html2canvas": "^1.4.1",
     "lodash.debounce": "4.0.8",
     "lodash.merge": "^4.6.2",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@babel/runtime": "7.16.3",
-    "@kitware/vtk.js": "25.9.0",
+    "@kitware/vtk.js": "26.4.0",
     "core-js": "^3.2.1"
   },
   "peerDependencies": {

--- a/platform/viewer/src/components/ViewportGrid.tsx
+++ b/platform/viewer/src/components/ViewportGrid.tsx
@@ -133,7 +133,9 @@ function ViewerViewportGrid(props) {
         // try to fill the empty viewport with a display set not already in the grid
         const displaySetsNotInGrid = availableDisplaySets.filter(
           displaySet =>
-            gridDisplaySetUIDs.indexOf(displaySet.displaySetInstanceUID) === -1
+            gridDisplaySetUIDs.indexOf(displaySet.displaySetInstanceUID) ===
+              -1 &&
+            ['SEG', 'SR', 'RTSTRUCT'].indexOf(displaySet.Modality) === -1
         );
 
         if (displaySetsNotInGrid.length > 0) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3589,14 +3589,15 @@
     merge-source-map "^1.1.0"
     schema-utils "^2.7.0"
 
-"@kitware/vtk.js@25.9.0":
-  version "25.9.0"
-  resolved "https://registry.npmjs.org/@kitware/vtk.js/-/vtk.js-25.9.0.tgz#ecf555c56f6e117b454131c43aba45311a515ecc"
-  integrity sha512-L4OQavJkSZjYYvW4GsEVkX7hqPKEbzEKwitq9GcjoAijrV0MINyxkChRbYEEYnTMcSW3i2jZ/jmiXaPfXuhPFQ==
+"@kitware/vtk.js@26.4.0":
+  version "26.4.0"
+  resolved "https://registry.npmjs.org/@kitware/vtk.js/-/vtk.js-26.4.0.tgz#2b876d94c33c365bbb6352cbe7b18f7942753ad3"
+  integrity sha512-V8lTv0E0/cp5ORLId0Noy3+NryZjneDvZOrHnRCGhVzMuH/aCND8xy8M9AejwC0BRI0mIp5eX9MjH3xhAlbeFg==
   dependencies:
     "@babel/runtime" "7.17.9"
     commander "9.2.0"
     d3-scale "4.0.2"
+    fast-deep-equal "^3.1.3"
     fflate "0.7.3"
     gl-matrix "3.4.3"
     globalthis "1.0.3"


### PR DESCRIPTION
- Updates vtk js to 26.4.0 since cs3d has been bumped before
- For filling out the empty viewports, we should exclude non-imaging ones