### PR TITLE
feat(ImageSet): Avoid exposing the images field by adding a getNumImagesMethod

### DIFF
--- a/platform/core/src/classes/ImageSet.js
+++ b/platform/core/src/classes/ImageSet.js
@@ -56,6 +56,8 @@ class ImageSet {
     }
   }
 
+  getNumImages = () => this.images.length
+
   getImage(index) {
     return this.images[index];
   }


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://v3-docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

Many places in the OHIF code reference the non-exposed `ImageSet.images` property directly.

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

Adding a `ImageSet.getNumImages` allows for a convenient way to get the number of images and there is already a `ImageSet.getImage(index)` method to accompany it.
<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

