### PR TITLE
fix(DicomJSON): Patient name from DICOM JSON now visible in the patient info popup

### DIFF
--- a/extensions/default/src/DicomJSONDataSource/index.js
+++ b/extensions/default/src/DicomJSONDataSource/index.js
@@ -206,8 +206,10 @@ function createDicomJSONApi(dicomJsonConfig) {
                 url: instance.url,
                 imageId: instance.url,
                 ...series,
+                ...study,
               };
               delete obj.instances;
+              delete obj.series;
               return obj;
             });
             storeInstances(instances);

--- a/extensions/measurement-tracking/src/viewports/TrackedCornerstoneViewport.tsx
+++ b/extensions/measurement-tracking/src/viewports/TrackedCornerstoneViewport.tsx
@@ -211,7 +211,7 @@ function TrackedCornerstoneViewport(props) {
           seriesDescription: SeriesDescription,
           patientInformation: {
             patientName: PatientName
-              ? OHIF.utils.formatPN(PatientName.Alphabetic)
+              ? OHIF.utils.formatPN(PatientName)
               : '',
             patientSex: PatientSex || '',
             patientAge: PatientAge || '',

--- a/platform/core/src/utils/formatPN.js
+++ b/platform/core/src/utils/formatPN.js
@@ -6,9 +6,11 @@ export default function formatPN(name) {
     return;
   }
 
+  const nameToUse = name.Alphabetic ?? name;
+
   // Convert the first ^ to a ', '. String.replace() only affects
   // the first appearance of the character.
-  const commaBetweenFirstAndLast = name.replace('^', ', ');
+  const commaBetweenFirstAndLast = nameToUse.replace('^', ', ');
 
   // Replace any remaining '^' characters with spaces
   const cleaned = commaBetweenFirstAndLast.replace(/\^/g, ' ');


### PR DESCRIPTION
- formatPN should accept a string person name as well as an object with a Alphabetic field.
- For DICOM JSON data sources, spread in the patient data from the study object into the instance.

<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://v3-docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

1. Display a DICOM JSON study, that includes a patient name, in OHIF. 
2. Click the patient info icon in the top right of a viewport.
3. The patient name is/was NOT displayed in the popup that is displayed.

The following URL depicts the incorrect behaviour prior to merging this PR...

https://v3-demo.ohif.org/viewer/dicomjson?url=https://ohif-dicom-json-example.s3.amazonaws.com/LIDC-IDRI-0001.json

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

- The code no longer assumes that ALL patient names are an object with an ALPHABETIC field - a check for this field is done first and if not present a string is assumed
- For DICOM JSON data sources, we are now spreading in the study info that includes such info as patient name

Now when the patient info icon is clicked, the patient name should appear in the popup.

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

1. Launch the following DICOM JSON study https://deploy-preview-3183--ohif-platform-viewer.netlify.app/viewer/dicomjson?url=https://ohif-dicom-json-example.s3.amazonaws.com/LIDC-IDRI-0001.json
2. Click the patient info icon.
3. The patient name Doe, Anonymized should be displayed.

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://v3-docs.ohif.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] "OS: Windows 11<!--[e.g. Windows 10, macOS 10.15.4]"-->
- [x] "Node version: 18.10.0"<!--[e.g. 16.14.0]"-->
- [x] "Browser: Chrome Version 110.0.5481.100"
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
