### PR TITLE
fix: state setter for download aspect toggle

### DIFF
--- a/platform/ui/src/components/content/viewportDownloadForm/ViewportDownloadForm.js
+++ b/platform/ui/src/components/content/viewportDownloadForm/ViewportDownloadForm.js
@@ -150,12 +150,14 @@ const ViewportDownloadForm = ({
 
   const onKeepAspectToggle = () => {
     const { width, height } = dimensions;
-    const aspectMultiplier = { ...aspectMultiplier };
     if (!keepAspect) {
-      const base = Math.min(width, height);
-      aspectMultiplier.width = width / base;
-      aspectMultiplier.height = height / base;
-      setAspectMultiplier(aspectMultiplier);
+      setAspectMultiplier(oldAspectMultiplier => {
+        const aspectMultiplier = { ...oldAspectMultiplier };
+        const base = Math.min(width, height);
+        aspectMultiplier.width = width / base;
+        aspectMultiplier.height = height / base;
+        return aspectMultiplier;
+      });
     }
 
     setKeepAspect(!keepAspect);


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://v3-docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

Clicking the aspect ratio button in the ViewportDownloadForm fails due to an error. When shadowing a class member name in js, you can't use the shadowed name to initialize the shadowing variable.

![image](https://user-images.githubusercontent.com/8948001/220602109-6299fb91-9976-4fab-a96f-b14b3b41ad95.png)

### Changes & Results

I fixed the syntax to avoid the error, and used the setter with callback, which should always be used when the new state depends on the current state in react.

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

Click the aspect ratio button, and it will now work.

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://v3-docs.ohif.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
