### PR TITLE
Fix servicesManager use before initialization

### DIFF
--- a/platform/viewer/src/appInit.js
+++ b/platform/viewer/src/appInit.js
@@ -24,12 +24,6 @@ import {
  * @param {object[]} defaultExtensions - array of extension objects
  */
 async function appInit(appConfigOrFunc, defaultExtensions, defaultModes) {
-  const appConfig = {
-    ...(typeof appConfigOrFunc === 'function'
-      ? appConfigOrFunc({ servicesManager })
-      : appConfigOrFunc),
-  };
-
   const commandsManagerConfig = {
     getAppState: () => {},
   };
@@ -37,6 +31,13 @@ async function appInit(appConfigOrFunc, defaultExtensions, defaultModes) {
   const commandsManager = new CommandsManager(commandsManagerConfig);
   const servicesManager = new ServicesManager(commandsManager);
   const hotkeysManager = new HotkeysManager(commandsManager, servicesManager);
+
+  const appConfig = {
+    ...(typeof appConfigOrFunc === 'function'
+      ? appConfigOrFunc({ servicesManager })
+      : appConfigOrFunc),
+  };
+
   const extensionManager = new ExtensionManager({
     commandsManager,
     servicesManager,


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://v3-docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

in AppInit.js, when `appConfigOrFunc` is defined as a function, it is being called with `servicesManager`. 
`servicesManager` is only initialized after, which results in the app crashing.

<img width="570" alt="Screenshot 2023-02-22 at 18 47 55" src="https://user-images.githubusercontent.com/29004228/220714586-14612d0d-2f89-446e-aeee-7b57020948ee.png">

 

### Changes & Results

Move the definition of `appConfig` down, after the initialization of `servicesManager`.

### Testing

you could reproduce this by using a function as configs.

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://v3-docs.ohif.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] "OS: macOS 13.1"
- [x] "Node version: 16.14.2"
- [x] "Chrome 110.0.5481.100, Firefox 110.0"

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
