### PR TITLE
feat(OrthancSetupEntrypoint): Use environment variables to setup Orthanc in the entrypoint

### DIFF
--- a/.docker/Viewer-v2.x/entrypoint.sh
+++ b/.docker/Viewer-v2.x/entrypoint.sh
@@ -34,6 +34,19 @@ if [ -n "${PORT}" ]
     sed -i -e "s/listen 80/listen ${PORT}/g" /etc/nginx/conf.d/default.conf
 fi
 
+if [ -n "$ORTHANC_NAME" ] && [ -n "$ORTHANC_URI" ]
+  then
+    echo "Orthanc config has been provided:"
+    echo "name: $ORTHANC_NAME"
+    echo "uri: $ORTHANC_URI"
+
+    sed -i -e "s+name: 'DCM4CHEE'+name: '$ORTHANC_NAME'+g" /usr/share/nginx/html/app-config.js
+    sed -i -e "s+wadoUriRoot:.*,+wadoUriRoot: '$ORTHANC_URI/wado',+g" /usr/share/nginx/html/app-config.js 
+    sed -i -e "s+qidoRoot:.*,+qidoRoot: '$ORTHANC_URI/dicom-web',+g" /usr/share/nginx/html/app-config.js
+    sed -i -e "s+wadoRoot:.*,+wadoRoot: '$ORTHANC_URI/dicom-web',+g" /usr/share/nginx/html/app-config.js
+
+fi
+
 echo "Starting Nginx to serve the OHIF Viewer..."
 
 exec "$@"


### PR DESCRIPTION
This fixes#3201

<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://v3-docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

Fixes https://github.com/OHIF/Viewers/issues/3201

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

I have changed the entrypoint of the docker images. With this change, you can use ORTHANC_NAME and ORTHANC_URI environment variables to setup Orthanc , the same way you do with google healthcare.

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

Build the docker image and then run it with:

```
docker run -ti -e ORTHANC_NAME="orthanc" ORTHANC_URI="http://orthanc-hostname:1234" ohif_viewer_image bash
```
Check the application settings in /usr/share/nginx/html/app-config.js and check that you have

```
dicomWeb: [
      {
        name: 'orthanc',
        wadoUriRoot: 'http://orthanc-hostname:1234/wado',
        qidoRoot: 'http://orthanc-hostname:1234/dicomweb',
        wadoRoot: 'http://orthanc-hostname:1234/dicomweb',

```


### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [X] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [X] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://v3-docs.ohif.org/ -->

- [X] The documentation page has been updated as necessary for any public API
  additions or removals.

No API changes.I am selecting the checkbox because it does not apply.

#### Tested Environment

- [X] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [X] "Node version: <!--[e.g. 16.14.0]"-->
- [X] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

Tested with docker. I am selecting the checkbox because it does not apply.

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
