### PR TITLE
Handle large volumes

### DIFF
--- a/extensions/cornerstone/src/init.tsx
+++ b/extensions/cornerstone/src/init.tsx
@@ -71,12 +71,14 @@ export default async function init({
     uiNotificationService,
     cineService,
     cornerstoneViewportService,
+    cornerstoneCacheService,
     hangingProtocolService,
     toolGroupService,
     viewportGridService,
   } = servicesManager.services;
 
   window.services = servicesManager.services;
+  cornerstoneCacheService.setMaxFramesInVolume(appConfig?.maxFramesInVolume);
 
   if (
     appConfig.showWarningMessageForCrossOrigin &&

--- a/platform/viewer/public/config/default.js
+++ b/platform/viewer/public/config/default.js
@@ -10,6 +10,9 @@ window.config = {
   showStudyList: true,
   // some windows systems have issues with more than 3 web workers
   maxNumberOfWebWorkers: 3,
+  maxFramesInVolume: 400,
+  maxCacheSize: 1073741824,
+
   // below flag is for performance reasons, but it might not work for all servers
   omitQuotationForMultipartRequest: true,
   showWarningMessageForCrossOrigin: true,


### PR DESCRIPTION
Fixes https://github.com/OHIF/Viewers/pull/3235
<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->
Some volumes can be 2500-3500 large and it is challenging to load these in memory. This PR helps by limiting the volume size and adds a callback function on the ImageSet class which can be used to filter out or change the metadata of an ImageSet / displaySet

### Changes & Results
Large volumes are evenly sampled when they go above the maxFramesInVolume config. Changes have been made to the ImageSet class and config has been added to the CornerstoneCacheService.

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing
1. Open the viewer to http://localhost:3000/viewer?StudyInstanceUIDs=1.3.6.1.4.1.25403.345050719074.3824.20170125095722.1

2. Open MPR mode to go into the volume mode (stack is unaffected by these changes)

3. Run the following on the console/window
`services.CornerstoneCacheService.setMaxFramesInVolume(20)`

4. You should see the volume update due to the DisplaySet being invalidated. You can also use the DisplaySetService to set the ImageMapper and invalidate. This functionality is left to be placed in extensions as use cases can vary.

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://v3-docs.ohif.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [x] "Browser: Chrome Version 110.0.5481.177 (Official Build) (arm64)
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
