### PR TITLE
Fix/hp validate match offset

### DIFF
--- a/extensions/cornerstone-dicom-sr/package.json
+++ b/extensions/cornerstone-dicom-sr/package.json
@@ -46,7 +46,7 @@
     "@babel/runtime": "^7.20.13",
     "classnames": "^2.3.2",
     "@cornerstonejs/adapters": "^0.4.1",
-    "@cornerstonejs/core": "^0.36.2",
+    "@cornerstonejs/core": "^0.36.4",
     "@cornerstonejs/tools": "^0.55.1"
   }
 }

--- a/extensions/cornerstone/package.json
+++ b/extensions/cornerstone/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@babel/runtime": "^7.20.13",
     "@cornerstonejs/adapters": "^0.4.1",
-    "@cornerstonejs/core": "^0.36.2",
+    "@cornerstonejs/core": "^0.36.4",
     "@cornerstonejs/streaming-image-volume-loader": "^0.15.1",
     "@cornerstonejs/tools": "^0.55.1",
     "@kitware/vtk.js": "26.5.6",

--- a/extensions/default/src/getHangingProtocolModule.js
+++ b/extensions/default/src/getHangingProtocolModule.js
@@ -98,7 +98,7 @@ const defaultProtocol = {
       viewportStructure: {
         layoutType: 'grid',
         properties: {
-          rows: 1,
+          rows: 2,
           columns: 2,
         },
       },
@@ -137,13 +137,7 @@ const defaultProtocol = {
           ],
         },
         {
-          viewportOptions: {
-            toolGroupId: 'default',
-            // initialImageOptions: {
-            //   index: 180,
-            //   preset: 'middle', // 'first', 'last', 'middle'
-            // },
-          },
+          viewportOptions: {},
           displaySets: [
             {
               id: 'defaultDisplaySetId',
@@ -154,10 +148,61 @@ const defaultProtocol = {
       ],
     },
 
+    {
+      name: '3x1',
+      // Indicate that the number of viewports needed is 2 filled viewports,
+      // but that 4 viewports are preferred.
+      stageActivation: {
+        enabled: {
+          minViewportsMatched: 3,
+        },
+      },
+
+      viewportStructure: {
+        layoutType: 'grid',
+        properties: {
+          rows: 1,
+          columns: 3,
+        },
+      },
+      viewports: [
+        {
+          viewportOptions: {
+            toolGroupId: 'default',
+          },
+          displaySets: [
+            {
+              id: 'defaultDisplaySetId',
+              matchedDisplaySetsIndex: 2,
+            },
+          ],
+        },
+        {
+          viewportOptions: {
+            toolGroupId: 'default',
+          },
+          displaySets: [
+            {
+              id: 'defaultDisplaySetId',
+              matchedDisplaySetsIndex: 1,
+            },
+          ],
+        },
+        {
+          viewportOptions: {},
+          displaySets: [
+            {
+              id: 'defaultDisplaySetId',
+            },
+          ],
+        },
+      ],
+    },
+
     // This is an example of a layout with more than one element in it
     // It can be navigated to using , and . (prev/next stage)
     {
-      name: '1x2',
+      name: '2x1',
       // Indicate that the number of viewports needed is 1 filled viewport,
       // but that 2 viewports are preferred.
       stageActivation: {
@@ -185,17 +230,42 @@ const defaultProtocol = {
           displaySets: [
             {
               id: 'defaultDisplaySetId',
+              // Shows the second index of this image set
+              matchedDisplaySetsIndex: 1,
             },
           ],
         },
         {
-          viewportOptions: {
-            toolGroupId: 'default',
-            // initialImageOptions: {
-            //   index: 180,
-            //   preset: 'middle', // 'first', 'last', 'middle'
-            // },
-          },
+          viewportOptions: {},
+          displaySets: [
+            {
+              id: 'defaultDisplaySetId',
+            },
+          ],
+        },
+      ],
+    },
+
+    {
+      name: '2x1',
+      // Indicate that the number of viewports needed is 1 filled viewport,
+      // but that 2 viewports are preferred.
+      stageActivation: {
+        enabled: {
+          minViewportsMatched: 3,
+        },
+      },
+
+      viewportStructure: {
+        layoutType: 'grid',
+        properties: {
+          rows: 2,
+          columns: 1,
+        },
+      },
+      viewports: [
+        {
+          viewportOptions: {},
           displaySets: [
             {
               id: 'defaultDisplaySetId',
@@ -204,8 +274,15 @@ const defaultProtocol = {
             },
           ],
         },
+        {
+          viewportOptions: {},
+          displaySets: [
+            {
+              id: 'defaultDisplaySetId',
+            },
+          ],
+        },
       ],
-      createdDate: '2021-02-23T18:32:42.850Z',
     },
   ],
 };

--- a/extensions/measurement-tracking/package.json
+++ b/extensions/measurement-tracking/package.json
@@ -32,7 +32,7 @@
   "peerDependencies": {
     "@ohif/core": "^3.0.0",
     "classnames": "^2.3.2",
-    "@cornerstonejs/core": "^0.36.2",
+    "@cornerstonejs/core": "^0.36.4",
     "@cornerstonejs/tools": "^0.55.1",
     "@ohif/extension-cornerstone-dicom-sr": "^3.0.0",
     "dcmjs": "^0.29.4",

--- a/platform/core/src/services/HangingProtocolService/HangingProtocolService.ts
+++ b/platform/core/src/services/HangingProtocolService/HangingProtocolService.ts
@@ -1011,6 +1011,7 @@ export default class HangingProtocolService extends PubSubService {
   ): HangingProtocol.DisplaySetMatchDetails {
     if (!matchDetails) return;
     if (offset === 0) return matchDetails;
+    const { matchingScores = [] } = matchDetails;
     if (offset === -1) {
       const { inDisplay } = options;
       if (!inDisplay) return matchDetails;
@@ -1022,13 +1023,14 @@ export default class HangingProtocolService extends PubSubService {
         ) {
           const match = matchDetails.matchingScores[i];
           return match.matchingScore > 0
-            ? matchDetails.matchingScores[i]
+            ? { matchingScores, ...matchDetails.matchingScores[i] }
             : null;
         }
       }
       return;
     }
-    return matchDetails.matchingScores[offset];
+    const matchFound = matchingScores[offset];
+    return matchFound ? { ...matchFound, matchingScores } : undefined;
   }
 
   protected validateDisplaySetSelectMatch(
@@ -1037,6 +1039,9 @@ export default class HangingProtocolService extends PubSubService {
     displaySetUID: string
   ): void {
     if (match.displaySetInstanceUID === displaySetUID) return;
+    if (!match.matchingScores) {
+      throw new Error('No matchingScores found in ' + match);
+    }
     for (const subMatch of match.matchingScores) {
       if (subMatch.displaySetInstanceUID === displaySetUID) return;
     }
@@ -1085,7 +1090,7 @@ export default class HangingProtocolService extends PubSubService {
       const reuseDisplaySetUID =
         id &&
         displaySetSelectorMap[
-        `${activeStudyUID}:${id}:${matchedDisplaySetsIndex || 0}`
+          `${activeStudyUID}:${id}:${matchedDisplaySetsIndex || 0}`
         ];
       const viewportDisplaySetMain = this.displaySetMatchDetails.get(id);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1459,6 +1459,14 @@
     detect-gpu "^4.0.45"
     lodash.clonedeep "4.5.0"
 
+"@cornerstonejs/core@^0.36.4":
+  version "0.36.4"
+  resolved "https://registry.yarnpkg.com/@cornerstonejs/core/-/core-0.36.4.tgz#43e4e1212a87ea39c7ad866c6d151fe4c8d9d3c0"
+  integrity sha512-BTkWApuU+tZxVEmePNltmUJEXKSxL2AlKvEnbbP2Q7mpZx+8iFAslLOEHxkik9jfRJE0h95jggdlzRrfqK8p+A==
+  dependencies:
+    detect-gpu "^4.0.45"
+    lodash.clonedeep "4.5.0"
+
 "@cornerstonejs/streaming-image-volume-loader@^0.15.1":
   version "0.15.1"
   resolved "https://registry.npmjs.org/@cornerstonejs/streaming-image-volume-loader/-/streaming-image-volume-loader-0.15.1.tgz#b9fd0efbebbd232119ef0ae7b63bf8b3498bf539"
@@ -8519,23 +8527,7 @@ cornerstone-math@^0.1.9:
   resolved "https://registry.npmjs.org/cornerstone-math/-/cornerstone-math-0.1.10.tgz#a3f99db64d73c5adee61ae0d570128eca1682d07"
   integrity sha512-23XSAyP7t70ANvhFyqwvva+zFd1bQ2d5GL7tg9qKE932WmImjA2Y9tiy5n0iTtnf51W/78Png8Lia2o4dCdJaQ==
 
-cornerstone-wado-image-loader@^4.10.0:
-  version "4.10.2"
-  resolved "https://registry.npmjs.org/cornerstone-wado-image-loader/-/cornerstone-wado-image-loader-4.10.2.tgz#139956654324fd2b01fe5b4900d0f4ed8c52633d"
-  integrity sha512-qj9dThELqYCm3jAZfg9qnUl8d76gngOl55kYJabY5lh/dFeVIxno/hYxy3ydE7RtG2c/TUGXb+EMUl0CJSqKBQ==
-  dependencies:
-    "@babel/eslint-parser" "^7.19.1"
-    "@cornerstonejs/codec-charls" "^1.2.3"
-    "@cornerstonejs/codec-libjpeg-turbo-8bit" "^1.2.2"
-    "@cornerstonejs/codec-openjpeg" "^1.2.2"
-    "@cornerstonejs/codec-openjph" "^2.4.2"
-    coverage-istanbul-loader "^3.0.5"
-    date-format "^4.0.14"
-    dicom-parser "^1.8.9"
-    pako "^2.0.4"
-    uuid "^9.0.0"
-
-cornerstone-wado-image-loader@^4.10.2:
+cornerstone-wado-image-loader@^4.10.0, cornerstone-wado-image-loader@^4.10.2:
   version "4.10.2"
   resolved "https://registry.yarnpkg.com/cornerstone-wado-image-loader/-/cornerstone-wado-image-loader-4.10.2.tgz#139956654324fd2b01fe5b4900d0f4ed8c52633d"
   integrity sha512-qj9dThELqYCm3jAZfg9qnUl8d76gngOl55kYJabY5lh/dFeVIxno/hYxy3ydE7RtG2c/TUGXb+EMUl0CJSqKBQ==


### PR DESCRIPTION
### Context

When a display set selector uses an offset other than 0, the matchingScores wasn't being set, which made later validation of any changes to the protocol fail to validate.  This change fixes that by adding the matching scores back in when required so that later validation can succeed.

### Changes & Results

Changed the validation of drag and dropped images in hanging protocols.
Also added more example stages in the default hanging protocol.

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://v3-docs.ohif.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
