### PR TITLE
Fix/hp validate match offset 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 <!-- markdownlint-disable -->
 <div align="center">
   <h1>OHIF Medical Imaging Viewer</h1>
-  <p><strong>The OHIF Viewer</strong> is a zero-footprint medical image viewer provided by the <a href="https://ohif.org/">Open Health Imaging Foundation (OHIF)</a>. It is a configurable and extensible progressive web application with out-of-the-box support for image archives which support <a href="https://www.dicomstandard.org/dicomweb/">DICOMweb</a>.</p>
+  <p><strong>The OHIF Viewer</strong> is a zero-footprint medical image viewer
+provided by the <a href="https://ohif.org/">Open Health Imaging Foundation (OHIF)</a>. It is a configurable and extensible progressive web application with out-of-the-box support for image archives which support <a href="https://www.dicomstandard.org/dicomweb/">DICOMweb</a>.</p>
 </div>
 
 

--- a/extensions/default/src/getHangingProtocolModule.js
+++ b/extensions/default/src/getHangingProtocolModule.js
@@ -98,7 +98,7 @@ const defaultProtocol = {
       viewportStructure: {
         layoutType: 'grid',
         properties: {
-          rows: 1,
+          rows: 2,
           columns: 2,
         },
       },
@@ -137,13 +137,7 @@ const defaultProtocol = {
           ],
         },
         {
-          viewportOptions: {
-            toolGroupId: 'default',
-            // initialImageOptions: {
-            //   index: 180,
-            //   preset: 'middle', // 'first', 'last', 'middle'
-            // },
-          },
+          viewportOptions: {},
           displaySets: [
             {
               id: 'defaultDisplaySetId',
@@ -154,10 +148,61 @@ const defaultProtocol = {
       ],
     },
 
+    {
+      name: '3x1',
+      // Indicate that the number of viewports needed is 2 filled viewports,
+      // but that 4 viewports are preferred.
+      stageActivation: {
+        enabled: {
+          minViewportsMatched: 3,
+        },
+      },
+
+      viewportStructure: {
+        layoutType: 'grid',
+        properties: {
+          rows: 1,
+          columns: 3,
+        },
+      },
+      viewports: [
+        {
+          viewportOptions: {
+            toolGroupId: 'default',
+          },
+          displaySets: [
+            {
+              id: 'defaultDisplaySetId',
+              matchedDisplaySetsIndex: 2,
+            },
+          ],
+        },
+        {
+          viewportOptions: {
+            toolGroupId: 'default',
+          },
+          displaySets: [
+            {
+              id: 'defaultDisplaySetId',
+              matchedDisplaySetsIndex: 1,
+            },
+          ],
+        },
+        {
+          viewportOptions: {},
+          displaySets: [
+            {
+              id: 'defaultDisplaySetId',
+            },
+          ],
+        },
+      ],
+    },
+
     // This is an example of a layout with more than one element in it
     // It can be navigated to using , and . (prev/next stage)
     {
-      name: '1x2',
+      name: '2x1',
       // Indicate that the number of viewports needed is 1 filled viewport,
       // but that 2 viewports are preferred.
       stageActivation: {
@@ -185,17 +230,42 @@ const defaultProtocol = {
           displaySets: [
             {
               id: 'defaultDisplaySetId',
+              // Shows the second index of this image set
+              matchedDisplaySetsIndex: 1,
             },
           ],
         },
         {
-          viewportOptions: {
-            toolGroupId: 'default',
-            // initialImageOptions: {
-            //   index: 180,
-            //   preset: 'middle', // 'first', 'last', 'middle'
-            // },
-          },
+          viewportOptions: {},
+          displaySets: [
+            {
+              id: 'defaultDisplaySetId',
+            },
+          ],
+        },
+      ],
+    },
+
+    {
+      name: '2x1',
+      // Indicate that the number of viewports needed is 1 filled viewport,
+      // but that 2 viewports are preferred.
+      stageActivation: {
+        enabled: {
+          minViewportsMatched: 3,
+        },
+      },
+
+      viewportStructure: {
+        layoutType: 'grid',
+        properties: {
+          rows: 2,
+          columns: 1,
+        },
+      },
+      viewports: [
+        {
+          viewportOptions: {},
           displaySets: [
             {
               id: 'defaultDisplaySetId',
@@ -204,8 +274,15 @@ const defaultProtocol = {
             },
           ],
         },
+        {
+          viewportOptions: {},
+          displaySets: [
+            {
+              id: 'defaultDisplaySetId',
+            },
+          ],
+        },
       ],
-      createdDate: '2021-02-23T18:32:42.850Z',
     },
   ],
 };

--- a/platform/core/src/services/HangingProtocolService/HangingProtocolService.ts
+++ b/platform/core/src/services/HangingProtocolService/HangingProtocolService.ts
@@ -1011,6 +1011,7 @@ export default class HangingProtocolService extends PubSubService {
   ): HangingProtocol.DisplaySetMatchDetails {
     if (!matchDetails) return;
     if (offset === 0) return matchDetails;
+    const { matchingScores = [] } = matchDetails;
     if (offset === -1) {
       const { inDisplay } = options;
       if (!inDisplay) return matchDetails;
@@ -1022,13 +1023,14 @@ export default class HangingProtocolService extends PubSubService {
         ) {
           const match = matchDetails.matchingScores[i];
           return match.matchingScore > 0
-            ? matchDetails.matchingScores[i]
+            ? { matchingScores, ...matchDetails.matchingScores[i] }
             : null;
         }
       }
       return;
     }
-    return matchDetails.matchingScores[offset];
+    const matchFound = matchingScores[offset];
+    return matchFound ? { ...matchFound, matchingScores } : undefined;
   }
 
   protected validateDisplaySetSelectMatch(
@@ -1037,6 +1039,9 @@ export default class HangingProtocolService extends PubSubService {
     displaySetUID: string
   ): void {
     if (match.displaySetInstanceUID === displaySetUID) return;
+    if (!match.matchingScores) {
+      throw new Error('No matchingScores found in ' + match);
+    }
     for (const subMatch of match.matchingScores) {
       if (subMatch.displaySetInstanceUID === displaySetUID) return;
     }
@@ -1085,7 +1090,7 @@ export default class HangingProtocolService extends PubSubService {
       const reuseDisplaySetUID =
         id &&
         displaySetSelectorMap[
-        `${activeStudyUID}:${id}:${matchedDisplaySetsIndex || 0}`
+          `${activeStudyUID}:${id}:${matchedDisplaySetsIndex || 0}`
         ];
       const viewportDisplaySetMain = this.displaySetMatchDetails.get(id);
 


### PR DESCRIPTION
Recreate validate match offset PR to fix build issues.
Context
When a display set selector uses an offset other than 0, the matchingScores wasn't being set, which made later validation of any changes to the protocol fail to validate. This change fixes that by adding the matching scores back in when required so that later validation can succeed.

Changes & Results
Changed the validation of drag and dropped images in hanging protocols.
Also added more example stages in the default hanging protocol.