### PR TITLE
fix(Volume3DViewport) - Replacing the volume 3D viewport with another https://github.com/jbocce/Viewers/pull/new/fix/replace-reconstructable-series-for-volume-3D-viewport

### DIFF
--- a/extensions/cornerstone-dicom-sr/package.json
+++ b/extensions/cornerstone-dicom-sr/package.json
@@ -46,7 +46,7 @@
     "@babel/runtime": "^7.20.13",
     "classnames": "^2.3.2",
     "@cornerstonejs/adapters": "^0.4.1",
-    "@cornerstonejs/core": "^0.36.2",
+    "@cornerstonejs/core": "^0.36.5",
     "@cornerstonejs/tools": "^0.55.1"
   }
 }

--- a/extensions/cornerstone/package.json
+++ b/extensions/cornerstone/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@babel/runtime": "^7.20.13",
     "@cornerstonejs/adapters": "^0.4.1",
-    "@cornerstonejs/core": "^0.36.2",
+    "@cornerstonejs/core": "^0.36.5",
     "@cornerstonejs/streaming-image-volume-loader": "^0.15.1",
     "@cornerstonejs/tools": "^0.55.1",
     "@kitware/vtk.js": "26.5.6",

--- a/extensions/cornerstone/src/Viewport/OHIFCornerstoneViewport.tsx
+++ b/extensions/cornerstone/src/Viewport/OHIFCornerstoneViewport.tsx
@@ -339,7 +339,7 @@ const OHIFCornerstoneViewport = React.memo(props => {
         elementEnabledHandler
       );
     };
-  }, []);
+  }, [viewportIndex]);
 
   // subscribe to displaySet metadata invalidation (updates)
   // Currently, if the metadata changes we need to re-render the display set

--- a/extensions/cornerstone/src/services/ViewportService/CornerstoneViewportService.ts
+++ b/extensions/cornerstone/src/services/ViewportService/CornerstoneViewportService.ts
@@ -173,9 +173,9 @@ class CornerstoneViewportService extends PubSubService
   }
 
   public setPresentations(viewport, presentations?: Presentations): void {
-    const properties = presentations.lutPresentation?.properties;
+    const properties = presentations?.lutPresentation?.properties;
     if (properties) viewport.setProperties(properties);
-    const camera = presentations.positionPresentation?.camera;
+    const camera = presentations?.positionPresentation?.camera;
     if (camera) viewport.setCamera(camera);
   }
 

--- a/extensions/measurement-tracking/package.json
+++ b/extensions/measurement-tracking/package.json
@@ -32,7 +32,7 @@
   "peerDependencies": {
     "@ohif/core": "^3.0.0",
     "classnames": "^2.3.2",
-    "@cornerstonejs/core": "^0.36.2",
+    "@cornerstonejs/core": "^0.36.5",
     "@cornerstonejs/tools": "^0.55.1",
     "@ohif/extension-cornerstone-dicom-sr": "^3.0.0",
     "dcmjs": "^0.29.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1459,6 +1459,14 @@
     detect-gpu "^4.0.45"
     lodash.clonedeep "4.5.0"
 
+"@cornerstonejs/core@^0.36.5":
+  version "0.36.5"
+  resolved "https://registry.yarnpkg.com/@cornerstonejs/core/-/core-0.36.5.tgz#2e8c2fc2f9d00c2b5a0f1666aa575ab5024f3616"
+  integrity sha512-5Z4GEjpWaYbEbSpbgNc92oiwTcD8TUpVw1TUQ5UC4OkzxBMN4THmkGifRq5kJpxJTahGVsoU4W1S7of+YsULlg==
+  dependencies:
+    detect-gpu "^4.0.45"
+    lodash.clonedeep "4.5.0"
+
 "@cornerstonejs/streaming-image-volume-loader@^0.15.1":
   version "0.15.1"
   resolved "https://registry.npmjs.org/@cornerstonejs/streaming-image-volume-loader/-/streaming-image-volume-loader-0.15.1.tgz#b9fd0efbebbd232119ef0ae7b63bf8b3498bf539"


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://v3-docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

When viewing a reconstructable series using the hanging protocol with id `mprAnd3DVolumeViewport` replacing the series in view either via a double click or a drag and drop of a series in the series thumbnail tray fails - the 3D volume viewport does not show the 3D volume and the following exceptions are thrown in the console...

```
Uncaught (in promise) Error: Method not implemented.
    at $d.getCurrentImageIdIndex (BaseVolumeViewport.js:98:19)
    at sk.getPresentation (CornerstoneViewportService.ts:195:42)
    at L (OHIFCornerstoneViewport.tsx:220:60)
    at OHIFCornerstoneViewport.tsx:397:7
getCurrentImageIdIndex @ BaseVolumeViewport.js:98
getPresentation @ CornerstoneViewportService.ts:195
L @ OHIFCornerstoneViewport.tsx:220
(anonymous) @ OHIFCornerstoneViewport.tsx:397
await in (anonymous) (async)
(anonymous) @ OHIFCornerstoneViewport.tsx:421
Fl @ react-dom.production.min.js:262
t.unstable_runWithPriority @ scheduler.production.min.js:18
Za @ react-dom.production.min.js:122
Nl @ react-dom.production.min.js:261
Sl @ react-dom.production.min.js:243
(anonymous) @ react-dom.production.min.js:123
t.unstable_runWithPriority @ scheduler.production.min.js:18
Za @ react-dom.production.min.js:122
Ya @ react-dom.production.min.js:123
Wa @ react-dom.production.min.js:122
xe @ react-dom.production.min.js:292
zt @ react-dom.production.min.js:73
```

```
Uncaught (in promise) TypeError: Cannot read properties of null (reading 'getInitialImageOptions')
    at sk.setVolumesForViewport (CornerstoneViewportService.ts:630:46)
setVolumesForViewport @ CornerstoneViewportService.ts:630
```
<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

- updated cornerstone3D core package dependency
- checked for null presentations when setting presentations
- added viewportIndex as a dependency for enabling and disabling an OHIFCornerstoneViewport; the dependency is required because if an OHIFCornerstoneViewport has it viewportIndex changed and some other/different OHIFCornerstoneViewport later gets that viewportIndex the code could potentially disable the wrong viewport on unmount

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

1. Launch OHIF with a study with several reconstructable series and applying the mprAnd3DVolumeViewport hanging protocol. Something like this...
http://v3-demo.ohif.org/viewer?StudyInstanceUIDs=1.3.6.1.4.1.25403.345050719074.3824.20170125095722.1&hangingProtocolId=mprAnd3DVolumeViewport
2. Drag and drop or double click various series from the side series tray into view.

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://v3-docs.ohif.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] "OS: Windows 11 <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [x] "Node version: 18.10.0 <!--[e.g. 16.14.0]"-->
- [x] "Browser: Chrome  111.0.5563.111
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
