### PR TITLE
feat(DoubleClick): double click a viewport to one up and back

### DIFF
--- a/extensions/cornerstone/src/init.tsx
+++ b/extensions/cornerstone/src/init.tsx
@@ -25,6 +25,7 @@ import interleaveCenterLoader from './utils/interleaveCenterLoader';
 import nthLoader from './utils/nthLoader';
 import interleaveTopToBottom from './utils/interleaveTopToBottom';
 import initContextMenu from './initContextMenu';
+import initDoubleClick from './initDoubleClick';
 
 // TODO: Cypress tests are currently grabbing this from the window?
 window.cornerstone = cornerstone;
@@ -104,6 +105,12 @@ export default async function init({
     clearOnModeExit: true,
   });
 
+  // Stores the entire ViewportGridService getState when toggling to one up
+  // (e.g. via a double click) so that it can be restored when toggling back.
+  stateSyncService.register('toggleOneUpViewportGridStore', {
+    clearOnModeExit: true,
+  });
+
   const labelmapRepresentation =
     cornerstoneTools.Enums.SegmentationRepresentations.Labelmap;
 
@@ -177,6 +184,11 @@ export default async function init({
 
   initContextMenu({
     cornerstoneViewportService,
+    customizationService,
+    commandsManager,
+  });
+
+  initDoubleClick({
     customizationService,
     commandsManager,
   });

--- a/extensions/cornerstone/src/initDoubleClick.ts
+++ b/extensions/cornerstone/src/initDoubleClick.ts
@@ -1,0 +1,59 @@
+import { eventTarget, EVENTS } from '@cornerstonejs/core';
+import { Enums } from '@cornerstonejs/tools';
+import { CommandsManager, CustomizationService, Types } from '@ohif/core';
+
+const cs3DToolsEvents = Enums.Events;
+
+const DEFAULT_DOUBLE_CLICK_COMMAND: Types.Command = {
+  commandName: 'toggleOneUp',
+  commandOptions: {},
+};
+
+export type initDoubleClickArgs = {
+  customizationService: CustomizationService;
+  commandsManager: CommandsManager;
+};
+
+function initDoubleClick({
+  customizationService,
+  commandsManager,
+}: initDoubleClickArgs): void {
+  const cornerstoneViewportHandleDoubleClick = _ => {
+    const customizations: Types.Command | Types.CommandCustomization =
+      (customizationService.get(
+        'cornerstoneViewportDoubleClickCommands'
+      ) as Types.CommandCustomization) || DEFAULT_DOUBLE_CLICK_COMMAND;
+
+    commandsManager.run(customizations);
+  };
+
+  function elementEnabledHandler(evt: CustomEvent) {
+    const { element } = evt.detail;
+
+    element.addEventListener(
+      cs3DToolsEvents.MOUSE_DOUBLE_CLICK,
+      cornerstoneViewportHandleDoubleClick
+    );
+  }
+
+  function elementDisabledHandler(evt: CustomEvent) {
+    const { element } = evt.detail;
+
+    element.removeEventListener(
+      cs3DToolsEvents.MOUSE_DOUBLE_CLICK,
+      cornerstoneViewportHandleDoubleClick
+    );
+  }
+
+  eventTarget.addEventListener(
+    EVENTS.ELEMENT_ENABLED,
+    elementEnabledHandler.bind(null)
+  );
+
+  eventTarget.addEventListener(
+    EVENTS.ELEMENT_DISABLED,
+    elementDisabledHandler.bind(null)
+  );
+}
+
+export default initDoubleClick;

--- a/platform/core/src/services/ViewportGridService/ViewportGridService.ts
+++ b/platform/core/src/services/ViewportGridService/ViewportGridService.ts
@@ -2,6 +2,8 @@ import { PubSubService } from '../_shared/pubSubServiceInterface';
 
 const EVENTS = {
   ACTIVE_VIEWPORT_INDEX_CHANGED: 'event::activeviewportindexchanged',
+  LAYOUT_CHANGED: 'event::layoutChanged',
+  GRID_STATE_CHANGED: 'event::gridStateChanged',
 };
 
 class ViewportGridService extends PubSubService {
@@ -101,11 +103,25 @@ class ViewportGridService extends PubSubService {
    *    options that is initially provided as {} (eg to store intermediate state)
    *    The function returns a viewport object to use at the given position.
    */
-  public setLayout({ numCols, numRows, findOrCreateViewport = undefined }) {
+  public setLayout({
+    numCols,
+    numRows,
+    layoutOptions,
+    layoutType = 'grid',
+    activeViewportIndex = undefined,
+    findOrCreateViewport = undefined,
+  }) {
     this.serviceImplementation._setLayout({
       numCols,
       numRows,
+      layoutOptions,
+      layoutType,
+      activeViewportIndex,
       findOrCreateViewport,
+    });
+    this._broadcastEvent(this.EVENTS.LAYOUT_CHANGED, {
+      numCols,
+      numRows,
     });
   }
 
@@ -125,6 +141,9 @@ class ViewportGridService extends PubSubService {
 
   public set(state) {
     this.serviceImplementation._set(state);
+    this._broadcastEvent(this.EVENTS.GRID_STATE_CHANGED, {
+      state,
+    });
   }
 
   public getNumViewportPanes() {

--- a/platform/core/src/types/Command.ts
+++ b/platform/core/src/types/Command.ts
@@ -6,5 +6,5 @@ export interface Command {
 
 /** A set of commands, typically contained in a tool item or other configuration */
 export interface Commands {
-  commands: Commands[];
+  commands: Command[];
 }

--- a/platform/core/src/utils/index.js
+++ b/platform/core/src/utils/index.js
@@ -32,6 +32,7 @@ import {
   sortingCriteria,
   seriesSortCriteria,
 } from './sortStudy';
+import { subscribeToNextViewportGridChange } from './subscribeToNextViewportGridChange';
 
 // Commented out unused functionality.
 // Need to implement new mechanism for derived displaySets using the displaySetManager.
@@ -69,6 +70,7 @@ const utils = {
   debounce,
   roundNumber,
   downloadCSVReport,
+  subscribeToNextViewportGridChange,
 };
 
 export {

--- a/platform/core/src/utils/index.test.js
+++ b/platform/core/src/utils/index.test.js
@@ -35,6 +35,7 @@ describe('Top level exports', () => {
       'resolveObjectPath',
       'hierarchicalListUtils',
       'progressTrackingUtils',
+      'subscribeToNextViewportGridChange',
     ].sort();
 
     const exports = Object.keys(utils.default).sort();

--- a/platform/core/src/utils/subscribeToNextViewportGridChange.ts
+++ b/platform/core/src/utils/subscribeToNextViewportGridChange.ts
@@ -1,0 +1,37 @@
+import { ViewportGridService } from '../services';
+
+/**
+ * Subscribes to the very next LAYOUT_CHANGED or GRID_STATE_CHANGED event that
+ * is not currently on the event queue. The subscriptions are made on a 'zero'
+ * timeout so as to avoid responding to any of those events currently on the event queue.
+ * The subscription persists only for a single invocation of either event.
+ * Once either event is fired, the subscriptions are unsubscribed.
+ * @param viewportGridService the viewport grid service to subscribe to
+ * @param gridChangeCallback the callback
+ */
+function subscribeToNextViewportGridChange(
+  viewportGridService: ViewportGridService,
+  gridChangeCallback: (arg: unknown) => void
+): void {
+  const subscriber = () => {
+    const callback = (callbackProps: unknown) => {
+      subscriptions.forEach(subscription => subscription.unsubscribe());
+      gridChangeCallback(callbackProps);
+    };
+
+    const subscriptions = [
+      viewportGridService.subscribe(
+        viewportGridService.EVENTS.LAYOUT_CHANGED,
+        callback
+      ),
+      viewportGridService.subscribe(
+        viewportGridService.EVENTS.GRID_STATE_CHANGED,
+        callback
+      ),
+    ];
+  };
+
+  window.setTimeout(subscriber, 0);
+}
+
+export { subscribeToNextViewportGridChange };

--- a/platform/ui/src/contextProviders/ViewportGridProvider.tsx
+++ b/platform/ui/src/contextProviders/ViewportGridProvider.tsx
@@ -146,6 +146,7 @@ export function ViewportGridProvider({ children, service }) {
           numRows,
           layoutOptions,
           layoutType = 'grid',
+          activeViewportIndex,
           findOrCreateViewport,
         } = action.payload;
 
@@ -160,7 +161,7 @@ export function ViewportGridProvider({ children, service }) {
         // haven't been viewed yet, and add them in the appropriate order.
         const options = {};
 
-        let activeViewportIndex;
+        let activeViewportIndexToSet = activeViewportIndex;
         for (let row = 0; row < numRows; row++) {
           for (let col = 0; col < numCols; col++) {
             const pos = col + row * numCols;
@@ -170,10 +171,11 @@ export function ViewportGridProvider({ children, service }) {
               continue;
             }
             if (
-              !activeViewportIndex ||
-              state.viewports[pos]?.positionId === positionId
+              activeViewportIndexToSet == null &&
+              state.viewports[state.activeViewportIndex]?.positionId ===
+                positionId
             ) {
-              activeViewportIndex = pos;
+              activeViewportIndexToSet = pos;
             }
             const viewport = findOrCreateViewport(pos, positionId, options);
             if (!viewport) continue;
@@ -199,6 +201,8 @@ export function ViewportGridProvider({ children, service }) {
           }
         }
 
+        activeViewportIndexToSet = activeViewportIndexToSet ?? 0;
+
         const viewportIdSet = {};
         for (
           let viewportIndex = 0;
@@ -223,7 +227,7 @@ export function ViewportGridProvider({ children, service }) {
 
         const ret = {
           ...state,
-          activeViewportIndex,
+          activeViewportIndex: activeViewportIndexToSet,
           layout: {
             ...state.layout,
             numCols,
@@ -300,6 +304,7 @@ export function ViewportGridProvider({ children, service }) {
       numRows,
       numCols,
       layoutOptions = [],
+      activeViewportIndex,
       findOrCreateViewport,
     }) =>
       dispatch({
@@ -309,6 +314,7 @@ export function ViewportGridProvider({ children, service }) {
           numRows,
           numCols,
           layoutOptions,
+          activeViewportIndex,
           findOrCreateViewport,
         },
       }),
@@ -375,9 +381,9 @@ export function ViewportGridProvider({ children, service }) {
     setActiveViewportIndex: index => service.setActiveViewportIndex(index), // run it through the service itself since we want to publish events
     setDisplaySetsForViewport,
     setDisplaySetsForViewports,
-    setLayout,
+    setLayout: layout => service.setLayout(layout), // run it through the service itself since we want to publish events
     reset,
-    set,
+    set: gridLayoutState => service.setState(gridLayoutState), // run it through the service itself since we want to publish events
     getNumViewportPanes,
   };
 

--- a/platform/viewer/cypress/integration/customization/OHIFDoubleClick.spec.js
+++ b/platform/viewer/cypress/integration/customization/OHIFDoubleClick.spec.js
@@ -1,0 +1,52 @@
+describe('OHIF Double Click', () => {
+  beforeEach(() => {
+    cy.checkStudyRouteInViewer(
+      '1.3.6.1.4.1.25403.345050719074.3824.20170125113417.1',
+      '&hangingProtocolId=@ohif/hp-extension.mn'
+    );
+    cy.expectMinimumThumbnails(3);
+    cy.initCornerstoneToolsAliases();
+    cy.initCommonElementsAliases();
+  });
+
+  it('Should double click each viewport to one up and back', () => {
+    const numExpectedViewports = 3;
+    cy.get('[data-cy="viewport-pane"]')
+      .its('length')
+      .should('be.eq', numExpectedViewports);
+
+    for (let i = 0; i < numExpectedViewports; i += 1) {
+      // For whatever reason, with Cypress tests, we have to activate the
+      // viewport we are double clicking first.
+      cy.get('[data-cy="viewport-pane"]')
+        .eq(i)
+        .trigger('mousedown', 'center', { force: true })
+        .trigger('mouseup', 'center', { force: true });
+
+      // Wait for the viewport to be 'active'.
+      // TODO Is there a better way to do this?
+      cy.get('[data-cy="viewport-pane"]')
+        .eq(i)
+        .parent()
+        .find('[data-cy="viewport-pane"]')
+        .not('.pointer-events-none');
+
+      // The actual double click.
+      cy.get('[data-cy="viewport-pane"]')
+        .eq(i)
+        .trigger('dblclick', 'center');
+
+      cy.get('[data-cy="viewport-pane"]')
+        .its('length')
+        .should('be.eq', 1);
+
+      cy.get('[data-cy="viewport-pane"]')
+        .eq(0)
+        .trigger('dblclick', 'center');
+
+      cy.get('[data-cy="viewport-pane"]')
+        .its('length')
+        .should('be.eq', numExpectedViewports);
+    }
+  });
+});

--- a/platform/viewer/public/config/e2e.js
+++ b/platform/viewer/public/config/e2e.js
@@ -122,6 +122,7 @@ window.config = {
     { commandName: 'resetViewport', label: 'Reset', keys: ['space'] },
     { commandName: 'nextImage', label: 'Next Image', keys: ['down'] },
     { commandName: 'previousImage', label: 'Previous Image', keys: ['up'] },
+    { commandName: 'toggleOneUp', label: 'Toggle One Up', keys: ['w'] },
     // {
     //   commandName: 'previousViewportDisplaySet',
     //   label: 'Previous Series',


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://v3-docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context
See OHIF https://github.com/OHIF/Viewers/issues/3245
<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

Added a toggleOneUp command that puts the active viewport into a 1x1 grid layout and it toggles out of 'one-up' by restoring its saved 'toggleOneUpViewportGridStore' from the StateSyncService.
Added double click customization for the Cornerstone extension with the default double click handling being the toggleOneUp command. 
Added a cypress test for the double click functionality.


<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

In various grid non 1x1 grid layouts, double click a viewport to put it in one-up (i.e. 1x1). After double clicking to 1x1, double clicking that viewport restores the pre-double click to one-up grid state.

After choosing the 1x1 layout from the grid layout menu OR when starting in an HP stage that is 1x1, double clicking does nothing.

The presentation state of the viewport toggle to/from one up should be maintained.

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://v3-docs.ohif.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] OS: Windows 11 <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [x] Node version: 18.10.0 <!--[e.g. 16.14.0]"-->
- [x] Browser: Chrome 111.0.5563.111
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
