### PR TITLE
fix(viewports): The display of linked viewports during drag and drop has a race

### DIFF
--- a/extensions/cornerstone-dicom-seg/src/utils/_hydrateSEG.ts
+++ b/extensions/cornerstone-dicom-seg/src/utils/_hydrateSEG.ts
@@ -31,8 +31,6 @@ async function _hydrateSEGDisplaySet({
     displaySetInstanceUID
   );
 
-  viewportGridService.setDisplaySetsForViewports(updatedViewports);
-
   // Todo: fix this after we have a better way for stack viewport segmentations
 
   // check every viewport in the viewports to see if the displaySetInstanceUID
@@ -50,7 +48,7 @@ async function _hydrateSEGDisplaySet({
     );
 
     if (shouldDisplaySeg) {
-      viewportGridService.setDisplaySetsForViewport({
+      updatedViewports.push({
         viewportIndex: index,
         displaySetInstanceUIDs: viewport.displaySetInstanceUIDs,
         viewportOptions: {
@@ -61,6 +59,9 @@ async function _hydrateSEGDisplaySet({
       });
     }
   });
+
+  // Do the entire update at once
+  viewportGridService.setDisplaySetsForViewports(updatedViewports);
 
   return true;
 }

--- a/extensions/cornerstone/src/Viewport/OHIFCornerstoneViewport.tsx
+++ b/extensions/cornerstone/src/Viewport/OHIFCornerstoneViewport.tsx
@@ -10,7 +10,6 @@ import {
   utilities as csUtils,
   CONSTANTS,
 } from '@cornerstonejs/core';
-import { Services } from '@ohif/core';
 
 import { setEnabledElement } from '../state';
 
@@ -22,9 +21,6 @@ import {
 } from '@cornerstonejs/core/dist/esm/types';
 import getSOPInstanceAttributes from '../utils/measurementServiceMappings/utils/getSOPInstanceAttributes';
 import { CinePlayer, useCine, useViewportGrid } from '@ohif/ui';
-
-import { CornerstoneViewportService } from '../services/ViewportService/CornerstoneViewportService';
-import Presentation from '../types/Presentation';
 
 const STACK = 'stack';
 
@@ -407,7 +403,6 @@ const OHIFCornerstoneViewport = React.memo(props => {
         lutPresentation:
           lutPresentationStore[presentationIds?.lutPresentationId],
       };
-      console.log('Using presentations', presentations);
 
       cornerstoneViewportService.setViewportData(
         viewportIndex,

--- a/extensions/cornerstone/src/getHangingProtocolModule.ts
+++ b/extensions/cornerstone/src/getHangingProtocolModule.ts
@@ -11,7 +11,7 @@ const mpr: Types.HangingProtocol.Protocol = {
   // Unknown number of priors referenced - so just match any study
   numberOfPriorsReferenced: 0,
   protocolMatchingRules: [],
-  imageLoadStrategy: 'interleaveTopToBottom',
+  imageLoadStrategy: 'nth',
   callbacks: {
     // Switches out of MPR mode when the layout change button is used
     onLayoutChange: [

--- a/extensions/cornerstone/src/getHangingProtocolModule.ts
+++ b/extensions/cornerstone/src/getHangingProtocolModule.ts
@@ -303,11 +303,11 @@ const mprAnd3DVolumeViewport = {
 function getHangingProtocolModule() {
   return [
     {
-      id: 'mpr',
+      name: 'mpr',
       protocol: mpr,
     },
     {
-      id: mprAnd3DVolumeViewport.id,
+      name: mprAnd3DVolumeViewport.id,
       protocol: mprAnd3DVolumeViewport,
     },
   ];

--- a/extensions/cornerstone/src/services/ViewportService/CornerstoneViewportService.ts
+++ b/extensions/cornerstone/src/services/ViewportService/CornerstoneViewportService.ts
@@ -156,7 +156,7 @@ class CornerstoneViewportService extends PubSubService
    * Disables the viewport inside the renderingEngine, if no viewport is left
    * it destroys the renderingEngine.
    *
-   * This is called when the element goes away entire - with new viewportId's
+   * This is called when the element goes away entirely - with new viewportId's
    * created for every new viewport, this will be called whenever the set of
    * viewports is changed, but NOT when the viewport position changes only.
    *
@@ -283,6 +283,9 @@ class CornerstoneViewportService extends PubSubService
     const viewport = renderingEngine.getViewport(viewportId);
     this._setDisplaySets(viewport, viewportData, viewportInfo, presentations);
 
+    // The broadcast event here ensures that listeners have a valid, up to date
+    // viewport to access.  Doing it too early can result in exceptions or
+    // invalid data.
     this._broadcastEvent(this.EVENTS.VIEWPORT_DATA_CHANGED, {
       viewportData,
       viewportIndex,
@@ -391,8 +394,6 @@ class CornerstoneViewportService extends PubSubService
       }
     }
 
-    // There is a bug in CS3D that the setStack does not
-    // navigate to the desired image.
     viewport.setStack(imageIds, initialImageIndexToUse).then(() => {
       viewport.setProperties(properties);
       const camera = presentations.positionPresentation?.camera;

--- a/extensions/cornerstone/src/services/ViewportService/CornerstoneViewportService.ts
+++ b/extensions/cornerstone/src/services/ViewportService/CornerstoneViewportService.ts
@@ -155,9 +155,14 @@ class CornerstoneViewportService extends PubSubService
   /**
    * Disables the viewport inside the renderingEngine, if no viewport is left
    * it destroys the renderingEngine.
+   *
+   * This is called when the element goes away entire - with new viewportId's
+   * created for every new viewport, this will be called whenever the set of
+   * viewports is changed, but NOT when the viewport position changes only.
+   *
    * @param viewportIndex
    */
-  public disableElement(viewportIndex: number) {
+  public disableElement(viewportIndex: number): void {
     const viewportInfo = this.viewportsInfo.get(viewportIndex);
     if (!viewportInfo) {
       return;
@@ -620,6 +625,10 @@ class CornerstoneViewportService extends PubSubService
     }
 
     const viewportInfo = this.getViewportInfo(viewport.id);
+
+    if (!viewportInfo) {
+      console.warn('Viewport info not defined for', viewport.id);
+    }
 
     const toolGroup = toolGroupService.getToolGroupForViewport(viewport.id);
     csToolsUtils.segmentation.triggerSegmentationRender(toolGroup.id);

--- a/extensions/cornerstone/src/services/ViewportService/CornerstoneViewportService.ts
+++ b/extensions/cornerstone/src/services/ViewportService/CornerstoneViewportService.ts
@@ -259,12 +259,6 @@ class CornerstoneViewportService extends PubSubService
     viewportInfo.setDisplaySetOptions(displaySetOptions);
     viewportInfo.setViewportData(viewportData);
 
-    this._broadcastEvent(this.EVENTS.VIEWPORT_DATA_CHANGED, {
-      viewportData,
-      viewportIndex,
-      viewportId,
-    });
-
     const element = viewportInfo.getElement();
     const type = viewportInfo.getViewportType();
     const background = viewportInfo.getBackground();
@@ -288,6 +282,12 @@ class CornerstoneViewportService extends PubSubService
 
     const viewport = renderingEngine.getViewport(viewportId);
     this._setDisplaySets(viewport, viewportData, viewportInfo, presentations);
+
+    this._broadcastEvent(this.EVENTS.VIEWPORT_DATA_CHANGED, {
+      viewportData,
+      viewportIndex,
+      viewportId,
+    });
   }
 
   public getCornerstoneViewport(
@@ -393,9 +393,7 @@ class CornerstoneViewportService extends PubSubService
 
     // There is a bug in CS3D that the setStack does not
     // navigate to the desired image.
-    viewport.setStack(imageIds, 0).then(() => {
-      // The scroll, however, works fine in CS3D
-      viewport.scroll(initialImageIndexToUse);
+    viewport.setStack(imageIds, initialImageIndexToUse).then(() => {
       viewport.setProperties(properties);
       const camera = presentations.positionPresentation?.camera;
       if (camera) viewport.setCamera(camera);

--- a/extensions/cornerstone/src/utils/nthLoader.ts
+++ b/extensions/cornerstone/src/utils/nthLoader.ts
@@ -18,7 +18,6 @@ const viewportIdVolumeInputArrayMap = new Map<string, unknown[]>();
 export default function interleaveNthLoader({
   data: { viewportId, volumeInputArray },
   displaySetsMatchDetails,
-  viewportMatchDetails: matchDetails,
 }) {
   viewportIdVolumeInputArrayMap.set(viewportId, volumeInputArray);
 
@@ -29,6 +28,7 @@ export default function interleaveNthLoader({
     const volume = cache.getVolume(volumeId);
 
     if (!volume) {
+      console.log("interleaveNthLoader::No volume, can't load it");
       return;
     }
 
@@ -36,33 +36,6 @@ export default function interleaveNthLoader({
     if (!volumeIdMapsToLoad.has(volumeId)) {
       const { metadata } = volume;
       volumeIdMapsToLoad.set(volumeId, metadata.SeriesInstanceUID);
-    }
-  }
-
-  /**
-   * The following is checking if all the viewports that were matched in the HP has been
-   * successfully created their cornerstone viewport or not. Todo: This can be
-   * improved by not checking it, and as soon as the matched DisplaySets have their
-   * volume loaded, we start the loading, but that comes at the cost of viewports
-   * not being created yet (e.g., in a 10 viewport ptCT fusion, when one ct viewport and one
-   * pt viewport are created we have a guarantee that the volumes are created in the cache
-   * but the rest of the viewports (fusion, mip etc.) are not created yet. So
-   * we can't initiate setting the volumes for those viewports. One solution can be
-   * to add an event when a viewport is created (not enabled element event) and then
-   * listen to it and as the other viewports are created we can set the volumes for them
-   * since volumes are already started loading.
-   */
-  if (matchDetails.size !== viewportIdVolumeInputArrayMap.size) {
-    return;
-  }
-
-  // Check if all the matched volumes are loaded
-  for (const [_, details] of displaySetsMatchDetails.entries()) {
-    const { SeriesInstanceUID } = details;
-
-    // HangingProtocol has matched, but don't have all the volumes created yet, so return
-    if (!Array.from(volumeIdMapsToLoad.values()).includes(SeriesInstanceUID)) {
-      return;
     }
   }
 

--- a/extensions/default/src/getHangingProtocolModule.js
+++ b/extensions/default/src/getHangingProtocolModule.js
@@ -290,7 +290,7 @@ const defaultProtocol = {
 function getHangingProtocolModule() {
   return [
     {
-      id: defaultProtocol.id,
+      name: defaultProtocol.id,
       protocol: defaultProtocol,
     },
   ];

--- a/extensions/test-extension/src/hp/index.ts
+++ b/extensions/test-extension/src/hp/index.ts
@@ -2,7 +2,7 @@ import hpMN from './hpMN';
 
 const hangingProtocols = [
   {
-    id: '@ohif/hp-extension.mn',
+    name: '@ohif/hp-extension.mn',
     protocol: hpMN,
   },
 ];

--- a/extensions/tmtv/src/getHangingProtocolModule.js
+++ b/extensions/tmtv/src/getHangingProtocolModule.js
@@ -323,7 +323,7 @@ const ptCT = {
 function getHangingProtocolModule() {
   return [
     {
-      id: ptCT.id,
+      name: ptCT.id,
       protocol: ptCT,
     },
   ];

--- a/platform/core/src/extensions/ExtensionManager.test.js
+++ b/platform/core/src/extensions/ExtensionManager.test.js
@@ -206,40 +206,40 @@ describe('ExtensionManager.ts', () => {
       const extension = {
         id: 'hello-world',
         getViewportModule: () => {
-          return [{}];
+          return [{ name: 'test' }];
         },
         getSopClassHandlerModule: () => {
-          return [{}];
+          return [{ name: 'test' }];
         },
         getPanelModule: () => {
-          return [{}];
+          return [{ name: 'test' }];
         },
         getToolbarModule: () => {
-          return [{}];
+          return [{ name: 'test' }];
         },
         getCommandsModule: () => {
-          return [{}];
+          return [{ name: 'test' }];
         },
         getLayoutTemplateModule: () => {
-          return [{}];
+          return [{ name: 'test' }];
         },
         getDataSourcesModule: () => {
-          return [{}];
+          return [{ name: 'test' }];
         },
         getHangingProtocolModule: () => {
-          return [{}];
+          return [{ name: 'test' }];
         },
         getContextModule: () => {
-          return [{}];
+          return [{ name: 'test' }];
         },
         getUtilityModule: () => {
-          return [{}];
+          return [{ name: 'test' }];
         },
         getCustomizationModule: () => {
-          return [{}];
+          return [{ name: 'test' }];
         },
         getStateSyncModule: () => {
-          return [{}];
+          return [{ name: 'test' }];
         },
       };
 

--- a/platform/core/src/extensions/ExtensionManager.ts
+++ b/platform/core/src/extensions/ExtensionManager.ts
@@ -283,6 +283,11 @@ export default class ExtensionManager {
             // Default for most extension points,
             // Just adds each entry ready for consumption by mode.
             extensionModule.forEach(element => {
+              if (!element.name) {
+                throw new Error(
+                  `Extension ID ${extensionId} module ${moduleType} element has no name`
+                );
+              }
               const id = `${extensionId}.${moduleType}.${element.name}`;
               element.id = id;
               this.modulesMap[id] = element;
@@ -366,10 +371,10 @@ export default class ExtensionManager {
 
   _initHangingProtocolsModule = (extensionModule, extensionId) => {
     const { hangingProtocolService } = this._servicesManager.services;
-    extensionModule.forEach(({ id, protocol }) => {
+    extensionModule.forEach(({ name, protocol }) => {
       if (protocol) {
         // Only auto-register if protocol specified, otherwise let mode register
-        hangingProtocolService.addProtocol(id, protocol);
+        hangingProtocolService.addProtocol(name, protocol);
       }
     });
   };

--- a/platform/core/src/services/ViewportGridService/ViewportGridService.ts
+++ b/platform/core/src/services/ViewportGridService/ViewportGridService.ts
@@ -73,12 +73,13 @@ class ViewportGridService extends PubSubService {
     return this.serviceImplementation._getState();
   }
 
-  public setDisplaySetsForViewport(viewport) {
-    this.serviceImplementation._setDisplaySetsForViewports([viewport]);
+  public setDisplaySetsForViewport(props) {
+    // Just update a single viewport, but use the multi-viewport update for it.
+    this.serviceImplementation._setDisplaySetsForViewports([props]);
   }
 
-  public setDisplaySetsForViewports(viewports) {
-    this.serviceImplementation._setDisplaySetsForViewports(viewports);
+  public setDisplaySetsForViewports(props) {
+    this.serviceImplementation._setDisplaySetsForViewports(props);
   }
 
   /**

--- a/platform/core/src/services/ViewportGridService/ViewportGridService.ts
+++ b/platform/core/src/services/ViewportGridService/ViewportGridService.ts
@@ -26,7 +26,6 @@ class ViewportGridService extends PubSubService {
   public setServiceImplementation({
     getState: getStateImplementation,
     setActiveViewportIndex: setActiveViewportIndexImplementation,
-    setDisplaySetsForViewport: setDisplaySetsForViewportImplementation,
     setDisplaySetsForViewports: setDisplaySetsForViewportsImplementation,
     setLayout: setLayoutImplementation,
     reset: resetImplementation,
@@ -39,9 +38,6 @@ class ViewportGridService extends PubSubService {
     }
     if (setActiveViewportIndexImplementation) {
       this.serviceImplementation._setActiveViewportIndex = setActiveViewportIndexImplementation;
-    }
-    if (setDisplaySetsForViewportImplementation) {
-      this.serviceImplementation._setDisplaySetsForViewport = setDisplaySetsForViewportImplementation;
     }
     if (setDisplaySetsForViewportsImplementation) {
       this.serviceImplementation._setDisplaySetsForViewports = setDisplaySetsForViewportsImplementation;
@@ -77,18 +73,8 @@ class ViewportGridService extends PubSubService {
     return this.serviceImplementation._getState();
   }
 
-  public setDisplaySetsForViewport({
-    viewportIndex,
-    displaySetInstanceUIDs,
-    viewportOptions,
-    displaySetOptions,
-  }) {
-    this.serviceImplementation._setDisplaySetsForViewport({
-      viewportIndex,
-      displaySetInstanceUIDs,
-      viewportOptions,
-      displaySetOptions,
-    });
+  public setDisplaySetsForViewport(viewport) {
+    this.serviceImplementation._setDisplaySetsForViewports([viewport]);
   }
 
   public setDisplaySetsForViewports(viewports) {

--- a/platform/ui/src/contextProviders/ViewportGridProvider.tsx
+++ b/platform/ui/src/contextProviders/ViewportGridProvider.tsx
@@ -187,24 +187,6 @@ export function ViewportGridProvider({ children, service }) {
 
           viewports[viewportIndex] = newViewport;
         }
-        viewports.forEach((viewport, index) => {
-          console.log(
-            'Viewport',
-            index,
-            viewport.viewportIndex,
-            state.viewports[index].viewportIndex,
-            viewport.viewportId,
-            state.viewports[index].viewportId
-          );
-          if (
-            viewport.id !== viewport.viewportId ||
-            viewport.id !== viewport.viewportOptions.viewportId
-          ) {
-            throw new Error(
-              `Viewport ${index} ${viewport.id} ${viewport.viewportId}`
-            );
-          }
-        });
 
         return { ...state, viewports };
       }

--- a/platform/ui/src/contextProviders/ViewportGridProvider.tsx
+++ b/platform/ui/src/contextProviders/ViewportGridProvider.tsx
@@ -79,11 +79,6 @@ const reuseViewportId = (idSet: Set, viewport, stateViewports) => {
       // since we have gotten here, the viewport ID isn't used, so we
       // are good to reuse it.
       // This will remember the old viewport options, assuming they are unchanging.
-      console.log(
-        'Reusing viewport',
-        oldId,
-        viewport.viewportOptions.viewportType
-      );
       return {
         ...oldViewport,
         ...viewport,
@@ -106,11 +101,6 @@ const reuseViewportId = (idSet: Set, viewport, stateViewports) => {
   viewportCounter = (viewportCounter + 1) % 100000;
   // viewportOptions is already a copy, so can just update direct
   viewport.viewportOptions.viewportId = viewportId;
-  console.log(
-    'New viewport',
-    viewportId,
-    viewport.viewportOptions.viewportType
-  );
 
   return {
     ...viewport,

--- a/platform/ui/src/contextProviders/ViewportGridProvider.tsx
+++ b/platform/ui/src/contextProviders/ViewportGridProvider.tsx
@@ -151,10 +151,13 @@ export function ViewportGridProvider({ children, service }) {
           };
 
           const displaySetOptions = updatedViewport.displaySetOptions || [];
-          if (displaySetOptions.length === 0) {
+          if (!displaySetOptions.length) {
             // Copy all the display set options, assuming a full set of displa
             // set UID's is provided.
             displaySetOptions.push(...previousViewport.displaySetOptions);
+            if (!displaySetOptions.length) {
+              displaySetOptions.push({});
+            }
           }
 
           let newViewport = {

--- a/platform/viewer/public/config/multiple.js
+++ b/platform/viewer/public/config/multiple.js
@@ -43,6 +43,31 @@ window.config = {
       },
     },
     {
+      friendlyName: 'dcmjs DICOMWeb Server',
+      namespace: '@ohif/extension-default.dataSourcesModule.dicomweb',
+      sourceName: 'ohif',
+      configuration: {
+        name: 'aws',
+        // old server
+        // wadoUriRoot: 'https://server.dcmjs.org/dcm4chee-arc/aets/DCM4CHEE/wado',
+        // qidoRoot: 'https://server.dcmjs.org/dcm4chee-arc/aets/DCM4CHEE/rs',
+        // wadoRoot: 'https://server.dcmjs.org/dcm4chee-arc/aets/DCM4CHEE/rs',
+        // new server
+        wadoUriRoot: 'https://domvja9iplmyu.cloudfront.net/dicomweb',
+        qidoRoot: 'https://domvja9iplmyu.cloudfront.net/dicomweb',
+        wadoRoot: 'https://domvja9iplmyu.cloudfront.net/dicomweb',
+        qidoSupportsIncludeField: false,
+        supportsReject: false,
+        imageRendering: 'wadors',
+        thumbnailRendering: 'wadors',
+        enableStudyLazyLoad: true,
+        supportsFuzzyMatching: false,
+        supportsWildcard: true,
+        staticWado: true,
+        singlepart: 'bulkdata,video,pdf',
+      },
+    },
+    {
       friendlyName: 'AWS S3 OHIF',
       namespace: '@ohif/extension-default.dataSourcesModule.dicomweb',
       sourceName: 'aws',


### PR DESCRIPTION
### Context

If multiple react state events occur near each other, react can decide to combine this, or can serialize them, or any combination thereof.  As well, any number of renderings or none can occur in between these.  This combination can lead to viewports
being in the midst of being created or destroyed when being rendered, or a partial new rendering occur, causing exceptions.


### Changes & Results

There are two parts to the fix.  First, not reusing viewport Id's at all means that create/destroy events on single viewport id's don't occur.  Second, making the drag and drop and segmentation updates atomic (single operation done at once) means it occurs consistently and in the same order and doesn't invoke multiple renders.  This also, incidentally, makes it faster.

### Testing

To test, the easiest way is to open up the test:e2e:serve environment, and view the SEG containing series in basic test mode
Try it with various layouts and protocol stages with:
Seg in one viewport, primary images in one or two other viewports
Ensure that you can load the seg, and that after you can:
1. Add the SEG to a blank viewport
2. Navigate each image series separately
3. Change layouts still
4. Note that during changing layouts there are some issues with remembering the positioning of multiple viewports containing the same series.

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://v3-docs.ohif.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
