### PR TITLE
feat(4d): 1x3 PET layout with some panels on the left

### DIFF
--- a/extensions/cornerstone-dynamic-volume/.webpack/webpack.dev.js
+++ b/extensions/cornerstone-dynamic-volume/.webpack/webpack.dev.js
@@ -1,0 +1,8 @@
+const path = require('path');
+const webpackCommon = require('./../../../.webpack/webpack.commonjs.js');
+const SRC_DIR = path.join(__dirname, '../src');
+const DIST_DIR = path.join(__dirname, '../dist');
+
+module.exports = (env, argv) => {
+  return webpackCommon(env, argv, { SRC_DIR, DIST_DIR });
+};

--- a/extensions/cornerstone-dynamic-volume/.webpack/webpack.prod.js
+++ b/extensions/cornerstone-dynamic-volume/.webpack/webpack.prod.js
@@ -1,0 +1,63 @@
+const path = require('path');
+const pkg = require('../package.json');
+
+const outputFile = 'index.umd.js';
+const rootDir = path.resolve(__dirname, '../');
+const outputFolder = path.join(__dirname, `../dist/umd/${pkg.name}/`);
+
+// Todo: add ESM build for the extension in addition to umd build
+
+const config = {
+  mode: 'production',
+  entry: rootDir + '/' + pkg.module,
+  devtool: 'source-map',
+  output: {
+    path: outputFolder,
+    filename: outputFile,
+    library: pkg.name,
+    libraryTarget: 'umd',
+    chunkFilename: '[name].chunk.js',
+    umdNamedDefine: true,
+    globalObject: "typeof self !== 'undefined' ? self : this",
+  },
+  externals: [
+    {
+      react: {
+        root: 'React',
+        commonjs2: 'react',
+        commonjs: 'react',
+        amd: 'react',
+      },
+      '@ohif/core': {
+        commonjs2: '@ohif/core',
+        commonjs: '@ohif/core',
+        amd: '@ohif/core',
+        root: '@ohif/core',
+      },
+      '@ohif/ui': {
+        commonjs2: '@ohif/ui',
+        commonjs: '@ohif/ui',
+        amd: '@ohif/ui',
+        root: '@ohif/ui',
+      },
+    },
+  ],
+  module: {
+    rules: [
+      {
+        test: /(\.jsx|\.js|\.tsx|\.ts)$/,
+        loader: 'babel-loader',
+        exclude: /(node_modules|bower_components)/,
+        resolve: {
+          extensions: ['.js', '.jsx', '.ts', '.tsx'],
+        },
+      },
+    ],
+  },
+  resolve: {
+    modules: [path.resolve('./node_modules'), path.resolve('./src')],
+    extensions: ['.json', '.js', '.jsx', '.tsx', '.ts'],
+  },
+};
+
+module.exports = config;

--- a/extensions/cornerstone-dynamic-volume/LICENSE
+++ b/extensions/cornerstone-dynamic-volume/LICENSE
@@ -1,0 +1,20 @@
+MIT License
+
+Copyright (c) 2023 cornerstone-dynamic-volume ()
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/extensions/cornerstone-dynamic-volume/README.md
+++ b/extensions/cornerstone-dynamic-volume/README.md
@@ -1,0 +1,8 @@
+# cornerstone-dynamic-volume
+## Description
+
+## Author
+OHIF
+
+## License
+MIT

--- a/extensions/cornerstone-dynamic-volume/babel.config.js
+++ b/extensions/cornerstone-dynamic-volume/babel.config.js
@@ -1,0 +1,1 @@
+module.exports = require('../../babel.config.js');

--- a/extensions/cornerstone-dynamic-volume/package.json
+++ b/extensions/cornerstone-dynamic-volume/package.json
@@ -1,0 +1,73 @@
+{
+  "name": "@ohif/extension-cornerstone-dynamic-volume",
+  "version": "1.0.0",
+  "description": "4D volumes data",
+  "author": "OHIF",
+  "license": "MIT",
+  "main": "dist/umd/@ohif/cornerstone-dynamic-volume/index.umd.js",
+  "module": "src/index.ts",
+  "files": [
+    "dist/**",
+    "public/**",
+    "README.md"
+  ],
+  "repository": "OHIF/Viewers",
+  "keywords": [
+    "ohif-extension"
+  ],
+  "engines": {
+    "node": ">=14",
+    "npm": ">=6",
+    "yarn": ">=1.18.0"
+  },
+  "scripts": {
+    "dev": "cross-env NODE_ENV=development webpack --config .webpack/webpack.dev.js --watch --debug --output-pathinfo",
+    "dev:dynamic-volume": "yarn run dev",
+    "build": "cross-env NODE_ENV=production webpack --config .webpack/webpack.prod.js",
+    "build:package": "yarn run build",
+    "start": "yarn run dev"
+  },
+  "peerDependencies": {
+    "@ohif/core": "^3.0.0",
+    "@ohif/extension-default": "^3.0.0",
+    "@ohif/extension-cornerstone": "^3.0.0",
+    "@ohif/i18n": "^1.0.0",
+    "prop-types": "^15.6.2",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
+    "react-i18next": "^10.11.0",
+    "react-router": "^6.8.1",
+    "react-router-dom": "^6.8.1",
+    "webpack": "^5.50.0",
+    "webpack-merge": "^5.7.3"
+  },
+  "dependencies": {
+    "@babel/runtime": "^7.20.13"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.17.8",
+    "@babel/plugin-proposal-class-properties": "^7.16.7",
+    "@babel/plugin-proposal-object-rest-spread": "^7.17.3",
+    "@babel/plugin-proposal-private-methods": "^7.18.6",
+    "@babel/plugin-syntax-dynamic-import": "^7.8.3",
+    "@babel/plugin-transform-arrow-functions": "^7.16.7",
+    "@babel/plugin-transform-regenerator": "^7.16.7",
+    "@babel/plugin-transform-runtime": "^7.17.0",
+    "babel-plugin-inline-react-svg": "^2.0.1",
+    "@babel/plugin-transform-typescript": "^7.13.0",
+    "@babel/preset-env": "^7.16.11",
+    "@babel/preset-react": "^7.16.7",
+    "@babel/preset-typescript": "^7.13.0",
+    "babel-eslint": "^8.0.3",
+    "babel-loader": "^8.0.0-beta.4",
+    "clean-webpack-plugin": "^4.0.0",
+    "copy-webpack-plugin": "^10.2.0",
+    "cross-env": "^7.0.3",
+    "dotenv": "^14.1.0",
+    "eslint": "^5.0.1",
+    "eslint-loader": "^2.0.0",
+    "webpack": "^5.50.0",
+    "webpack-merge": "^5.7.3",
+    "webpack-cli": "^4.7.2"
+  }
+}

--- a/extensions/cornerstone-dynamic-volume/src/getHangingProtocolModule.ts
+++ b/extensions/cornerstone-dynamic-volume/src/getHangingProtocolModule.ts
@@ -1,0 +1,348 @@
+function volumeDisplaySetMatcher() {
+
+}
+
+const defaultProtocol = {
+  id: 'default',
+  locked: true,
+  // Don't store this hanging protocol as it applies to the currently active
+  // display set by default
+  // cacheId: null,
+  hasUpdatedPriorsInformation: false,
+  name: 'Default',
+  createdDate: '2023-01-01T00:00:00.000Z',
+  modifiedDate: '2023-01-01T00:00:00.000Z',
+  availableTo: {},
+  editableBy: {},
+  protocolMatchingRules: [],
+  toolGroupIds: ['default'],
+  // -1 would be used to indicate active only, whereas other values are
+  // the number of required priors referenced - so 0 means active with
+  // 0 or more priors.
+  numberOfPriorsReferenced: 0,
+  // Default viewport is used to define the viewport when
+  // additional viewports are added using the layout tool
+  defaultViewport: {
+    viewportOptions: {
+      viewportType: 'volume',
+      toolGroupId: 'default',
+      allowUnmatchedView: true,
+      initialImageOptions: {
+        preset: 'middle', // 'first', 'last', 'middle'
+      },
+    },
+    displaySets: [
+      {
+        id: 'defaultDisplaySetId',
+        matchedDisplaySetsIndex: -1,
+      },
+    ],
+  },
+  displaySetSelectors: {
+    defaultDisplaySetId: {
+      // Unused currently
+      imageMatchingRules: [],
+      // Matches displaysets, NOT series
+      seriesMatchingRules: [
+        // Try to match series with images by default, to prevent weird display
+        // on SEG/SR containing studies
+        {
+          attribute: 'numImageFrames',
+          constraint: {
+            greaterThan: { value: 0 },
+          },
+        },
+      ],
+      // Can be used to select matching studies
+      // studyMatchingRules: [],
+    },
+    ctDisplaySetId: {
+      // Unused currently
+      imageMatchingRules: [],
+      // Matches displaysets, NOT series
+      seriesMatchingRules: [
+        // Try to match series with images by default, to prevent weird display
+        // on SEG/SR containing studies
+        {
+          attribute: 'numImageFrames',
+          constraint: {
+            greaterThan: { value: 0 },
+          },
+        },
+
+        {
+          attribute: 'Modality',
+          constraint: {
+            format: {
+              pattern: '^CT$',
+              flags: 'i'
+            },
+          },
+        },
+      ],
+      // Can be used to select matching studies
+      // studyMatchingRules: [],
+    },
+    ptDisplaySetId: {
+      // Unused currently
+      imageMatchingRules: [],
+      // Matches displaysets, NOT series
+      seriesMatchingRules: [
+        // Try to match series with images by default, to prevent weird display
+        // on SEG/SR containing studies
+        {
+          attribute: 'numImageFrames',
+          constraint: {
+            greaterThan: { value: 0 },
+          },
+        },
+
+        {
+          attribute: 'Modality',
+          constraint: {
+            format: {
+              pattern: '^PT$',
+              flags: 'i'
+            },
+          },
+        },
+
+        // 0028,0051 (CorrectedImage): NORM\DTIM\ATTN\SCAT\RADL\DECY
+        // {
+        //   attribute: 'Modality',
+        //   // weight: 10
+        //   constraint: {
+        //     format: {
+        //       pattern: '^PT$',
+        //       flags: 'i'
+        //     },
+        //   },
+        // },
+      ],
+      // Can be used to select matching studies
+      // studyMatchingRules: [],
+    },
+  },
+  stages: [
+    {
+      name: 'Data Preparation',
+      viewportStructure: {
+        layoutType: 'grid',
+        properties: {
+          rows: 1,
+          columns: 3,
+        },
+      },
+      viewports: [
+        {
+          viewportOptions: {
+            viewportType: 'volume',
+            orientation: 'axial',
+            toolGroupId: 'default',
+            initialImageOptions: {
+              preset: 'middle', // 'first', 'last', 'middle'
+            },
+          },
+          displaySets: [
+            {
+              id: 'ptDisplaySetId',
+            },
+          ],
+        },
+        {
+          viewportOptions: {
+            viewportType: 'volume',
+            orientation: 'coronal',
+            toolGroupId: 'default',
+            initialImageOptions: {
+              preset: 'middle', // 'first', 'last', 'middle'
+            },
+          },
+          displaySets: [
+            {
+              id: 'ptDisplaySetId',
+            },
+          ],
+        },
+        {
+          viewportOptions: {
+            viewportType: 'volume',
+            orientation: 'sagittal',
+            toolGroupId: 'default',
+            initialImageOptions: {
+              preset: 'middle', // 'first', 'last', 'middle'
+            },
+          },
+          displaySets: [
+            {
+              id: 'ptDisplaySetId',
+            },
+          ],
+        },
+      ],
+      createdDate: '2023-01-01T00:00:00.000Z',
+    },
+
+    // {
+    //   name: 'Registration',
+    //   viewportStructure: {
+    //     layoutType: 'grid',
+    //     properties: {
+    //       rows: 2,
+    //       columns: 3,
+    //     },
+    //   },
+    //   viewports: [
+    //     {
+    //       viewportOptions: {
+    //         viewportType: 'volume',
+    //         orientation: 'axial',
+    //         toolGroupId: 'default',
+    //         initialImageOptions: {
+    //           preset: 'middle', // 'first', 'last', 'middle'
+    //         },
+    //       },
+    //       displaySets: [
+    //         {
+    //           id: 'ctDisplaySetId',
+    //         },
+    //       ],
+    //     },
+    //     {
+    //       viewportOptions: {
+    //         viewportType: 'volume',
+    //         orientation: 'coronal',
+    //         toolGroupId: 'default',
+    //         initialImageOptions: {
+    //           preset: 'middle', // 'first', 'last', 'middle'
+    //         },
+    //       },
+    //       displaySets: [
+    //         {
+    //           id: 'ctDisplaySetId',
+    //         },
+    //       ],
+    //     },
+    //     {
+    //       viewportOptions: {
+    //         viewportType: 'volume',
+    //         orientation: 'sagittal',
+    //         toolGroupId: 'default',
+    //         initialImageOptions: {
+    //           preset: 'middle', // 'first', 'last', 'middle'
+    //         },
+    //       },
+    //       displaySets: [
+    //         {
+    //           id: 'ctDisplaySetId',
+    //         },
+    //       ],
+    //     },
+    //     {
+    //       viewportOptions: {
+    //         viewportType: 'volume',
+    //         orientation: 'axial',
+    //         toolGroupId: 'default',
+    //         initialImageOptions: {
+    //           preset: 'middle', // 'first', 'last', 'middle'
+    //         },
+    //       },
+    //       displaySets: [
+    //         {
+    //           id: 'ptDisplaySetId',
+    //         },
+    //       ],
+    //     },
+    //     {
+    //       viewportOptions: {
+    //         viewportType: 'volume',
+    //         orientation: 'coronal',
+    //         toolGroupId: 'default',
+    //         initialImageOptions: {
+    //           preset: 'middle', // 'first', 'last', 'middle'
+    //         },
+    //       },
+    //       displaySets: [
+    //         {
+    //           id: 'ptDisplaySetId',
+    //         },
+    //       ],
+    //     },
+    //     {
+    //       viewportOptions: {
+    //         viewportType: 'volume',
+    //         orientation: 'sagittal',
+    //         toolGroupId: 'default',
+    //         initialImageOptions: {
+    //           preset: 'middle', // 'first', 'last', 'middle'
+    //         },
+    //       },
+    //       displaySets: [
+    //         {
+    //           id: 'ptDisplaySetId',
+    //         },
+    //       ],
+    //     },
+    //   ],
+    //   createdDate: '2023-01-01T00:00:00.000Z',
+    // },
+
+    // {
+    //   name: 'Review',
+    //   viewportStructure: {
+    //     layoutType: 'grid',
+    //     properties: {
+    //       rows: 2,
+    //       columns: 3,
+    //     },
+    //   },
+    //   viewports: [],
+    //   createdDate: '2023-01-01T00:00:00.000Z',
+    // },
+
+    // {
+    //   name: 'ROI Quantification',
+    //   viewportStructure: {
+    //     layoutType: 'grid',
+    //     properties: {
+    //       rows: 2,
+    //       columns: 3,
+    //     },
+    //   },
+    //   viewports: [],
+    //   createdDate: '2023-01-01T00:00:00.000Z',
+    // },
+
+    // {
+    //   name: 'Kinetic Analysis',
+    //   viewportStructure: {
+    //     layoutType: 'grid',
+    //     properties: {
+    //       rows: 2,
+    //       columns: 3,
+    //     },
+    //   },
+    //   viewports: [],
+    //   createdDate: '2023-01-01T00:00:00.000Z',
+    // },
+  ],
+};
+
+/**
+   * HangingProtocolModule should provide a list of hanging protocols that will be
+   * available in OHIF for Modes to use to decide on the structure of the viewports
+   * and also the series that hung in the viewports. Each hanging protocol is defined by
+   * { name, protocols}. Examples include the default hanging protocol provided by
+   * the default extension that shows 2x2 viewports.
+   */
+
+function getHangingProtocolModule() {
+  return [
+    {
+      id: defaultProtocol.id,
+      protocol: defaultProtocol,
+    },
+  ];
+}
+
+export default getHangingProtocolModule;

--- a/extensions/cornerstone-dynamic-volume/src/getPanelModule.tsx
+++ b/extensions/cornerstone-dynamic-volume/src/getPanelModule.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { DynamicDataPanel } from './panels';
+
+function getPanelModule({
+  commandsManager,
+  extensionManager,
+  servicesManager,
+}) {
+  const wrappedDynamicDataPanel = () => {
+    return (
+      <DynamicDataPanel
+        commandsManager={commandsManager}
+        servicesManager={servicesManager}
+        extensionManager={extensionManager}
+      />
+    );
+  };
+
+  return [
+    {
+      name: 'dynamic-volume',
+      iconName: 'group-layers', // create tab-dynamic-volume icon
+      iconLabel: '4D Workflow',
+      label: '4D Workflow',
+      component: wrappedDynamicDataPanel,
+    },
+  ];
+}
+
+export default getPanelModule;

--- a/extensions/cornerstone-dynamic-volume/src/id.js
+++ b/extensions/cornerstone-dynamic-volume/src/id.js
@@ -1,0 +1,5 @@
+import packageJson from '../package.json';
+
+const id = packageJson.name;
+
+export { id };

--- a/extensions/cornerstone-dynamic-volume/src/index.ts
+++ b/extensions/cornerstone-dynamic-volume/src/index.ts
@@ -1,0 +1,120 @@
+import { id } from './id';
+import getPanelModule from './getPanelModule';
+import getHangingProtocolModule from './getHangingProtocolModule';
+
+/**
+ * You can remove any of the following modules if you don't need them.
+ */
+export default {
+  /**
+   * Only required property. Should be a unique value across all extensions.
+   * You ID can be anything you want, but it should be unique.
+   */
+  id,
+
+  /**
+   * Perform any pre-registration tasks here. This is called before the extension
+   * is registered. Usually we run tasks such as: configuring the libraries
+   * (e.g. cornerstone, cornerstoneTools, ...) or registering any services that
+   * this extension is providing.
+   */
+  preRegistration: ({
+    servicesManager,
+    commandsManager,
+    configuration = {},
+  }) => {},
+  /**
+   * PanelModule should provide a list of panels that will be available in OHIF
+   * for Modes to consume and render. Each panel is defined by a {name,
+   * iconName, iconLabel, label, component} object. Example of a panel module
+   * is the StudyBrowserPanel that is provided by the default extension in OHIF.
+   */
+  getPanelModule,
+  /**
+   * ViewportModule should provide a list of viewports that will be available in OHIF
+   * for Modes to consume and use in the viewports. Each viewport is defined by
+   * {name, component} object. Example of a viewport module is the CornerstoneViewport
+   * that is provided by the Cornerstone extension in OHIF.
+   */
+  getViewportModule: ({
+    servicesManager,
+    commandsManager,
+    extensionManager,
+  }) => {},
+  /**
+   * ToolbarModule should provide a list of tool buttons that will be available in OHIF
+   * for Modes to consume and use in the toolbar. Each tool button is defined by
+   * {name, defaultComponent, clickHandler }. Examples include radioGroupIcons and
+   * splitButton toolButton that the default extension is providing.
+   */
+  getToolbarModule: ({
+    servicesManager,
+    commandsManager,
+    extensionManager,
+  }) => {},
+  /**
+   * LayoutTemplateMOdule should provide a list of layout templates that will be
+   * available in OHIF for Modes to consume and use to layout the viewer.
+   * Each layout template is defined by a { name, id, component}. Examples include
+   * the default layout template provided by the default extension which renders
+   * a Header, left and right sidebars, and a viewport section in the middle
+   * of the viewer.
+   */
+  getLayoutTemplateModule: ({
+    servicesManager,
+    commandsManager,
+    extensionManager,
+  }) => {},
+  /**
+   * SopClassHandlerModule should provide a list of sop class handlers that will be
+   * available in OHIF for Modes to consume and use to create displaySets from Series.
+   * Each sop class handler is defined by a { name, sopClassUids, getDisplaySetsFromSeries}.
+   * Examples include the default sop class handler provided by the default extension
+   */
+  getSopClassHandlerModule: ({
+    servicesManager,
+    commandsManager,
+    extensionManager,
+  }) => {},
+  /**
+   * HangingProtocolModule should provide a list of hanging protocols that will be
+   * available in OHIF for Modes to use to decide on the structure of the viewports
+   * and also the series that hung in the viewports. Each hanging protocol is defined by
+   * { name, protocols}. Examples include the default hanging protocol provided by
+   * the default extension that shows 2x2 viewports.
+   */
+  getHangingProtocolModule,
+  /**
+   * CommandsModule should provide a list of commands that will be available in OHIF
+   * for Modes to consume and use in the viewports. Each command is defined by
+   * an object of { actions, definitions, defaultContext } where actions is an
+   * object of functions, definitions is an object of available commands, their
+   * options, and defaultContext is the default context for the command to run against.
+   */
+  getCommandsModule: ({
+    servicesManager,
+    commandsManager,
+    extensionManager,
+  }) => {},
+  /**
+   * ContextModule should provide a list of context that will be available in OHIF
+   * and will be provided to the Modes. A context is a state that is shared OHIF.
+   * Context is defined by an object of { name, context, provider }. Examples include
+   * the measurementTracking context provided by the measurementTracking extension.
+   */
+  getContextModule: ({
+    servicesManager,
+    commandsManager,
+    extensionManager,
+  }) => {},
+  /**
+   * DataSourceModule should provide a list of data sources to be used in OHIF.
+   * DataSources can be used to map the external data formats to the OHIF's
+   * native format. DataSources are defined by an object of { name, type, createDataSource }.
+   */
+  getDataSourcesModule: ({
+    servicesManager,
+    commandsManager,
+    extensionManager,
+  }) => {},
+};

--- a/extensions/cornerstone-dynamic-volume/src/panels/DynamicDataPanel.tsx
+++ b/extensions/cornerstone-dynamic-volume/src/panels/DynamicDataPanel.tsx
@@ -1,0 +1,23 @@
+import React, { useEffect, useState, useCallback } from 'react';
+import WorkflowPanel from './WorkflowPanel';
+import ToolsPanel from './ToolsPanel';
+import WindowLevelPanel from './WindowLevelPanel';
+
+function DynamicDataPanel({
+  servicesManager,
+  commandsManager,
+  extensionManager,
+}) {
+  return (
+    <div
+      className="flex flex-col flex-auto text-white"
+      data-cy={'dynamic-volume-panel'}
+    >
+      <WorkflowPanel></WorkflowPanel>
+      <ToolsPanel></ToolsPanel>
+      <WindowLevelPanel></WindowLevelPanel>
+    </div>
+  );
+}
+
+export default DynamicDataPanel;

--- a/extensions/cornerstone-dynamic-volume/src/panels/ToolsPanel.tsx
+++ b/extensions/cornerstone-dynamic-volume/src/panels/ToolsPanel.tsx
@@ -1,0 +1,11 @@
+import React, { useEffect, useState, useCallback } from 'react';
+
+function ToolsPanel() {
+  return (
+    <div data-cy={'tool-panel'}>
+      Tools Panel
+    </div>
+  );
+}
+
+export default ToolsPanel;

--- a/extensions/cornerstone-dynamic-volume/src/panels/WindowLevelPanel.tsx
+++ b/extensions/cornerstone-dynamic-volume/src/panels/WindowLevelPanel.tsx
@@ -1,0 +1,11 @@
+import React, { useEffect, useState, useCallback } from 'react';
+
+function WindowLevelPanel() {
+  return (
+    <div data-cy={'windowLevel-panel'}>
+      Window Level Panel
+    </div>
+  );
+}
+
+export default WindowLevelPanel;

--- a/extensions/cornerstone-dynamic-volume/src/panels/WorkflowPanel.tsx
+++ b/extensions/cornerstone-dynamic-volume/src/panels/WorkflowPanel.tsx
@@ -1,0 +1,11 @@
+import React, { useEffect, useState, useCallback } from 'react';
+
+function WorkflowPanel() {
+  return (
+    <div data-cy={'workflow-panel'}>
+      Workflow Panel
+    </div>
+  );
+}
+
+export default WorkflowPanel;

--- a/extensions/cornerstone-dynamic-volume/src/panels/index.js
+++ b/extensions/cornerstone-dynamic-volume/src/panels/index.js
@@ -1,0 +1,6 @@
+import DynamicDataPanel from './DynamicDataPanel';
+import WorkflowPanel from './WorkflowPanel';
+import ToolsPanel from './ToolsPanel';
+import WindowLevelPanel from './WindowLevelPanel';
+
+export { DynamicDataPanel, WorkflowPanel, ToolsPanel, WindowLevelPanel };

--- a/extensions/cornerstone/src/index.tsx
+++ b/extensions/cornerstone/src/index.tsx
@@ -6,6 +6,7 @@ import {
   imageLoadPoolManager,
   imageRetrievalPoolManager,
 } from '@cornerstonejs/core';
+import { helpers as volumeLoaderHelpers } from '@cornerstonejs/streaming-image-volume-loader';
 import { Enums as cs3DToolsEnums } from '@cornerstonejs/tools';
 import { Types } from '@ohif/core';
 
@@ -27,6 +28,8 @@ import { id } from './id';
 import * as csWADOImageLoader from './initWADOImageLoader.js';
 import { measurementMappingUtils } from './utils/measurementServiceMappings';
 import { PublicViewportOptions } from './services/ViewportService/Viewport';
+
+const { isDynamicVolume } = volumeLoaderHelpers;
 
 const Component = React.lazy(() => {
   return import(
@@ -140,6 +143,12 @@ const cornerstoneExtension: Types.Extensions.Extension = {
           Enums: cs3DToolsEnums,
         },
       },
+      {
+        name: 'volumeLoader',
+        exports: {
+          isDynamicVolume
+        }
+      }
     ];
   },
 };

--- a/extensions/cornerstone/src/init.tsx
+++ b/extensions/cornerstone/src/init.tsx
@@ -14,7 +14,10 @@ import {
   utilities as csUtilities,
 } from '@cornerstonejs/core';
 import { Enums, utilities, ReferenceLinesTool } from '@cornerstonejs/tools';
-import { cornerstoneStreamingImageVolumeLoader } from '@cornerstonejs/streaming-image-volume-loader';
+import {
+  cornerstoneStreamingImageVolumeLoader,
+  cornerstoneStreamingDynamicImageVolumeLoader,
+} from '@cornerstonejs/streaming-image-volume-loader';
 
 import initWADOImageLoader from './initWADOImageLoader';
 import initCornerstoneTools from './initCornerstoneTools';
@@ -122,6 +125,11 @@ export default async function init({
   volumeLoader.registerVolumeLoader(
     'cornerstoneStreamingImageVolume',
     cornerstoneStreamingImageVolumeLoader
+  );
+
+  volumeLoader.registerVolumeLoader(
+    'cornerstoneStreamingDynamicImageVolume',
+    cornerstoneStreamingDynamicImageVolumeLoader
   );
 
   hangingProtocolService.registerImageLoadStrategy(

--- a/extensions/cornerstone/src/initWADOImageLoader.js
+++ b/extensions/cornerstone/src/initWADOImageLoader.js
@@ -1,6 +1,9 @@
 import * as cornerstone from '@cornerstonejs/core';
 import { volumeLoader } from '@cornerstonejs/core';
-import { cornerstoneStreamingImageVolumeLoader } from '@cornerstonejs/streaming-image-volume-loader';
+import {
+  cornerstoneStreamingImageVolumeLoader,
+  cornerstoneStreamingDynamicImageVolumeLoader,
+} from '@cornerstonejs/streaming-image-volume-loader';
 import cornerstoneWADOImageLoader, {
   webWorkerManager,
 } from 'cornerstone-wado-image-loader';
@@ -43,6 +46,11 @@ export default function initWADOImageLoader(
   registerVolumeLoader(
     'cornerstoneStreamingImageVolume',
     cornerstoneStreamingImageVolumeLoader
+  );
+
+  registerVolumeLoader(
+    'cornerstoneStreamingDynamicImageVolume',
+    cornerstoneStreamingDynamicImageVolumeLoader
   );
 
   cornerstoneWADOImageLoader.configure({

--- a/extensions/default/src/Toolbar/Toolbar.tsx
+++ b/extensions/default/src/Toolbar/Toolbar.tsx
@@ -14,11 +14,15 @@ export default function Toolbar({ servicesManager }) {
   useEffect(() => {
     const { unsubscribe: unsub1 } = toolbarService.subscribe(
       toolbarService.EVENTS.TOOL_BAR_MODIFIED,
-      () => setToolbarButtons(toolbarService.getButtonSection('primary'))
+      () => {
+        setToolbarButtons(toolbarService.getButtonSection('primary'));
+      }
     );
     const { unsubscribe: unsub2 } = toolbarService.subscribe(
       toolbarService.EVENTS.TOOL_BAR_STATE_MODIFIED,
-      () => setButtonState({ ...toolbarService.state })
+      () => {
+        setButtonState({ ...toolbarService.state });
+      }
     );
 
     return () => {

--- a/modes/preclinical-4d/.webpack/webpack.prod.js
+++ b/modes/preclinical-4d/.webpack/webpack.prod.js
@@ -1,0 +1,62 @@
+const path = require('path');
+const pkg = require('../package.json');
+
+const outputFile = 'index.umd.js';
+const rootDir = path.resolve(__dirname, '../');
+const outputFolder = path.join(__dirname, `../dist/umd/${pkg.name}/`);
+
+// Todo: add ESM build for the mode in addition to umd build
+const config = {
+  mode: 'production',
+  entry: rootDir + '/' + pkg.module,
+  devtool: 'source-map',
+  output: {
+    path: outputFolder,
+    filename: outputFile,
+    library: pkg.name,
+    libraryTarget: 'umd',
+    chunkFilename: '[name].chunk.js',
+    umdNamedDefine: true,
+    globalObject: "typeof self !== 'undefined' ? self : this",
+  },
+  externals: [
+    {
+      react: {
+        root: 'React',
+        commonjs2: 'react',
+        commonjs: 'react',
+        amd: 'react',
+      },
+      '@ohif/core': {
+        commonjs2: '@ohif/core',
+        commonjs: '@ohif/core',
+        amd: '@ohif/core',
+        root: '@ohif/core',
+      },
+      '@ohif/ui': {
+        commonjs2: '@ohif/ui',
+        commonjs: '@ohif/ui',
+        amd: '@ohif/ui',
+        root: '@ohif/ui',
+      },
+    },
+  ],
+  module: {
+    rules: [
+      {
+        test: /(\.jsx|\.js|\.tsx|\.ts)$/,
+        loader: 'babel-loader',
+        exclude: /(node_modules|bower_components)/,
+        resolve: {
+          extensions: ['.js', '.jsx', '.ts', '.tsx'],
+        },
+      },
+    ],
+  },
+  resolve: {
+    modules: [path.resolve('./node_modules'), path.resolve('./src')],
+    extensions: ['.json', '.js', '.jsx', '.tsx', '.ts'],
+  },
+};
+
+module.exports = config;

--- a/modes/preclinical-4d/LICENSE
+++ b/modes/preclinical-4d/LICENSE
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) 2023 4d ()
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/modes/preclinical-4d/README.md
+++ b/modes/preclinical-4d/README.md
@@ -1,0 +1,7 @@
+# 4d 
+## Description 
+ 
+## Author 
+OHIF 
+## License 
+MIT

--- a/modes/preclinical-4d/babel.config.js
+++ b/modes/preclinical-4d/babel.config.js
@@ -1,0 +1,44 @@
+module.exports = {
+  plugins: ['inline-react-svg', '@babel/plugin-proposal-class-properties'],
+  env: {
+    test: {
+      presets: [
+        [
+          // TODO: https://babeljs.io/blog/2019/03/19/7.4.0#migration-from-core-js-2
+          '@babel/preset-env',
+          {
+            modules: 'commonjs',
+            debug: false,
+          },
+          "@babel/preset-typescript",
+        ],
+        '@babel/preset-react',
+      ],
+      plugins: [
+        '@babel/plugin-proposal-object-rest-spread',
+        '@babel/plugin-syntax-dynamic-import',
+        '@babel/plugin-transform-regenerator',
+        '@babel/plugin-transform-runtime',
+      ],
+    },
+    production: {
+      presets: [
+        // WebPack handles ES6 --> Target Syntax
+        ['@babel/preset-env', { modules: false }],
+        '@babel/preset-react',
+        "@babel/preset-typescript",
+      ],
+      ignore: ['**/*.test.jsx', '**/*.test.js', '__snapshots__', '__tests__'],
+    },
+    development: {
+      presets: [
+        // WebPack handles ES6 --> Target Syntax
+        ['@babel/preset-env', { modules: false }],
+        '@babel/preset-react',
+        "@babel/preset-typescript",
+      ],
+      plugins: ['react-hot-loader/babel'],
+      ignore: ['**/*.test.jsx', '**/*.test.js', '__snapshots__', '__tests__'],
+    },
+  },
+};

--- a/modes/preclinical-4d/package.json
+++ b/modes/preclinical-4d/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@ohif/preclinical-4d",
+  "version": "1.0.0",
+  "description": "4D Workflow",
+  "author": "OHIF",
+  "license": "MIT",
+  "repository": "OHIF/Viewers",
+  "main": "dist/index.umd.js",
+  "module": "src/index.tsx",
+  "engines": {
+    "node": ">=14",
+    "npm": ">=6",
+    "yarn": ">=1.16.0"
+  },
+  "files": [
+    "dist/**",
+    "public/**",
+    "README.md"
+  ],
+  "keywords": [
+    "ohif-mode"
+  ],
+  "scripts": {
+    "dev": "cross-env NODE_ENV=development webpack --config .webpack/webpack.dev.js --watch --debug --output-pathinfo",
+    "dev:cornerstone": "yarn run dev",
+    "build": "cross-env NODE_ENV=production webpack --config .webpack/webpack.prod.js",
+    "build:package": "yarn run build",
+    "start": "yarn run dev",
+    "test:unit": "jest --watchAll",
+    "test:unit:ci": "jest --ci --runInBand --collectCoverage --passWithNoTests"
+  },
+  "peerDependencies": {
+    "@ohif/core": "^3.0.0",
+    "@ohif/extension-default": "^3.0.0",
+    "@ohif/extension-cornerstone": "^3.0.0",
+    "@ohif/extension-cornerstone-dynamic-volume": "^1.0.0"
+  },
+  "dependencies": {
+    "@babel/runtime": "^7.20.13"
+  },
+  "devDependencies": {
+    "webpack": "^5.50.0",
+    "webpack-merge": "^5.7.3"
+  }
+}

--- a/modes/preclinical-4d/src/id.js
+++ b/modes/preclinical-4d/src/id.js
@@ -1,0 +1,5 @@
+import packageJson from '../package.json';
+
+const id = packageJson.name;
+
+export { id };

--- a/modes/preclinical-4d/src/index.tsx
+++ b/modes/preclinical-4d/src/index.tsx
@@ -1,0 +1,150 @@
+import { id } from './id';
+import { hotkeys } from '@ohif/core';
+import initToolGroups from './initToolGroups';
+import toolbarButtons from './toolbarButtons';
+
+const REQUIRED_MODALITIES = ['PT', 'CT'];
+
+const extensionDependencies = {
+  '@ohif/extension-default': '^3.0.0',
+  '@ohif/extension-cornerstone': '^3.0.0',
+  '@ohif/extension-cornerstone-dynamic-volume': '^1.0.0',
+};
+
+const ohif = {
+  layout: '@ohif/extension-default.layoutTemplateModule.viewerLayout',
+  sopClassHandler: '@ohif/extension-default.sopClassHandlerModule.stack',
+  hangingProtocol: '@ohif/extension-default.hangingProtocolModule.default',
+  leftPanel: '@ohif/extension-default.panelModule.seriesList',
+  rightPanel: '@ohif/extension-default.panelModule.measure',
+};
+
+const dynamicVolume = {
+  leftPanel:
+    '@ohif/extension-cornerstone-dynamic-volume.panelModule.dynamic-volume',
+};
+
+const cornerstone = {
+  viewport: '@ohif/extension-cornerstone.viewportModule.cornerstone',
+};
+
+function modeFactory({ modeConfiguration }) {
+  return {
+    id,
+    routeName: 'dynamic-volume',
+    displayName: '4D Volume',
+    onModeEnter: ({ servicesManager, extensionManager, commandsManager }) => {
+      const {
+        measurementService,
+        toolbarService,
+        toolGroupService,
+        panelService,
+      } = servicesManager.services;
+
+      measurementService.clearMeasurements();
+
+      initToolGroups(extensionManager, toolGroupService, commandsManager);
+
+      let unsubscribe;
+
+      ({ unsubscribe } = toolGroupService.subscribe(
+        toolGroupService.EVENTS.VIEWPORT_ADDED,
+        () => {
+          console.warn('>>>>> onViewportAdded');
+        }
+      ));
+
+      toolbarService.init(extensionManager);
+      toolbarService.addButtons(toolbarButtons);
+      toolbarService.createButtonSection('primary', [
+        'MeasurementTools',
+        'Zoom',
+        'WindowLevel',
+        'Pan',
+        'Capture',
+        // 'Layout',
+        'MPR',
+        'Crosshairs',
+        'MoreTools',
+      ]);
+    },
+    onModeExit: ({ servicesManager }) => {
+      const {
+        toolGroupService,
+        syncGroupService,
+        toolbarService,
+        segmentationService,
+        cornerstoneViewportService,
+      } = servicesManager.services;
+
+      toolGroupService.destroy();
+      syncGroupService.destroy();
+      segmentationService.destroy();
+      cornerstoneViewportService.destroy();
+    },
+    get validationTags() {
+      debugger;
+      return {
+        study: [],
+        series: [],
+      };
+    },
+    isValidMode: ({ modalities }) => {
+      const modalities_list = modalities.split('\\');
+
+      return REQUIRED_MODALITIES.every(modality =>
+        modalities_list.includes(modality)
+      );
+    },
+    /**
+     * Mode Routes are used to define the mode's behavior. A list of Mode Route
+     * that includes the mode's path and the layout to be used. The layout will
+     * include the components that are used in the layout. For instance, if the
+     * default layoutTemplate is used (id: '@ohif/extension-default.layoutTemplateModule.viewerLayout')
+     * it will include the leftPanels, rightPanels, and viewports. However, if
+     * you define another layoutTemplate that includes a Footer for instance,
+     * you should provide the Footer component here too. Note: We use Strings
+     * to reference the component's ID as they are registered in the internal
+     * ExtensionManager. The template for the string is:
+     * `${extensionId}.{moduleType}.${componentId}`.
+     */
+    routes: [
+      {
+        path: 'whatisthis',
+        layoutTemplate: ({ location, servicesManager }) => {
+          return {
+            id: ohif.layout,
+            props: {
+              leftPanels: [dynamicVolume.leftPanel],
+              rightPanels: [ohif.rightPanel],
+              rightPanelDefaultClosed: true,
+              viewports: [
+                {
+                  namespace: cornerstone.viewport,
+                  displaySetsToDisplay: [ohif.sopClassHandler],
+                },
+              ],
+            },
+          };
+        },
+      },
+    ],
+    extensions: extensionDependencies,
+    // Default protocol gets self-registered by default in the init
+    hangingProtocol: ['default'],
+    // Order is important in sop class handlers when two handlers both use
+    // the same sop class under different situations.  In that case, the more
+    // general handler needs to come last.  For this case, the dicomvideo must
+    // come first to remove video transfer syntax before ohif uses images
+    sopClassHandlers: [ohif.sopClassHandler],
+    hotkeys: [...hotkeys.defaults.hotkeyBindings],
+  };
+}
+
+const mode = {
+  id,
+  modeFactory,
+  extensionDependencies,
+};
+
+export default mode;

--- a/modes/preclinical-4d/src/initToolGroups.tsx
+++ b/modes/preclinical-4d/src/initToolGroups.tsx
@@ -1,0 +1,249 @@
+function initDefaultToolGroup(
+  extensionManager,
+  toolGroupService,
+  commandsManager,
+  toolGroupId
+) {
+  const utilityModule = extensionManager.getModuleEntry(
+    '@ohif/extension-cornerstone.utilityModule.tools'
+  );
+
+  const { toolNames, Enums } = utilityModule.exports;
+
+  const tools = {
+    active: [
+      {
+        toolName: toolNames.WindowLevel,
+        bindings: [{ mouseButton: Enums.MouseBindings.Primary }],
+      },
+      {
+        toolName: toolNames.Pan,
+        bindings: [{ mouseButton: Enums.MouseBindings.Auxiliary }],
+      },
+      {
+        toolName: toolNames.Zoom,
+        bindings: [{ mouseButton: Enums.MouseBindings.Secondary }],
+      },
+      { toolName: toolNames.StackScrollMouseWheel, bindings: [] },
+    ],
+    passive: [
+      { toolName: toolNames.Length },
+      { toolName: toolNames.ArrowAnnotate },
+      { toolName: toolNames.Bidirectional },
+      { toolName: toolNames.DragProbe },
+      { toolName: toolNames.EllipticalROI },
+      { toolName: toolNames.RectangleROI },
+      { toolName: toolNames.StackScroll },
+      { toolName: toolNames.Angle },
+      { toolName: toolNames.CobbAngle },
+      { toolName: toolNames.PlanarFreehandROI },
+      { toolName: toolNames.Magnify },
+      { toolName: toolNames.SegmentationDisplay },
+      { toolName: toolNames.CalibrationLine },
+    ],
+    // enabled
+    // disabled
+    disabled: [{ toolName: toolNames.ReferenceLines }],
+  };
+
+  const toolsConfig = {
+    [toolNames.ArrowAnnotate]: {
+      getTextCallback: (callback, eventDetails) =>
+        commandsManager.runCommand('arrowTextCallback', {
+          callback,
+          eventDetails,
+        }),
+
+      changeTextCallback: (data, eventDetails, callback) =>
+        commandsManager.runCommand('arrowTextCallback', {
+          callback,
+          data,
+          eventDetails,
+        }),
+    },
+  };
+
+  toolGroupService.createToolGroupAndAddTools(toolGroupId, tools, toolsConfig);
+}
+
+function initSRToolGroup(extensionManager, toolGroupService, commandsManager) {
+  const SRUtilityModule = extensionManager.getModuleEntry(
+    '@ohif/extension-cornerstone-dicom-sr.utilityModule.tools'
+  );
+
+  const CS3DUtilityModule = extensionManager.getModuleEntry(
+    '@ohif/extension-cornerstone.utilityModule.tools'
+  );
+
+  const { toolNames: SRToolNames } = SRUtilityModule.exports;
+  const { toolNames, Enums } = CS3DUtilityModule.exports;
+  const tools = {
+    active: [
+      {
+        toolName: toolNames.WindowLevel,
+        bindings: [
+          {
+            mouseButton: Enums.MouseBindings.Primary,
+          },
+        ],
+      },
+      {
+        toolName: toolNames.Pan,
+        bindings: [
+          {
+            mouseButton: Enums.MouseBindings.Auxiliary,
+          },
+        ],
+      },
+      {
+        toolName: toolNames.Zoom,
+        bindings: [
+          {
+            mouseButton: Enums.MouseBindings.Secondary,
+          },
+        ],
+      },
+      {
+        toolName: toolNames.StackScrollMouseWheel,
+        bindings: [],
+      },
+    ],
+    passive: [
+      { toolName: SRToolNames.SRLength },
+      { toolName: SRToolNames.SRArrowAnnotate },
+      { toolName: SRToolNames.SRBidirectional },
+      { toolName: SRToolNames.SREllipticalROI },
+    ],
+    enabled: [
+      // {
+      //   toolName: SRToolNames.DICOMSRDisplay,
+      //   bindings: [],
+      // },
+    ],
+    // disabled
+  };
+
+  const toolsConfig = {
+    [toolNames.ArrowAnnotate]: {
+      getTextCallback: (callback, eventDetails) =>
+        commandsManager.runCommand('arrowTextCallback', {
+          callback,
+          eventDetails,
+        }),
+
+      changeTextCallback: (data, eventDetails, callback) =>
+        commandsManager.runCommand('arrowTextCallback', {
+          callback,
+          data,
+          eventDetails,
+        }),
+    },
+  };
+
+  const toolGroupId = 'SRToolGroup';
+  toolGroupService.createToolGroupAndAddTools(toolGroupId, tools, toolsConfig);
+}
+
+function initMPRToolGroup(extensionManager, toolGroupService, commandsManager) {
+  const utilityModule = extensionManager.getModuleEntry(
+    '@ohif/extension-cornerstone.utilityModule.tools'
+  );
+
+  const { toolNames, Enums } = utilityModule.exports;
+
+  const tools = {
+    active: [
+      {
+        toolName: toolNames.WindowLevel,
+        bindings: [{ mouseButton: Enums.MouseBindings.Primary }],
+      },
+      {
+        toolName: toolNames.Pan,
+        bindings: [{ mouseButton: Enums.MouseBindings.Auxiliary }],
+      },
+      {
+        toolName: toolNames.Zoom,
+        bindings: [{ mouseButton: Enums.MouseBindings.Secondary }],
+      },
+      { toolName: toolNames.StackScrollMouseWheel, bindings: [] },
+    ],
+    passive: [
+      { toolName: toolNames.Length },
+      { toolName: toolNames.ArrowAnnotate },
+      { toolName: toolNames.Bidirectional },
+      { toolName: toolNames.DragProbe },
+      { toolName: toolNames.EllipticalROI },
+      { toolName: toolNames.RectangleROI },
+      { toolName: toolNames.StackScroll },
+      { toolName: toolNames.Angle },
+      { toolName: toolNames.CobbAngle },
+      { toolName: toolNames.PlanarFreehandROI },
+      { toolName: toolNames.SegmentationDisplay },
+    ],
+    disabled: [
+      { toolName: toolNames.Crosshairs },
+      { toolName: toolNames.ReferenceLines },
+    ],
+
+    // enabled
+    // disabled
+  };
+
+  const toolsConfig = {
+    [toolNames.Crosshairs]: {
+      viewportIndicators: false,
+      autoPan: {
+        enabled: false,
+        panSize: 10,
+      },
+    },
+    [toolNames.ArrowAnnotate]: {
+      getTextCallback: (callback, eventDetails) =>
+        commandsManager.runCommand('arrowTextCallback', {
+          callback,
+          eventDetails,
+        }),
+
+      changeTextCallback: (data, eventDetails, callback) =>
+        commandsManager.runCommand('arrowTextCallback', {
+          callback,
+          data,
+          eventDetails,
+        }),
+    },
+  };
+
+  toolGroupService.createToolGroupAndAddTools('mpr', tools, toolsConfig);
+}
+// function initVolume3DToolGroup(extensionManager, toolGroupService) {
+//   const utilityModule = extensionManager.getModuleEntry(
+//     '@ohif/extension-cornerstone.utilityModule.tools'
+//   );
+
+//   const { toolNames, Enums } = utilityModule.exports;
+
+//   const tools = {
+//     active: [
+//       {
+//         toolName: toolNames.TrackballRotateTool,
+//         bindings: [{ mouseButton: Enums.MouseBindings.Primary }],
+//       },
+//     ],
+//   };
+
+//   toolGroupService.createToolGroupAndAddTools('volume3d', tools);
+// }
+
+function initToolGroups(extensionManager, toolGroupService, commandsManager) {
+  initDefaultToolGroup(
+    extensionManager,
+    toolGroupService,
+    commandsManager,
+    'default'
+  );
+  initSRToolGroup(extensionManager, toolGroupService, commandsManager);
+  initMPRToolGroup(extensionManager, toolGroupService, commandsManager);
+  // initVolume3DToolGroup(extensionManager, toolGroupService);
+}
+
+export default initToolGroups;

--- a/modes/preclinical-4d/src/toolbarButtons.tsx
+++ b/modes/preclinical-4d/src/toolbarButtons.tsx
@@ -1,0 +1,649 @@
+// TODO: torn, can either bake this here; or have to create a whole new button type
+// Only ways that you can pass in a custom React component for render :l
+import {
+  // ExpandableToolbarButton,
+  // ListMenu,
+  WindowLevelMenuItem,
+} from '@ohif/ui';
+import { defaults } from '@ohif/core';
+
+const { windowLevelPresets } = defaults;
+/**
+ *
+ * @param {*} type - 'tool' | 'action' | 'toggle'
+ * @param {*} id
+ * @param {*} icon
+ * @param {*} label
+ */
+function _createButton(type, id, icon, label, commands, tooltip, uiType) {
+  return {
+    id,
+    icon,
+    label,
+    type,
+    commands,
+    tooltip,
+    uiType,
+  };
+}
+
+const _createActionButton = _createButton.bind(null, 'action');
+const _createToggleButton = _createButton.bind(null, 'toggle');
+const _createToolButton = _createButton.bind(null, 'tool');
+
+function _createLengthToolButton() {
+  return _createToolButton(
+    'Length',
+    'tool-length',
+    'Length',
+    [
+      {
+        commandName: 'setToolActive',
+        commandOptions: {
+          toolName: 'Length',
+        },
+        context: 'CORNERSTONE',
+      },
+      {
+        commandName: 'setToolActive',
+        commandOptions: {
+          toolName: 'SRLength',
+          toolGroupId: 'SRToolGroup',
+        },
+        // we can use the setToolActive command for this from Cornerstone commandsModule
+        context: 'CORNERSTONE',
+      },
+    ],
+    'Length'
+  );
+}
+
+function _createBidirectionalToolButton() {
+  return _createToolButton(
+    'Bidirectional',
+    'tool-bidirectional',
+    'Bidirectional',
+    [
+      {
+        commandName: 'setToolActive',
+        commandOptions: {
+          toolName: 'Bidirectional',
+        },
+        context: 'CORNERSTONE',
+      },
+      {
+        commandName: 'setToolActive',
+        commandOptions: {
+          toolName: 'SRBidirectional',
+          toolGroupId: 'SRToolGroup',
+        },
+        context: 'CORNERSTONE',
+      },
+    ],
+    'Bidirectional Tool'
+  );
+}
+
+function _createArrowAnnotateToolButton() {
+  return _createToolButton(
+    'ArrowAnnotate',
+    'tool-annotate',
+    'Annotation',
+    [
+      {
+        commandName: 'setToolActive',
+        commandOptions: {
+          toolName: 'ArrowAnnotate',
+        },
+        context: 'CORNERSTONE',
+      },
+      {
+        commandName: 'setToolActive',
+        commandOptions: {
+          toolName: 'SRArrowAnnotate',
+          toolGroupId: 'SRToolGroup',
+        },
+        context: 'CORNERSTONE',
+      },
+    ],
+    'Arrow Annotate'
+  );
+}
+
+function _createEllipticalROIToolButton() {
+  return _createToolButton(
+    'EllipticalROI',
+    'tool-elipse',
+    'Ellipse',
+    [
+      {
+        commandName: 'setToolActive',
+        commandOptions: {
+          toolName: 'EllipticalROI',
+        },
+        context: 'CORNERSTONE',
+      },
+      {
+        commandName: 'setToolActive',
+        commandOptions: {
+          toolName: 'SREllipticalROI',
+          toolGroupId: 'SRToolGroup',
+        },
+        context: 'CORNERSTONE',
+      },
+    ],
+    'Ellipse Tool'
+  );
+}
+
+function _createZoomToolButton() {
+  return {
+    id: 'Zoom',
+    type: 'ohif.radioGroup',
+    props: {
+      type: 'tool',
+      icon: 'tool-zoom',
+      label: 'Zoom',
+      commands: [
+        {
+          commandName: 'setToolActive',
+          commandOptions: {
+            toolName: 'Zoom',
+          },
+          context: 'CORNERSTONE',
+        },
+      ],
+    },
+  };
+}
+
+/**
+ *
+ * @param {*} preset - preset number (from above import)
+ * @param {*} title
+ * @param {*} subtitle
+ */
+function _createWwwcPreset(preset, title, subtitle) {
+  return {
+    id: preset.toString(),
+    title,
+    subtitle,
+    type: 'action',
+    commands: [
+      {
+        commandName: 'setWindowLevel',
+        commandOptions: {
+          ...windowLevelPresets[preset],
+        },
+        context: 'CORNERSTONE',
+      },
+    ],
+  };
+}
+
+function _createWindowLevelToolButton() {
+  return {
+    id: 'WindowLevel',
+    type: 'ohif.splitButton',
+    props: {
+      groupId: 'WindowLevel',
+      primary: _createToolButton(
+        'WindowLevel',
+        'tool-window-level',
+        'Window Level',
+        [
+          {
+            commandName: 'setToolActive',
+            commandOptions: {
+              toolName: 'WindowLevel',
+            },
+            context: 'CORNERSTONE',
+          },
+        ],
+        'Window Level'
+      ),
+      secondary: {
+        icon: 'chevron-down',
+        label: 'W/L Manual',
+        isActive: true,
+        tooltip: 'W/L Presets',
+      },
+      isAction: true,
+      renderer: WindowLevelMenuItem,
+      items: [
+        _createWwwcPreset(1, 'Soft tissue', '400 / 40'),
+        _createWwwcPreset(2, 'Lung', '1500 / -600'),
+        _createWwwcPreset(3, 'Liver', '150 / 90'),
+        _createWwwcPreset(4, 'Bone', '2500 / 480'),
+        _createWwwcPreset(5, 'Brain', '80 / 40'),
+      ],
+    },
+  };
+}
+
+function _createPanToolButton() {
+  return {
+    id: 'Pan',
+    type: 'ohif.radioGroup',
+    props: {
+      type: 'tool',
+      icon: 'tool-move',
+      label: 'Pan',
+      commands: [
+        {
+          commandName: 'setToolActive',
+          commandOptions: {
+            toolName: 'Pan',
+          },
+          context: 'CORNERSTONE',
+        },
+      ],
+    },
+  };
+}
+
+function _createCaptureToolButton() {
+  return {
+    id: 'Capture',
+    type: 'ohif.action',
+    props: {
+      icon: 'tool-capture',
+      label: 'Capture',
+      type: 'action',
+      commands: [
+        {
+          commandName: 'showDownloadViewportModal',
+          commandOptions: {},
+          context: 'CORNERSTONE',
+        },
+      ],
+    },
+  };
+}
+
+function _createLayoutToolbarButton() {
+  return {
+    id: 'Layout',
+    type: 'ohif.layoutSelector',
+    props: {
+      rows: 3,
+      columns: 3,
+    },
+  };
+}
+
+function _createMprToolButton() {
+  return {
+    id: 'MPR',
+    type: 'ohif.action',
+    props: {
+      type: 'toggle',
+      icon: 'icon-mpr',
+      label: 'MPR',
+      commands: [
+        {
+          commandName: 'toggleHangingProtocol',
+          commandOptions: {
+            protocolId: 'mpr',
+          },
+          context: 'DEFAULT',
+        },
+      ],
+    },
+  };
+}
+
+function _createCrosshairsToolButton() {
+  return {
+    id: 'Crosshairs',
+    type: 'ohif.radioGroup',
+    props: {
+      type: 'tool',
+      icon: 'tool-crosshair',
+      label: 'Crosshairs',
+      commands: [
+        {
+          commandName: 'setToolActive',
+          commandOptions: {
+            toolName: 'Crosshairs',
+            toolGroupId: 'mpr',
+          },
+          context: 'CORNERSTONE',
+        },
+      ],
+    },
+  };
+}
+
+function _createResetToolbarButton() {
+  return _createActionButton(
+    'Reset',
+    'tool-reset',
+    'Reset View',
+    [
+      {
+        commandName: 'resetViewport',
+        commandOptions: {},
+        context: 'CORNERSTONE',
+      },
+    ],
+    'Reset'
+  );
+}
+
+function _createRotateRightToolbarButton() {
+  return _createActionButton(
+    'rotate-right',
+    'tool-rotate-right',
+    'Rotate Right',
+    [
+      {
+        commandName: 'rotateViewportCW',
+        commandOptions: {},
+        context: 'CORNERSTONE',
+      },
+    ],
+    'Rotate +90'
+  );
+}
+
+function _createFlipHorizontalToolbarButton() {
+  return _createActionButton(
+    'flip-horizontal',
+    'tool-flip-horizontal',
+    'Flip Horizontally',
+    [
+      {
+        commandName: 'flipViewportHorizontal',
+        commandOptions: {},
+        context: 'CORNERSTONE',
+      },
+    ],
+    'Flip Horizontal'
+  );
+}
+
+function _createStackImageSyncToolbarButton() {
+  return _createToggleButton('StackImageSync', 'link', 'Stack Image Sync', [
+    {
+      commandName: 'toggleStackImageSync',
+      commandOptions: {},
+      context: 'CORNERSTONE',
+    },
+  ]);
+}
+
+function _createReferenceLineToolbarButton() {
+  return _createToggleButton(
+    'ReferenceLines',
+    'tool-referenceLines', // change this with the new icon
+    'Reference Lines',
+    [
+      {
+        commandName: 'toggleReferenceLines',
+        commandOptions: {},
+        context: 'CORNERSTONE',
+      },
+    ]
+  );
+}
+
+function _createStackScrollToolbarButton() {
+  return _createToolButton(
+    'StackScroll',
+    'tool-stack-scroll',
+    'Stack Scroll',
+    [
+      {
+        commandName: 'setToolActive',
+        commandOptions: {
+          toolName: 'StackScroll',
+        },
+        context: 'CORNERSTONE',
+      },
+    ],
+    'Stack Scroll'
+  );
+}
+
+function _createInvertToolbarButton() {
+  return _createActionButton(
+    'invert',
+    'tool-invert',
+    'Invert',
+    [
+      {
+        commandName: 'invertViewport',
+        commandOptions: {},
+        context: 'CORNERSTONE',
+      },
+    ],
+    'Invert Colors'
+  );
+}
+
+function _createProbeToolbarButton() {
+  return _createToolButton(
+    'Probe',
+    'tool-probe',
+    'Probe',
+    [
+      {
+        commandName: 'setToolActive',
+        commandOptions: {
+          toolName: 'DragProbe',
+        },
+        context: 'CORNERSTONE',
+      },
+    ],
+    'Probe'
+  );
+}
+
+function _createCineToolbarButton() {
+  return _createToggleButton(
+    'cine',
+    'tool-cine',
+    'Cine',
+    [
+      {
+        commandName: 'toggleCine',
+        context: 'CORNERSTONE',
+      },
+    ],
+    'Cine'
+  );
+}
+
+function _createAngleToolbarButton() {
+  return _createToolButton(
+    'Angle',
+    'tool-angle',
+    'Angle',
+    [
+      {
+        commandName: 'setToolActive',
+        commandOptions: {
+          toolName: 'Angle',
+        },
+        context: 'CORNERSTONE',
+      },
+    ],
+    'Angle'
+  );
+}
+
+function _createCobbAngleToolbarButton() {
+  return _createToolButton(
+    'Cobb Angle',
+    'tool-cobb-angle',
+    'Cobb Angle',
+    [
+      {
+        commandName: 'setToolActive',
+        commandOptions: {
+          toolName: 'CobbAngle',
+        },
+        context: 'CORNERSTONE',
+      },
+    ],
+    'Cobb Angle'
+  );
+}
+
+function _createPlanarFreehandROIToolbarButton() {
+  return _createToolButton(
+    'Planar Freehand ROI',
+    'tool-freehand',
+    'PlanarFreehandROI',
+    [
+      {
+        commandName: 'setToolActive',
+        commandOptions: {
+          toolName: 'PlanarFreehandROI',
+        },
+        context: 'CORNERSTONE',
+      },
+    ],
+    'Planar Freehand ROI'
+  );
+}
+
+function _createMagnifyToolbarButton() {
+  return _createToolButton(
+    'Magnify',
+    'tool-magnify',
+    'Magnify',
+    [
+      {
+        commandName: 'setToolActive',
+        commandOptions: {
+          toolName: 'Magnify',
+        },
+        context: 'CORNERSTONE',
+      },
+    ],
+    'Magnify'
+  );
+}
+
+function _createRectangleToolbarButton() {
+  return _createToolButton(
+    'Rectangle',
+    'tool-rectangle',
+    'Rectangle',
+    [
+      {
+        commandName: 'setToolActive',
+        commandOptions: {
+          toolName: 'RectangleROI',
+        },
+        context: 'CORNERSTONE',
+      },
+    ],
+    'Rectangle'
+  );
+}
+
+function _createCalibrationLineToolbarButton() {
+  return _createToolButton(
+    'CalibrationLine',
+    'tool-calibration',
+    'Calibration',
+    [
+      {
+        commandName: 'setToolActive',
+        commandOptions: {
+          toolName: 'CalibrationLine',
+        },
+        context: 'CORNERSTONE',
+      },
+    ],
+    'Calibration Line'
+  );
+}
+
+function _createTagBrowserToolbarButton() {
+  return _createActionButton(
+    'TagBrowser',
+    'list-bullets',
+    'Dicom Tag Browser',
+    [
+      {
+        commandName: 'openDICOMTagViewer',
+        commandOptions: {},
+        context: 'DEFAULT',
+      },
+    ],
+    'Dicom Tag Browser'
+  );
+}
+
+const toolbarButtons = [
+  {
+    id: 'MeasurementTools',
+    type: 'ohif.splitButton',
+    props: {
+      groupId: 'MeasurementTools',
+      isRadio: true,
+      primary: _createLengthToolButton(),
+      secondary: {
+        icon: 'chevron-down',
+        label: '',
+        isActive: true,
+        tooltip: 'More Measure Tools',
+      },
+      items: [
+        _createLengthToolButton(),
+        _createBidirectionalToolButton(),
+        _createArrowAnnotateToolButton(),
+        _createEllipticalROIToolButton(),
+      ],
+    },
+  },
+  _createZoomToolButton(),
+  _createWindowLevelToolButton(),
+  _createPanToolButton(),
+  _createCaptureToolButton(),
+  // _createLayoutToolbarButton(),
+  _createMprToolButton(),
+  _createCrosshairsToolButton(),
+  {
+    id: 'MoreTools',
+    type: 'ohif.splitButton',
+    props: {
+      isRadio: true,
+      groupId: 'MoreTools',
+      primary: _createResetToolbarButton(),
+      secondary: {
+        icon: 'chevron-down',
+        label: '',
+        isActive: true,
+        tooltip: 'More Tools',
+      },
+      items: [
+        _createResetToolbarButton(),
+        _createRotateRightToolbarButton(),
+        _createFlipHorizontalToolbarButton(),
+        _createStackImageSyncToolbarButton(),
+        _createReferenceLineToolbarButton(),
+        _createStackScrollToolbarButton(),
+        _createInvertToolbarButton(),
+        _createProbeToolbarButton(),
+        _createCineToolbarButton(),
+        _createAngleToolbarButton(),
+
+        // Next two tools can be added once icons are added
+        // _createCobbAngleToolbarButton(),
+        // _createPlanarFreehandROIToolbarButton(),
+
+        _createMagnifyToolbarButton(),
+        _createRectangleToolbarButton(),
+        _createCalibrationLineToolbarButton(),
+        _createTagBrowserToolbarButton(),
+      ],
+    },
+  },
+];
+
+export default toolbarButtons;

--- a/platform/viewer/pluginConfig.json
+++ b/platform/viewer/pluginConfig.json
@@ -31,6 +31,10 @@
     {
       "packageName": "@ohif/extension-cornerstone-dicom-seg",
       "version": "3.0.0"
+    },
+    {
+      "packageName": "@ohif/extension-cornerstone-dynamic-volume",
+      "version": "1.0.0"
     }
   ],
   "modes": [
@@ -41,6 +45,10 @@
     {
       "packageName": "@ohif/mode-tmtv",
       "version": "3.0.0"
+    },
+    {
+      "packageName": "@ohif/preclinical-4d",
+      "version": "1.0.0"
     }
   ],
   "modesFactory": [],

--- a/yarn.lock
+++ b/yarn.lock
@@ -6454,6 +6454,11 @@ array-union@^2.1.0:
   resolved "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
   integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
 
+array-union@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/array-union/-/array-union-3.0.1.tgz#da52630d327f8b88cfbfb57728e2af5cd9b6b975"
+  integrity sha512-1OvF9IbWwaeiM9VhzYXVQacMibxpXOMYVNIvMtKRyX9SImBXpKcFr8XvFDeEslCyuH/t6KRt7HEO94AlP8Iatw==
+
 array-uniq@^1.0.1:
   version "1.0.3"
   resolved "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"
@@ -8465,6 +8470,18 @@ copy-text-to-clipboard@^3.0.1:
   version "3.0.1"
   resolved "https://registry.npmjs.org/copy-text-to-clipboard/-/copy-text-to-clipboard-3.0.1.tgz#8cbf8f90e0a47f12e4a24743736265d157bce69c"
   integrity sha512-rvVsHrpFcL4F2P8ihsoLdFHmd404+CMg71S756oRSeQgqk51U3kicGdnvfkrxva0xXH92SjGS62B0XIJsbh+9Q==
+
+copy-webpack-plugin@^10.2.0:
+  version "10.2.4"
+  resolved "https://registry.yarnpkg.com/copy-webpack-plugin/-/copy-webpack-plugin-10.2.4.tgz#6c854be3fdaae22025da34b9112ccf81c63308fe"
+  integrity sha512-xFVltahqlsRcyyJqQbDY6EYTtyQZF9rf+JPjwHObLdPFMEISqkFkr7mFoVOC6BfYS/dNThyoQKvziugm+OnwBg==
+  dependencies:
+    fast-glob "^3.2.7"
+    glob-parent "^6.0.1"
+    globby "^12.0.2"
+    normalize-path "^3.0.0"
+    schema-utils "^4.0.0"
+    serialize-javascript "^6.0.0"
 
 copy-webpack-plugin@^11.0.0:
   version "11.0.0"
@@ -11988,6 +12005,18 @@ globby@^11.0.1, globby@^11.0.2, globby@^11.0.3, globby@^11.0.4, globby@^11.1.0:
     merge2 "^1.4.1"
     slash "^3.0.0"
 
+globby@^12.0.2:
+  version "12.2.0"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-12.2.0.tgz#2ab8046b4fba4ff6eede835b29f678f90e3d3c22"
+  integrity sha512-wiSuFQLZ+urS9x2gGPl1H5drc5twabmm4m2gTR27XDFyjUHJUNsS8o/2aKyIF6IoBaR630atdher0XJ5g6OMmA==
+  dependencies:
+    array-union "^3.0.1"
+    dir-glob "^3.0.1"
+    fast-glob "^3.2.7"
+    ignore "^5.1.9"
+    merge2 "^1.4.1"
+    slash "^4.0.0"
+
 globby@^13.1.1:
   version "13.1.3"
   resolved "https://registry.npmjs.org/globby/-/globby-13.1.3.tgz#f62baf5720bcb2c1330c8d4ef222ee12318563ff"
@@ -12720,7 +12749,7 @@ ignore@^4.0.3, ignore@^4.0.6:
   resolved "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
-ignore@^5.0.0, ignore@^5.1.1, ignore@^5.1.8, ignore@^5.2.0:
+ignore@^5.0.0, ignore@^5.1.1, ignore@^5.1.8, ignore@^5.1.9, ignore@^5.2.0:
   version "5.2.4"
   resolved "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz#a291c0c6178ff1b960befe47fcdec301674a6324"
   integrity sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==


### PR DESCRIPTION
Initial commit that loads PET/CT 4D study (same one used on PET/CT 4D example) in the "Data Preparation" stage (1x3 PET - no colormap applied so far) and adds some empty panels on the left.

There is a method that depends on cornerstone but I updated it to run locally without having to update the library.