### PR TITLE
WIP feat: expose hanging protocol stage to default

### DIFF
--- a/platform/core/src/services/HangingProtocolService/HangingProtocolService.ts
+++ b/platform/core/src/services/HangingProtocolService/HangingProtocolService.ts
@@ -334,7 +334,11 @@ export default class HangingProtocolService extends PubSubService {
    *        the studies to display in viewports.
    * @param protocol is a specific protocol to apply.
    */
-  public run({ studies, displaySets, activeStudy }, protocolId) {
+  public run(
+    { studies, displaySets, activeStudy },
+    protocolId,
+    { stageIndex }
+  ) {
     this.studies = [...(studies || this.studies)];
     this.displaySets = displaySets;
     this.setActiveStudyUID((activeStudy || studies[0])?.StudyInstanceUID);
@@ -346,7 +350,7 @@ export default class HangingProtocolService extends PubSubService {
 
     if (protocolId && typeof protocolId === 'string') {
       const protocol = this.getProtocolById(protocolId);
-      this._setProtocol(protocol);
+      this._setProtocol(protocol, { stageIndex });
       return;
     }
 
@@ -355,7 +359,7 @@ export default class HangingProtocolService extends PubSubService {
       activeStudy,
       displaySets,
     });
-    this._setProtocol(matchedProtocol);
+    this._setProtocol(matchedProtocol, { stageIndex });
   }
 
   /**


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://v3-docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context
This PR is meant to expose the stage index as an initial setting from the mode. The final implementation needs some discussion before it gets merged.
 - HangingProtocolService options are a bit inconsistent, rather than one options `{}` with named key inputs it is a mix of Object and positional args
 - Should stages have a matching engine similar to HP?
 - Modes currently force matching engine to run for a protocol even if one is explicitly provided.

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results
This PR tries to expose stage selection or stage matching to the user.

@sedghi 