### PR TITLE
Fix/initial blank image

### DIFF
--- a/extensions/cornerstone-dicom-sr/src/getHangingProtocolModule.ts
+++ b/extensions/cornerstone-dicom-sr/src/getHangingProtocolModule.ts
@@ -1,0 +1,78 @@
+import { Types } from '@ohif/core';
+
+const srProtocol: Types.HangingProtocol.Protocol = {
+  id: '@ohif/sr',
+  // Don't store this hanging protocol as it applies to the currently active
+  // display set by default
+  // cacheId: null,
+  hasUpdatedPriorsInformation: false,
+  name: 'SR Key Images',
+  // Just apply this one when specifically listed
+  protocolMatchingRules: [],
+  toolGroupIds: ['default'],
+  // -1 would be used to indicate active only, whereas other values are
+  // the number of required priors referenced - so 0 means active with
+  // 0 or more priors.
+  numberOfPriorsReferenced: 0,
+  // Default viewport is used to define the viewport when
+  // additional viewports are added using the layout tool
+  defaultViewport: {
+    viewportOptions: {
+      viewportType: 'stack',
+      toolGroupId: 'default',
+      allowUnmatchedView: true,
+    },
+    displaySets: [
+      {
+        id: 'srDisplaySetId',
+        matchedDisplaySetsIndex: -1,
+      },
+    ],
+  },
+  displaySetSelectors: {
+    srDisplaySetId: {
+      seriesMatchingRules: [
+        {
+          attribute: 'Modality',
+          constraint: {
+            equals: 'SR',
+          },
+        },
+      ],
+    },
+  },
+  stages: [
+    {
+      name: 'SR Key Images',
+      viewportStructure: {
+        layoutType: 'grid',
+        properties: {
+          rows: 1,
+          columns: 1,
+        },
+      },
+      viewports: [
+        {
+          viewportOptions: { allowUnmatchedView: true },
+          displaySets: [
+            {
+              id: 'srDisplaySetId',
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+function getHangingProtocolModule() {
+  return [
+    {
+      name: srProtocol.id,
+      protocol: srProtocol,
+    },
+  ];
+}
+
+export default getHangingProtocolModule;
+export { srProtocol };

--- a/extensions/cornerstone-dicom-sr/src/index.tsx
+++ b/extensions/cornerstone-dicom-sr/src/index.tsx
@@ -1,8 +1,11 @@
 import React from 'react';
 import getSopClassHandlerModule from './getSopClassHandlerModule';
+import getHangingProtocolModule, {
+  srProtocol,
+} from './getHangingProtocolModule';
 import onModeEnter from './onModeEnter';
-import commandsModule from './commandsModule';
-import init from './init';
+import getCommandsModule from './commandsModule';
+import preRegistration from './init';
 import { id } from './id.js';
 import toolNames from './tools/toolNames';
 import hydrateStructuredReport from './utils/hydrateStructuredReport';
@@ -31,9 +34,7 @@ const dicomSRExtension = {
   id,
   onModeEnter,
 
-  preRegistration({ servicesManager, configuration = {} }) {
-    init({ servicesManager, configuration });
-  },
+  preRegistration,
 
   /**
    *
@@ -54,14 +55,11 @@ const dicomSRExtension = {
 
     return [{ name: 'dicom-sr', component: ExtendedOHIFCornerstoneSRViewport }];
   },
-  getCommandsModule({ servicesManager, commandsManager, extensionManager }) {
-    return commandsModule({
-      servicesManager,
-      commandsManager,
-      extensionManager,
-    });
-  },
+  getCommandsModule,
   getSopClassHandlerModule,
+  getHangingProtocolModule,
+
+  // Include dynmically computed values such as toolNames not known till instantiation
   getUtilityModule({ servicesManager }) {
     return [
       {
@@ -75,4 +73,6 @@ const dicomSRExtension = {
 };
 
 export default dicomSRExtension;
-export { hydrateStructuredReport };
+
+// Put static exports here so they can be type checked
+export { hydrateStructuredReport, srProtocol };

--- a/extensions/cornerstone/src/Viewport/OHIFCornerstoneViewport.tsx
+++ b/extensions/cornerstone/src/Viewport/OHIFCornerstoneViewport.tsx
@@ -390,8 +390,6 @@ const OHIFCornerstoneViewport = React.memo(props => {
         initialImageIndex
       );
 
-      storePresentation();
-
       const {
         lutPresentationStore,
         positionPresentationStore,

--- a/extensions/cornerstone/src/Viewport/OHIFCornerstoneViewport.tsx
+++ b/extensions/cornerstone/src/Viewport/OHIFCornerstoneViewport.tsx
@@ -390,6 +390,9 @@ const OHIFCornerstoneViewport = React.memo(props => {
         initialImageIndex
       );
 
+      // The presentation state will have been stored previously by closing
+      // a viewport.  Otherwise, this viewport will be unchanged and the
+      // presentation information will be directly carried over.
       const {
         lutPresentationStore,
         positionPresentationStore,

--- a/platform/viewer/src/components/ViewportGrid.tsx
+++ b/platform/viewer/src/components/ViewportGrid.tsx
@@ -200,11 +200,12 @@ function ViewerViewportGrid(props) {
         }
 
         updatedViewports.forEach(vp => {
+          vp.viewportOptions ||= {};
           const { orientation, viewportType } = vp.viewportOptions;
           let initialImageOptions;
 
           // For initial imageIndex to hang be careful for the volume viewport
-          if (viewportType === 'stack') {
+          if (viewportType === 'stack' || !viewportType) {
             initialImageOptions = {
               index: imageIndex,
             };
@@ -227,7 +228,7 @@ function ViewerViewportGrid(props) {
             }
           }
 
-          vp.viewportOptions['initialImageOptions'] = initialImageOptions;
+          vp.viewportOptions.initialImageOptions = initialImageOptions;
         });
 
         viewportGridService.setDisplaySetsForViewports(updatedViewports);


### PR DESCRIPTION
### Context

If one loads a DICOM SR initially, then the image will end up blank because the initial camera is wrong.
Also added a hanging protocol to demonstrate the issue easily.

### Changes & Results

Removed an incorrect storePresentation call in OHIFCornerstoneViewport

### Testing

The URL:

http://localhost:3000/viewer?StudyInstanceUIDs=1.2.840.113619.2.5.1762583153.215519.978957063.78&hangingProtocolId=@ohif/sr

should display an image initially (if you roll back the OHIFCornerstoneViewport change it will display black)
Also, a  direct load from: 
http://localhost:3000/viewer/ohif?StudyInstanceUIDs=1.3.6.1.4.1.14519.5.2.1.7311.5101.158323547117540061132729905711&hangingProtocolId=@ohif/sr
should work, as WELL as the button load - both types should load it. 

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://v3-docs.ohif.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
