### PR TITLE
fix(SRTool): Ellipse Display for DICOMSR Tool

### DIFF
--- a/extensions/cornerstone-dicom-sr/src/tools/DICOMSRDisplayTool.ts
+++ b/extensions/cornerstone-dicom-sr/src/tools/DICOMSRDisplayTool.ts
@@ -307,13 +307,26 @@ export default class DICOMSRDisplayTool extends AnnotationTool {
 
       const ellipsePointsWorld = data;
 
+      const rotation = viewport.getRotation();
+
       canvasCoordinates = ellipsePointsWorld.map(p =>
         viewport.worldToCanvas(p)
       );
-
-      const canvasCorners = <Array<Types.Point2>>(
-        utilities.math.ellipse.getCanvasEllipseCorners(canvasCoordinates)
-      );
+      let canvasCorners;
+      if (rotation == 90 || rotation == 270) {
+        canvasCorners = <Array<Types.Point2>>(
+          utilities.math.ellipse.getCanvasEllipseCorners([
+            canvasCoordinates[2],
+            canvasCoordinates[3],
+            canvasCoordinates[0],
+            canvasCoordinates[1],
+          ])
+        );
+      } else {
+        canvasCorners = <Array<Types.Point2>>(
+          utilities.math.ellipse.getCanvasEllipseCorners(canvasCoordinates)
+        );
+      }
 
       const lineUID = `${index}`;
       drawing.drawEllipse(


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://v3-docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

Fixes ellipse not rendering correctly when viewport is rotated. This was fixed in the native cornerstone3D tool and it's adapters, but also needed to be applied to the DICOMSRDisplayTool. 

See comments on the pull request

[Pull#479](https://github.com/cornerstonejs/cornerstone3D-beta/pull/479)

### Changes & Results

Added condition to check for the rotation and select the top/bottom/left/right canvas points based on it

Now Ellipse renders correctly in all scenarios, when drawn using the native tool, or when stored and restored, It will render correctly before/after re-hydration.

![GIF 6](https://user-images.githubusercontent.com/93064150/225842654-6d19b0e3-978d-4a3e-ab5a-7a1845c2f963.gif)


_______________________________________________________________________________________________________________________

