### PR TITLE
fix(URL): allow multi filter query

### DIFF
--- a/platform/core/src/utils/splitComma.ts
+++ b/platform/core/src/utils/splitComma.ts
@@ -21,11 +21,11 @@ const getSplitParam = (
   lowerCaseKey: string,
   params = new URLSearchParams(window.location.search)
 ): string[] => {
-  return splitComma(
-    [...params]
-      .find(([key, value]) => key.toLowerCase() === lowerCaseKey && value)
-      ?.slice?.(1)
+  const sourceKey = [...params.keys()].find(
+    it => it.toLowerCase() === lowerCaseKey
   );
+  if (!sourceKey) return;
+  return splitComma(params.getAll(sourceKey));
 };
 
 export { splitComma, getSplitParam };

--- a/platform/viewer/src/routes/Mode/Mode.tsx
+++ b/platform/viewer/src/routes/Mode/Mode.tsx
@@ -1,14 +1,15 @@
 import React, { useEffect, useState, useRef } from 'react';
 import { useParams, useLocation } from 'react-router';
-
 import PropTypes from 'prop-types';
 // TODO: DicomMetadataStore should be injected?
-import { DicomMetadataStore, ServicesManager } from '@ohif/core';
+import { DicomMetadataStore, ServicesManager, utils } from '@ohif/core';
 import { DragAndDropProvider, ImageViewerProvider } from '@ohif/ui';
 import { useQuery, useSearchParams } from '@hooks';
 import ViewportGrid from '@components/ViewportGrid';
 import Compose from './Compose';
 import getStudies from './studiesList';
+
+const { getSplitParam } = utils;
 
 /**
  * Initialize the route.
@@ -283,13 +284,14 @@ export default function ModeRoute({
             if (lowerVal !== 'studyinstanceuids') {
               // Not sure why the case matters here - it doesn't in the URL
               if (lowerVal === 'seriesinstanceuid') {
+                const seriesUIDs = getSplitParam(lowerVal, query);
                 return {
                   ...acc,
-                  seriesInstanceUID: query.get(val),
+                  seriesInstanceUID: seriesUIDs,
                 };
               }
 
-              return { ...acc, [val]: query.get(val) };
+              return { ...acc, [val]: getSplitParam(lowerVal, query) };
             }
           },
           {}


### PR DESCRIPTION
### Context

Bug fix to address the series filter not supporting multiple values.

### Changes & Results

Fix the comma split to work better and use it consistently.

### Testing

http://localhost:3000/viewer/ohif?StudyInstanceUIDs=1.3.6.1.4.1.25403.345050719074.3824.20170125095438.5&SeriesInstanceUID=1.3.6.1.4.1.25403.345050719074.3824.20170125095449.8&SeriesInstanceUID=1.3.6.1.4.1.25403.345050719074.3824.20170125095506.10
should show two series (may need to tweak the URL for the right datasource name)

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://v3-docs.ohif.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
