### PR TITLE
chore(version): updated Orthanc from 1.5.7 to 1.11.0

### DIFF
--- a/.docker/Nginx-Orthanc/docker-compose.yml
+++ b/.docker/Nginx-Orthanc/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.5'
 
 services:
   orthanc:
-    image: jodogne/orthanc-plugins:1.5.7
+    image: jodogne/orthanc-plugins:1.11.0
     hostname: orthanc
     volumes:
       # Config


### PR DESCRIPTION
Updated Orthanc docker version from 1.5.7 to 1.11.0 because saving SR was not working as expected (wrong data) and some versions before 1.11.0 does not have support for requests with `Accept: transfer-syntax=*` header. I've been using 1.11.0 for ~2 months with no problem.