### PR TITLE
feat(DICOM Upload): Decreased the minimum height for the upload dialog contents to better fit some laptops.

### DIFF
--- a/extensions/cornerstone/src/components/DicomUpload/DicomUpload.tsx
+++ b/extensions/cornerstone/src/components/DicomUpload/DicomUpload.tsx
@@ -19,7 +19,7 @@ function DicomUpload({
   onComplete,
   onStarted,
 }: DicomUploadProps): ReactElement {
-  const baseClassNames = 'min-h-[520px] flex flex-col bg-black select-none';
+  const baseClassNames = 'min-h-[480px] flex flex-col bg-black select-none';
   const [dicomFileUploaderArr, setDicomFileUploaderArr] = useState([]);
 
   const onDrop = useCallback(async acceptedFiles => {
@@ -99,7 +99,7 @@ function DicomUpload({
           />
         </div>
       ) : (
-        <div className={classNames('h-[520px]', baseClassNames)}>
+        <div className={classNames('h-[480px]', baseClassNames)}>
           {getDropZoneComponent()}
         </div>
       )}


### PR DESCRIPTION
### Context

Small tweak for the minimum height of the upload dialogue to better fit some laptops (e.g. Dell XPS 15)

### Testing

Try upload on various laptops and tablets. Most should not have a scrollbar for the uploader.

### Checklist

#### PR

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://v3-docs.ohif.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] OS: Windows 11 <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [x] Node version: 16.14.0 <!--[e.g. 16.14.0]"-->
- [x] Browser: Chrome 112.0.5615.138
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
