### PR TITLE
feat: added promise lifecycle to Viewport and hook for HangingProtocol

### DIFF
--- a/extensions/cornerstone/src/Viewport/OHIFCornerstoneViewport.tsx
+++ b/extensions/cornerstone/src/Viewport/OHIFCornerstoneViewport.tsx
@@ -119,6 +119,7 @@ const OHIFCornerstoneViewport = React.memo(props => {
     servicesManager,
     onElementEnabled,
     onElementDisabled,
+    onViewportDataLoad,
     // Note: you SHOULD NOT use the initialImageIdOrIndex for manipulation
     // of the imageData in the OHIFCornerstoneViewport. This prop is used
     // to set the initial state of the viewport's first image to render
@@ -433,7 +434,11 @@ const OHIFCornerstoneViewport = React.memo(props => {
         viewportOptions,
         displaySetOptions,
         presentations
-      );
+      ).then((val) => {
+        if (onViewportDataLoad) {
+          onViewportDataLoad(val)
+        }
+      });;
 
       if (measurement) {
         cs3DTools.annotation.selection.setAnnotationSelected(measurement.uid);
@@ -723,6 +728,7 @@ OHIFCornerstoneViewport.propTypes = {
   displaySetOptions: PropTypes.arrayOf(PropTypes.any),
   servicesManager: PropTypes.object.isRequired,
   onElementEnabled: PropTypes.func,
+  onViewportDataLoad: PropTypes.func,
   // Note: you SHOULD NOT use the initialImageIdOrIndex for manipulation
   // of the imageData in the OHIFCornerstoneViewport. This prop is used
   // to set the initial state of the viewport's first image to render

--- a/platform/core/src/types/HangingProtocol.ts
+++ b/platform/core/src/types/HangingProtocol.ts
@@ -250,6 +250,13 @@ export type ProtocolNotifications = {
   // The numRows and numCols is included in the command params, so it is possible
   // to apply a specific hanging protocol
   onLayoutChange?: Command[];
+
+  // Once all image data containers are loaded, this command runs.
+  // While the data container exists, the actual internal data may not be
+  // hydrated. This is because stack and volume viewports will load progressively.
+  // TODO: Another protocol notification which may need to load is when all data is actually
+  // loaded. This may be related to imageLoader code.
+  onLayoutViewportDataContainersLoaded?: Command[];
 };
 
 /**

--- a/platform/viewer/src/components/ViewportGrid.tsx
+++ b/platform/viewer/src/components/ViewportGrid.tsx
@@ -5,6 +5,7 @@ import { ViewportGrid, ViewportPane, useViewportGrid } from '@ohif/ui';
 import { utils } from '@ohif/core';
 import EmptyViewport from './EmptyViewport';
 import classNames from 'classnames';
+import { commandsManager } from '../App';
 
 const { isEqualWithin } = utils;
 
@@ -260,6 +261,17 @@ function ViewerViewportGrid(props) {
     const viewportPanes = [];
 
     const numViewportPanes = viewportGridService.getNumViewportPanes();
+    let readyViewports = 0;
+    const checkReady = () => {
+      readyViewports = readyViewports + 1;
+      if (readyViewports === numViewportPanes) {
+        const layoutLoaded = hangingProtocolService?.protocol?.callbacks?.onLayoutViewportDataContainersLoaded;
+        if (layoutLoaded) {
+          commandsManager.run(layoutLoaded)
+        }
+      }
+    }
+
     for (let i = 0; i < numViewportPanes; i++) {
       const viewportIndex = i;
       const isActive = activeViewportIndex === viewportIndex;
@@ -344,6 +356,7 @@ function ViewerViewportGrid(props) {
               viewportOptions={viewportOptions}
               displaySetOptions={displaySetOptions}
               needsRerendering={displaySetsNeedsRerendering}
+              onViewportDataLoad={checkReady}
             />
           </div>
         </ViewportPane>


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://v3-docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context
It is useful to know when the data containers related to a hanging protocol change are loaded. This PR triggers a new HangingProtocolHook: `onLayoutViewportDataContainersLoaded`. This only fires once all viewportDataContainers related to running a hanging protocol are complete. The reason it is only a "DataContainer" load is because data is loaded progressively in OHIF. So while the metadata container exists (i.e. empty volume or empty stack)--the actual pixel data may not have been progressively loaded in yet. Future work may consider adding a `onLayoutViewportDataLoaded` when all data related to a hanging protocol is fully downloaded.

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results
CornerstoneViewportService previously had many async functions which returned void. Instead, they now return the actual promise these async functions intend to fire. This allows downstream functions to optionally call the .then() or ignore which should keep behaviour exactly the same.

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing
This feature can be tested by simply using the `onLayoutViewportDataContainersLoaded` hook on hangingProtocol.

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://v3-docs.ohif.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
