### PR TITLE
fix(DICOM PDF and Video): fixes for local DICOM load and remote data sources

### DIFF
--- a/extensions/default/src/DicomLocalDataSource/index.js
+++ b/extensions/default/src/DicomLocalDataSource/index.js
@@ -115,6 +115,18 @@ function createDicomLocalApi(dicomLocalConfig) {
       },
     },
     retrieve: {
+      directURL: params => {
+        const { instance, tag, defaultType } = params;
+
+        const value = instance[tag];
+        if (value instanceof Array && value[0] instanceof ArrayBuffer) {
+          return URL.createObjectURL(
+            new Blob([value[0]], {
+              type: defaultType,
+            })
+          );
+        }
+      },
       series: {
         metadata: async ({ StudyInstanceUID, madeInClient = false } = {}) => {
           if (!StudyInstanceUID) {

--- a/extensions/default/src/DicomWebDataSource/index.js
+++ b/extensions/default/src/DicomWebDataSource/index.js
@@ -178,7 +178,7 @@ function createDicomWebApi(dicomWebConfig, userAuthenticationService) {
        *    or is already retrieved, or a promise to a URL for such use if a BulkDataURI
        */
       directURL: params => {
-        return getDirectURL(wadoRoot, params);
+        return getDirectURL({ wadoRoot, singlepart }, params);
       },
       bulkDataURI: async ({ StudyInstanceUID, BulkDataURI }) => {
         const options = {
@@ -394,7 +394,13 @@ function createDicomWebApi(dicomWebConfig, userAuthenticationService) {
               };
               // Todo: this needs to be from wado dicom web client
               return qidoDicomWebClient.retrieveBulkData(options).then(val => {
-                const ret = (val && val[0]) || undefined;
+                // There are DICOM PDF cases where the first ArrayBuffer in the array is
+                // the bulk data and DICOM video cases where the second ArrayBuffer is
+                // the bulk data. Here we play it safe and do a find.
+                const ret =
+                  (val instanceof Array &&
+                    val.find(arrayBuffer => arrayBuffer?.byteLength)) ||
+                  undefined;
                 value.Value = ret;
                 return ret;
               });

--- a/extensions/default/src/utils/getDirectURL.js
+++ b/extensions/default/src/utils/getDirectURL.js
@@ -19,13 +19,13 @@ import {
  * @returns an absolute URL to the resource, if the absolute URL can be retrieved as singlepart,
  *    or is already retrieved, or a promise to a URL for such use if a BulkDataURI
  */
-const getDirectURL = (wadoRoot, params) => {
+const getDirectURL = (config, params) => {
+  const { wadoRoot, singlepart } = config;
   const {
     instance,
     tag = 'PixelData',
     defaultPath = '/pixeldata',
     defaultType = 'video/mp4',
-    singlepart = null,
     singlepart: fetchPart = 'video',
   } = params;
   const value = instance[tag];
@@ -53,11 +53,7 @@ const getDirectURL = (wadoRoot, params) => {
     return undefined;
   }
 
-  const {
-    StudyInstanceUID,
-    SeriesInstanceUID,
-    SOPInstanceUID,
-  } = instance;
+  const { StudyInstanceUID, SeriesInstanceUID, SOPInstanceUID } = instance;
   const BulkDataURI =
     (value && value.BulkDataURI) ||
     `series/${SeriesInstanceUID}/instances/${SOPInstanceUID}${defaultPath}`;
@@ -66,7 +62,13 @@ const getDirectURL = (wadoRoot, params) => {
   const acceptUri =
     BulkDataURI +
     (hasAccept ? '' : (hasQuery ? '&' : '?') + `accept=${defaultType}`);
-  if (BulkDataURI.indexOf('http') === 0) return acceptUri;
+  if (BulkDataURI.indexOf('http') === 0) {
+    if (tag === 'PixelData' || tag === 'EncapsulatedDocument') {
+      return `${wadoRoot}/studies/${StudyInstanceUID}/series/${SeriesInstanceUID}/instances/${SOPInstanceUID}/rendered`;
+    } else {
+      return acceptUri;
+    }
+  }
   if (BulkDataURI.indexOf('/') === 0) {
     return wadoRoot + acceptUri;
   }

--- a/extensions/dicom-pdf/src/viewports/OHIFCornerstonePdfViewport.tsx
+++ b/extensions/dicom-pdf/src/viewports/OHIFCornerstonePdfViewport.tsx
@@ -14,15 +14,14 @@ function OHIFCornerstonePdfViewport({ displaySets }) {
 
   useEffect(() => {
     const load = async () => {
-      await pdfUrl;
-      setUrl(pdfUrl);
+      setUrl(await pdfUrl);
     };
 
     load();
   }, [pdfUrl]);
 
   return (
-    <div className="bg-primary-black w-full h-full">
+    <div className="bg-primary-black w-full h-full text-white">
       <object data={url} type="application/pdf" className="w-full h-full">
         <div>No online PDF viewer installed</div>
       </object>

--- a/extensions/dicom-video/src/getSopClassHandlerModule.js
+++ b/extensions/dicom-video/src/getSopClassHandlerModule.js
@@ -37,7 +37,18 @@ const _getDisplaySetsFromSeries = (
         metadata.AvailableTransferSyntaxUID ||
         metadata.TransferSyntaxUID ||
         metadata['00083002'];
-      return supportedTransferSyntaxUIDs.includes(tsuid);
+
+      if (supportedTransferSyntaxUIDs.includes(tsuid)) {
+        return true;
+      }
+
+      // Assume that an instance with certain SOPClassUID and
+      // with at least 90 frames (i.e. typically 3 seconds of video) is indeed a video.
+      return (
+        metadata.SOPClassUID ===
+          SOP_CLASS_UIDS.MULTIFRAME_TRUE_COLOR_SECONDARY_CAPTURE_IMAGE_STORAGE &&
+        metadata.NumberOfFrames >= 90
+      );
     })
     .map(instance => {
       const {

--- a/extensions/dicom-video/src/viewports/OHIFCornerstoneVideoViewport.tsx
+++ b/extensions/dicom-video/src/viewports/OHIFCornerstoneVideoViewport.tsx
@@ -14,8 +14,7 @@ function OHIFCornerstoneVideoViewport({ displaySets }) {
 
   useEffect(() => {
     const load = async () => {
-      await videoUrl;
-      setUrl(videoUrl);
+      setUrl(await videoUrl);
     };
 
     load();

--- a/platform/viewer/public/config/local_dcm4chee.js
+++ b/platform/viewer/public/config/local_dcm4chee.js
@@ -32,6 +32,7 @@ window.config = {
           auth: 'admin:admin',
         },
         dicomUploadEnabled: true,
+        singlepart: 'pdf,video',
       },
     },
     {

--- a/platform/viewer/src/routes/Local/dicomFileLoader.js
+++ b/platform/viewer/src/routes/Local/dicomFileLoader.js
@@ -21,6 +21,10 @@ const DICOMFileLoader = new (class extends FileLoader {
       dicomData.meta
     );
 
+    dataset.AvailableTransferSyntaxUID =
+      dataset.AvailableTransferSyntaxUID ||
+      dataset._meta.TransferSyntaxUID?.Value?.[0];
+
     return dataset;
   }
 })();


### PR DESCRIPTION

<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://v3-docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

DICOM PDF and video series/instances were not loading in OHIF.

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

- added retrieve.directURL for local DICOM load data source; it returns a data URL
- fixed various checks for video using transfer syntaxes and SOP class UID with number of frames
- added call to 'rendered' endpoint for those data sources that support it; others get BulkDataURI

DICOM PDF and video should load and be viewable in OHIF.

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

Test A
1. Try to view a DICOM PDF or Video from your local file system via the local OHIF route (e.g. http://localhost:3000/local)

Test B
1. Try to view a DICOM PDF or Video from either an orthanc or dcm4cee DICOM web data source. You may need to configure some of the CORS response headers for either server.
<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://v3-docs.ohif.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] OS: Windows 11 <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [x] Node version: 16.14.0 <!--[e.g. 16.14.0]"-->
- [x] Browser: Chrome  112.0.5615.138
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
