### PR TITLE
fix(service-worker): fixes service worker issue in init-service-worke…

### DIFF
--- a/platform/viewer/public/init-service-worker.js
+++ b/platform/viewer/public/init-service-worker.js
@@ -3,50 +3,57 @@
 // modules, so it's perfectly fine to serve this code to any browsers
 // (older browsers will just ignore it)
 //
-import { Workbox } from 'https://storage.googleapis.com/workbox-cdn/releases/5.0.0-beta.1/workbox-window.prod.mjs';
+//import { Workbox } from './workbox-window.prod.mjs';
+// proper initialization
+if( 'function' === typeof importScripts) {
+  importScripts(
+    'https://storage.googleapis.com/workbox-cdn/releases/6.5.4/workbox-window.prod.mjs'
+  );
 
-var supportsServiceWorker = 'serviceWorker' in navigator;
-var isNotLocalDevelopment =
-  ['localhost', '127'].indexOf(location.hostname) === -1;
+  var supportsServiceWorker = 'serviceWorker' in navigator;
+  var isNotLocalDevelopment =
+    ['localhost', '127'].indexOf(location.hostname) === -1;
 
-if (supportsServiceWorker && isNotLocalDevelopment) {
-  const swFileLocation = (window.PUBLIC_URL || '/') + 'sw.js';
-  const wb = new Workbox(swFileLocation);
+  if (supportsServiceWorker && isNotLocalDevelopment) {
+    const swFileLocation = (window.PUBLIC_URL || '/') + 'sw.js';
+    const wb = new Workbox(swFileLocation);
 
-  // Add an event listener to detect when the registered
-  // service worker has installed but is waiting to activate.
-  wb.addEventListener('waiting', event => {
-    // customize the UI prompt accordingly.
-    const isFirstTimeUpdatedServiceWorkerIsWaiting =
-      event.wasWaitingBeforeRegister === false;
-    console.log(
-      'isFirstTimeUpdatedServiceWorkerIsWaiting',
-      isFirstTimeUpdatedServiceWorkerIsWaiting
-    );
+    // Add an event listener to detect when the registered
+    // service worker has installed but is waiting to activate.
+    wb.addEventListener('waiting', event => {
+      // customize the UI prompt accordingly.
+      const isFirstTimeUpdatedServiceWorkerIsWaiting =
+        event.wasWaitingBeforeRegister === false;
+      console.log(
+        'isFirstTimeUpdatedServiceWorkerIsWaiting',
+        isFirstTimeUpdatedServiceWorkerIsWaiting
+      );
 
-    // Assumes your app has some sort of prompt UI element
-    // that a user can either accept or reject.
-    // const prompt = createUIPrompt({
-    //  onAccept: async () => {
-    // Assuming the user accepted the update, set up a listener
-    // that will reload the page as soon as the previously waiting
-    // service worker has taken control.
-    wb.addEventListener('controlling', event => {
-      window.location.reload();
+      // Assumes your app has some sort of prompt UI element
+      // that a user can either accept or reject.
+      // const prompt = createUIPrompt({
+      //  onAccept: async () => {
+      // Assuming the user accepted the update, set up a listener
+      // that will reload the page as soon as the previously waiting
+      // service worker has taken control.
+      wb.addEventListener('controlling', event => {
+        window.location.reload();
+      });
+
+      // Send a message telling the service worker to skip waiting.
+      // This will trigger the `controlling` event handler above.
+      // Note: for this to work, you have to add a message
+      // listener in your service worker. See below.
+      wb.messageSW({ type: 'SKIP_WAITING' });
+      // },
+
+      // onReject: () => {
+      //   prompt.dismiss();
+      // },
+      // });
     });
 
-    // Send a message telling the service worker to skip waiting.
-    // This will trigger the `controlling` event handler above.
-    // Note: for this to work, you have to add a message
-    // listener in your service worker. See below.
-    wb.messageSW({ type: 'SKIP_WAITING' });
-    // },
+    wb.register();
+  }
 
-    // onReject: () => {
-    //   prompt.dismiss();
-    // },
-    // });
-  });
-
-  wb.register();
 }


### PR DESCRIPTION
…r.js

<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://v3-docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context
The V3 version fails to load service worker and shows below error on initial load
```
caught ReferenceError: importScripts is not defined
    at init-service-worker.js:1:1
```
<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results
This PR fixes that error
<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing
Run and open the application in browser. This error present in console
<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR
<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://v3-docs.ohif.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"--> macOS 13
- [x] "Node version: <!--[e.g. 16.14.0]"--> 16.x
- [x] "Browser: Chrome 112
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
