### PR TITLE
feat: query string dynamic app config

### DIFF
--- a/extensions/default/src/ViewerLayout/index.tsx
+++ b/extensions/default/src/ViewerLayout/index.tsx
@@ -50,6 +50,8 @@ function ViewerLayout({
     //   dataSourceIdx === -1
     //     ? undefined
     //     : `datasources=${pathname.substring(dataSourceIdx + 1)}`;
+
+    // Todo: Handle parameters in a better way.
     const query = new URLSearchParams(window.location.search);
     const configUrl = query.get('configUrl');
 

--- a/extensions/default/src/ViewerLayout/index.tsx
+++ b/extensions/default/src/ViewerLayout/index.tsx
@@ -46,13 +46,25 @@ function ViewerLayout({
   const onClickReturnButton = () => {
     const { pathname } = location;
     const dataSourceIdx = pathname.indexOf('/', 1);
-    const search =
-      dataSourceIdx === -1
-        ? undefined
-        : `datasources=${pathname.substring(dataSourceIdx + 1)}`;
+    // const search =
+    //   dataSourceIdx === -1
+    //     ? undefined
+    //     : `datasources=${pathname.substring(dataSourceIdx + 1)}`;
+    const query = new URLSearchParams(window.location.search);
+    const configUrl = query.get('configUrl');
+
+    const searchQuery = new URLSearchParams();
+    if (dataSourceIdx !== -1) {
+      searchQuery.append('datasources', pathname.substring(dataSourceIdx + 1));
+    }
+
+    if (configUrl) {
+      searchQuery.append('configUrl', configUrl);
+    }
+
     navigate({
       pathname: '/',
-      search,
+      search: decodeURIComponent(searchQuery.toString()),
     });
   };
 

--- a/platform/docs/docs/configuration/configurationFiles.md
+++ b/platform/docs/docs/configuration/configurationFiles.md
@@ -116,7 +116,24 @@ Here are a list of some options available:
 if auth headers are used, a preflight request is required.
 - `maxNumRequests`: The maximum number of requests to allow in parallel. It is an object with keys of `interaction`, `thumbnail`, and `prefetch`. You can specify a specific number for each type.
 - `showLoadingIndicator`: (default to true), if set to false, the loading indicator will not be shown when navigating between studies.
-
+- `dangerouslyUseDynamicConfig`: Dynamic config allows user to pass `configUrl` query string. This allows to load config without recompiling application. If the `configUrl` query string is passed, the worklist and modes will load from the referenced json rather than the default .env config. If there is no `configUrl` path provided, the default behaviour is used and there should not be any deviation from current user experience.<br/>
+Points to consider while using `dangerouslyUseDynamicConfig`:<br/>
+  - User have to enable this feature by setting `dangerouslyUseDynamicConfig.enabled:true`. By default it is `false`.
+  - Regex helps to avoid easy exploit. Dafault is `/.*/`. Setup your own regex to choose a specific source of configuration only.
+  - System administrators can return `cross-origin: same-origin` with OHIF files to disallow any loading from other origin. It will block read access to resources loaded from a different origin to avoid potential attack vector.
+  - Example config:
+    ```js
+    dangerouslyUseDynamicConfig: {
+      enabled: false,
+      regex: /.*/
+    }
+    ```
+  > Example 1, to allow numbers and letters in an absolute or sub-path only.<br/>
+`regex: /(0-9A-Za-z.]+)(\/[0-9A-Za-z.]+)*/`<br/>
+Example 2, to restricts to either hosptial.com or othersite.com.<br/>
+`regex: /(https:\/\/hospital.com(\/[0-9A-Za-z.]+)*)|(https:\/\/othersite.com(\/[0-9A-Za-z.]+)*)/` <br/>
+Example usage:<br/>
+`http://localhost:3000/?configUrl=http://localhost:3000/config/example.json`<br/>
 
 
 

--- a/platform/viewer/public/config/default.js
+++ b/platform/viewer/public/config/default.js
@@ -26,15 +26,15 @@ window.config = {
   // filterQueryParam: false,
   defaultDataSourceName: 'dicomweb',
   /* Dynamic config allows user to pass "configUrl" query string this allows to load config without recompiling application. The regex will ensure valid configuration source */
-  dangerouslyUseDynamicConfig: {
-    enabled: false,
-    // regex will ensure valid configuration source and default is /.*/ which matches any character. To use this, setup your own regex to choose a specific source of configuration only.
-    // Example 1, to allow numbers and letters in an absolute or sub-path only.
-    // regex: /(0-9A-Za-z.]+)(\/[0-9A-Za-z.]+)*/
-    // Example 2, to restricts to either hosptial.com or othersite.com.
-    // regex: /(https:\/\/hospital.com(\/[0-9A-Za-z.]+)*)|(https:\/\/othersite.com(\/[0-9A-Za-z.]+)*)/
-    regex: /.*/,
-  },
+  // dangerouslyUseDynamicConfig: {
+  //   enabled: true,
+  //   // regex will ensure valid configuration source and default is /.*/ which matches any character. To use this, setup your own regex to choose a specific source of configuration only.
+  //   // Example 1, to allow numbers and letters in an absolute or sub-path only.
+  //   // regex: /(0-9A-Za-z.]+)(\/[0-9A-Za-z.]+)*/
+  //   // Example 2, to restricts to either hosptial.com or othersite.com.
+  //   // regex: /(https:\/\/hospital.com(\/[0-9A-Za-z.]+)*)|(https:\/\/othersite.com(\/[0-9A-Za-z.]+)*)/
+  //   regex: /.*/,
+  // },
   dataSources: [
     {
       friendlyName: 'dcmjs DICOMWeb Server',

--- a/platform/viewer/public/config/default.js
+++ b/platform/viewer/public/config/default.js
@@ -25,6 +25,16 @@ window.config = {
   },
   // filterQueryParam: false,
   defaultDataSourceName: 'dicomweb',
+  /* Dynamic config allows user to pass "configUrl" query string this allows to load config without recompiling application. The regex will ensure valid configuration source */
+  dangerouslyUseDynamicConfig: {
+    enabled: false,
+    // regex will ensure valid configuration source and default is /.*/ which matches any character. To use this, setup your own regex to choose a specific source of configuration only.
+    // Example 1, to allow numbers and letters in an absolute or sub-path only.
+    // regex: /(0-9A-Za-z.]+)(\/[0-9A-Za-z.]+)*/
+    // Example 2, to restricts to either hosptial.com or othersite.com.
+    // regex: /(https:\/\/hospital.com(\/[0-9A-Za-z.]+)*)|(https:\/\/othersite.com(\/[0-9A-Za-z.]+)*)/
+    regex: /.*/,
+  },
   dataSources: [
     {
       friendlyName: 'dcmjs DICOMWeb Server',

--- a/platform/viewer/src/index.js
+++ b/platform/viewer/src/index.js
@@ -20,20 +20,28 @@ import {
   modes as defaultModes,
   extensions as defaultExtensions,
 } from './pluginImports';
+import loadDynamicConfig from './loadDynamicConfig';
 
-/**
- * Combine our appConfiguration with installed extensions and modes.
- * In the future appConfiguration may contain modes added at runtime.
- *  */
-const appProps = {
-  config: window ? window.config : {},
-  defaultExtensions,
-  defaultModes,
-};
+loadDynamicConfig(window.config).then(config_json => {
+  // Reset Dynamic config if defined
+  if (config_json !== null) {
+    window.config = config_json;
+  }
 
-/** Create App */
-const app = React.createElement(App, appProps, null);
-/** Render */
-ReactDOM.render(app, document.getElementById('root'));
+  /**
+   * Combine our appConfiguration with installed extensions and modes.
+   * In the future appConfiguration may contain modes added at runtime.
+   *  */
+  const appProps = {
+    config: window ? window.config : {},
+    defaultExtensions,
+    defaultModes,
+  };
+
+  /** Create App */
+  const app = React.createElement(App, appProps, null);
+  /** Render */
+  ReactDOM.render(app, document.getElementById('root'));
+});
 
 export { history };

--- a/platform/viewer/src/loadDynamicConfig.js
+++ b/platform/viewer/src/loadDynamicConfig.js
@@ -1,0 +1,23 @@
+export default async config => {
+  const useDynamicConfig = config.dangerouslyUseDynamicConfig;
+
+  // Check if dangerouslyUseDynamicConfig enabled
+  if (useDynamicConfig.enabled) {
+    // If enabled then get configUrl query-string
+    let query = new URLSearchParams(window.location.search);
+    let configUrl = query.get('configUrl');
+
+    if (configUrl) {
+      // validate regex
+      const regex = useDynamicConfig.regex;
+
+      if (regex.test(configUrl)) {
+        const response = await fetch(configUrl);
+        return response.json();
+      } else {
+        return null;
+      }
+    }
+  }
+  return null;
+};

--- a/platform/viewer/src/loadDynamicConfig.js
+++ b/platform/viewer/src/loadDynamicConfig.js
@@ -2,7 +2,7 @@ export default async config => {
   const useDynamicConfig = config.dangerouslyUseDynamicConfig;
 
   // Check if dangerouslyUseDynamicConfig enabled
-  if (useDynamicConfig.enabled) {
+  if (useDynamicConfig?.enabled) {
     // If enabled then get configUrl query-string
     let query = new URLSearchParams(window.location.search);
     let configUrl = query.get('configUrl');
@@ -11,7 +11,7 @@ export default async config => {
       // validate regex
       const regex = useDynamicConfig.regex;
 
-      if (regex.test(configUrl)) {
+      if (configUrl.match(regex)) {
         const response = await fetch(configUrl);
         return response.json();
       } else {

--- a/platform/viewer/src/routes/DataSourceWrapper.tsx
+++ b/platform/viewer/src/routes/DataSourceWrapper.tsx
@@ -170,6 +170,7 @@ function _getQueryFilterValues(query, queryLimit) {
     // Offset...
     offset:
       Math.floor((pageNumber * resultsPerPage) / queryLimit) * (queryLimit - 1),
+    config: query.get('configUrl'),
   };
 
   // patientName: good

--- a/platform/viewer/src/routes/WorkList/WorkList.tsx
+++ b/platform/viewer/src/routes/WorkList/WorkList.tsx
@@ -345,12 +345,17 @@ function WorkList({
             // mode.routeName
             // mode.routes[x].path
             // Don't specify default data source, and it should just be picked up... (this may not currently be the case)
-            // How do we know which params to pass? Today, it's just StudyInstanceUIDs
+            // How do we know which params to pass? Today, it's just StudyInstanceUIDs and configUrl if exists
+            const query = new URLSearchParams();
+            if (filterValues.configUrl) {
+              query.append('configUrl', filterValues.configUrl);
+            }
+            query.append('StudyInstanceUIDs', studyInstanceUid);
             return (
               <Link
                 key={i}
                 to={`${dataPath ? '../../' : ''}${mode.routeName}${dataPath ||
-                  ''}?StudyInstanceUIDs=${studyInstanceUid}`}
+                  ''}?${decodeURIComponent(query.toString())}`}
                 // to={`${mode.routeName}/dicomweb?StudyInstanceUIDs=${studyInstanceUid}`}
               >
                 <Button
@@ -531,6 +536,7 @@ const defaultFilterValues = {
   pageNumber: 1,
   resultsPerPage: 25,
   datasources: '',
+  configUrl: null,
 };
 
 function _tryParseInt(str, defaultValue) {
@@ -561,6 +567,7 @@ function _getQueryFilterValues(params) {
     pageNumber: _tryParseInt(params.get('pagenumber'), undefined),
     resultsPerPage: _tryParseInt(params.get('resultsperpage'), undefined),
     datasources: params.get('datasources'),
+    configUrl: params.get('configurl'),
   };
 
   // Delete null/undefined keys

--- a/platform/viewer/src/routes/WorkList/WorkList.tsx
+++ b/platform/viewer/src/routes/WorkList/WorkList.tsx
@@ -355,7 +355,7 @@ function WorkList({
               <Link
                 key={i}
                 to={`${dataPath ? '../../' : ''}${mode.routeName}${dataPath ||
-                  ''}?${decodeURIComponent(query.toString())}`}
+                  ''}?${query.toString()}`}
                 // to={`${mode.routeName}/dicomweb?StudyInstanceUIDs=${studyInstanceUid}`}
               >
                 <Button


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://v3-docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context
This PR allows for the app config to reference a json over network. This allows for
fast swapping of data source configuration, OIDC, etc, without recompiling the application.

If the `configUrl` query string is passed, the worklist and modes will load from the referenced json
rather than the default .env config

If there is no `configUrl` path provided, the default behaviour is used and there should not be any
deviation from current user experience.

**Points to consider**

- User have to enable this feature by setting `dangerouslyUseDynamicConfig.enabled:true`. By default it is `false`.
- Regex helps to avoid easy exploit
- User must set `cross-origin = same-origin` to avoid potential harder exploit

**Sample local config**
```
/* Dynamic config allows user to pass "configUrl" query string this allows to load config without recompiling application. The regex will ensure valid configuration source */
  dangerouslyUseDynamicConfig: {
    enabled: false,
    regex: /.*/,
  }
```

**Example usage**

`http://localhost:3000/?configUrl=http://localhost:3000/config/example.json`

This PR is related to another PR https://github.com/OHIF/Viewers/pull/2925

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Checklist

#### PR

- [x] Brief description of changes
- [x] Links to any relevant issues
- [ ] Required status checks are passing
- [x] User cases if changes impact the user's experience
- [x] `@mention` a maintainer to request a review

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://v3-docs.ohif.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.
