### PR TITLE
fix(Measurement): Use dashed lines for measurments of viewports where getCurrentImageId returns undefined

### DIFF
--- a/extensions/cornerstone-dicom-sr/package.json
+++ b/extensions/cornerstone-dicom-sr/package.json
@@ -46,7 +46,7 @@
     "@babel/runtime": "^7.20.13",
     "classnames": "^2.3.2",
     "@cornerstonejs/adapters": "^0.6.0",
-    "@cornerstonejs/core": "^0.46.2",
-    "@cornerstonejs/tools": "^0.67.2"
+    "@cornerstonejs/core": "^0.47.1",
+    "@cornerstonejs/tools": "^0.67.4"
   }
 }

--- a/extensions/cornerstone/package.json
+++ b/extensions/cornerstone/package.json
@@ -34,7 +34,7 @@
   "peerDependencies": {
     "@ohif/core": "^3.0.0",
     "@ohif/ui": "^2.0.0",
-    "@cornerstonejs/dicom-image-loader": "^0.6.4",
+    "@cornerstonejs/dicom-image-loader": "^0.6.6",
     "@cornerstonejs/codec-charls": "^1.2.3",
     "@cornerstonejs/codec-libjpeg-turbo-8bit": "^1.2.2",
     "@cornerstonejs/codec-openjpeg": "^1.2.2",
@@ -53,9 +53,9 @@
   "dependencies": {
     "@babel/runtime": "^7.20.13",
     "@cornerstonejs/adapters": "^0.6.0",
-    "@cornerstonejs/core": "^0.46.2",
-    "@cornerstonejs/streaming-image-volume-loader": "^0.20.2",
-    "@cornerstonejs/tools": "^0.67.2",
+    "@cornerstonejs/core": "^0.47.1",
+    "@cornerstonejs/streaming-image-volume-loader": "^0.20.4",
+    "@cornerstonejs/tools": "^0.67.4",
     "@kitware/vtk.js": "27.3.1",
     "html2canvas": "^1.4.1",
     "lodash.debounce": "4.0.8",

--- a/extensions/measurement-tracking/package.json
+++ b/extensions/measurement-tracking/package.json
@@ -32,8 +32,8 @@
   "peerDependencies": {
     "@ohif/core": "^3.0.0",
     "classnames": "^2.3.2",
-    "@cornerstonejs/core": "^0.46.2",
-    "@cornerstonejs/tools": "^0.67.2",
+    "@cornerstonejs/core": "^0.47.1",
+    "@cornerstonejs/tools": "^0.67.4",
     "@ohif/extension-cornerstone-dicom-sr": "^3.0.0",
     "dcmjs": "^0.29.5",
     "lodash.debounce": "^4.17.21",

--- a/extensions/measurement-tracking/src/viewports/TrackedCornerstoneViewport.tsx
+++ b/extensions/measurement-tracking/src/viewports/TrackedCornerstoneViewport.tsx
@@ -1,14 +1,8 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import OHIF, { utils } from '@ohif/core';
 
-import {
-  Notification,
-  ViewportActionBar,
-  useViewportDialog,
-  Tooltip,
-  Icon,
-} from '@ohif/ui';
+import { ViewportActionBar, Tooltip, Icon } from '@ohif/ui';
 
 import { useTranslation } from 'react-i18next';
 

--- a/extensions/measurement-tracking/src/viewports/TrackedCornerstoneViewport.tsx
+++ b/extensions/measurement-tracking/src/viewports/TrackedCornerstoneViewport.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import OHIF, { utils } from '@ohif/core';
 
@@ -19,13 +19,11 @@ const { formatDate } = utils;
 
 function TrackedCornerstoneViewport(props) {
   const {
-    children,
     displaySets,
     viewportIndex,
     viewportLabel,
     servicesManager,
     extensionManager,
-    commandsManager,
     viewportOptions,
   } = props;
 
@@ -40,7 +38,6 @@ function TrackedCornerstoneViewport(props) {
   const displaySet = displaySets[0];
 
   const [trackedMeasurements] = useTrackedMeasurements();
-  const [viewportDialogState] = useViewportDialog();
   const [isTracked, setIsTracked] = useState(false);
   const [trackedMeasurementUID, setTrackedMeasurementUID] = useState(null);
 
@@ -48,7 +45,6 @@ function TrackedCornerstoneViewport(props) {
   const viewportId = viewportOptions.viewportId;
 
   const {
-    Modality,
     SeriesDate,
     SeriesDescription,
     SeriesInstanceUID,
@@ -93,8 +89,17 @@ function TrackedCornerstoneViewport(props) {
     };
   }, [isTracked]);
 
-  if (trackedSeries.includes(SeriesInstanceUID) !== isTracked) {
-    setIsTracked(!isTracked);
+  // A current image will only exist for viewports that can have measurements tracked.
+  // Typically these are stack viewports and those volume viewports for the series of acquisition.
+  const currentImageId = cornerstoneViewportService
+    .getCornerstoneViewport(viewportId)
+    ?.getCurrentImageId();
+  if (currentImageId) {
+    if (trackedSeries.includes(SeriesInstanceUID) !== isTracked) {
+      setIsTracked(!isTracked);
+    }
+  } else if (isTracked) {
+    setIsTracked(false);
   }
 
   function switchMeasurement(direction) {

--- a/extensions/measurement-tracking/src/viewports/TrackedCornerstoneViewport.tsx
+++ b/extensions/measurement-tracking/src/viewports/TrackedCornerstoneViewport.tsx
@@ -89,7 +89,7 @@ function TrackedCornerstoneViewport(props) {
     };
   }, [isTracked]);
 
-  // A current image will only exist for viewports that can have measurements tracked.
+  // A current image id will only exist for viewports that can have measurements tracked.
   // Typically these are stack viewports and those volume viewports for the series of acquisition.
   const currentImageId = cornerstoneViewportService
     .getCornerstoneViewport(viewportId)

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     ]
   },
   "resolutions": {
-    "@cornerstonejs/core": "^0.46.2",
+    "@cornerstonejs/core": "^0.47.1",
     "**/@babel/runtime": "^7.20.13",
     "nth-check": "^2.1.1",
     "trim-newlines": "^5.0.0",

--- a/platform/core/package.json
+++ b/platform/core/package.json
@@ -32,7 +32,7 @@
   },
   "peerDependencies": {
     "cornerstone-math": "0.1.9",
-    "@cornerstonejs/dicom-image-loader": "^0.6.4",
+    "@cornerstonejs/dicom-image-loader": "^0.6.6",
     "@cornerstonejs/codec-charls": "^1.2.3",
     "@cornerstonejs/codec-libjpeg-turbo-8bit": "^1.2.2",
     "@cornerstonejs/codec-openjpeg": "^1.2.2",

--- a/platform/viewer/package.json
+++ b/platform/viewer/package.json
@@ -68,7 +68,7 @@
     "config-point": "^0.4.8",
     "core-js": "^3.16.1",
     "cornerstone-math": "^0.1.9",
-    "@cornerstonejs/dicom-image-loader": "^0.6.4",
+    "@cornerstonejs/dicom-image-loader": "^0.6.6",
     "@cornerstonejs/codec-charls": "^1.2.3",
     "@cornerstonejs/codec-libjpeg-turbo-8bit": "^1.2.2",
     "@cornerstonejs/codec-openjpeg": "^1.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1469,43 +1469,43 @@
   resolved "https://registry.npmjs.org/@cornerstonejs/codec-openjph/-/codec-openjph-2.4.2.tgz#e96721d56f6ec96f7f95c16321d88cc8467d8d81"
   integrity sha512-lgdvBvvNezleY+4pIe2ceUsJzlZe/0PipdeubQ3vZZOz3xxtHHMR1XFCl4fgd8gosR8COHuD7h6q+MwgrwBsng==
 
-"@cornerstonejs/core@^0.46.2":
-  version "0.46.2"
-  resolved "https://registry.npmjs.org/@cornerstonejs/core/-/core-0.46.2.tgz#89ba0d27f491aab8b0a22d15ce5ed601ee23d2ec"
-  integrity sha512-HHActbdv3np/QXmQPl+DOqVMXPeOXbkqDov1SagF1om6Me4V7O8N2HbM4CgKCdf2VrEId6h0BL3+MG3Cxn7LPQ==
+"@cornerstonejs/core@^0.47.1":
+  version "0.47.1"
+  resolved "https://registry.yarnpkg.com/@cornerstonejs/core/-/core-0.47.1.tgz#8bbb9d5d8a6cd8a4c0fbf0b20bc0f56808d4fa40"
+  integrity sha512-bA69qo2WkMd5lkFFegYQ1UWHbnOADF0TD6DHiOnabFxHMQYZLB9CkCy4lT/tPAYL2w9WKm6b52ScUPNLTirWeA==
   dependencies:
     "@kitware/vtk.js" "27.3.1"
     detect-gpu "^5.0.22"
     gl-matrix "^3.4.3"
     lodash.clonedeep "4.5.0"
 
-"@cornerstonejs/dicom-image-loader@^0.6.4":
-  version "0.6.4"
-  resolved "https://registry.npmjs.org/@cornerstonejs/dicom-image-loader/-/dicom-image-loader-0.6.4.tgz#8020402b11dd78df52957345ca57ed8c05b2999b"
-  integrity sha512-+y9NklTFYlq61frxKcJ2u+0h9zfKKiv20N28N5qBr3Ie6CFcNrY51ETkujNnNKKRUBvxXDidjVdY+j+MSPPJKQ==
+"@cornerstonejs/dicom-image-loader@^0.6.6":
+  version "0.6.6"
+  resolved "https://registry.yarnpkg.com/@cornerstonejs/dicom-image-loader/-/dicom-image-loader-0.6.6.tgz#086b14e93e67923ea999d7f80c42bf766db3918f"
+  integrity sha512-pdJ5f7/JEX4BAXR2keAAGf6RUfuyzB3vhEvk0T4yDv960TdpT4RZqRjs5acZMs9bkGqY8zAb+c9+Gdz5vypfvg==
   dependencies:
     "@cornerstonejs/codec-charls" "^1.2.3"
     "@cornerstonejs/codec-libjpeg-turbo-8bit" "^1.2.2"
     "@cornerstonejs/codec-openjpeg" "^1.2.2"
     "@cornerstonejs/codec-openjph" "^2.4.2"
-    "@cornerstonejs/core" "^0.46.2"
+    "@cornerstonejs/core" "^0.47.1"
     dicom-parser "^1.8.9"
     pako "^2.0.4"
     uuid "^9.0.0"
 
-"@cornerstonejs/streaming-image-volume-loader@^0.20.2":
-  version "0.20.2"
-  resolved "https://registry.npmjs.org/@cornerstonejs/streaming-image-volume-loader/-/streaming-image-volume-loader-0.20.2.tgz#0df2ed5afd012d2851356af01eed48646d3a6c60"
-  integrity sha512-2TYoJ0wpE9KDpn8adfmTq0xOb/Xg7jhEyOuBnrr3il/NFvOfMlJieJVCYM0v3hyoANfqmDcFBqqtlm346VOMdw==
+"@cornerstonejs/streaming-image-volume-loader@^0.20.4":
+  version "0.20.4"
+  resolved "https://registry.yarnpkg.com/@cornerstonejs/streaming-image-volume-loader/-/streaming-image-volume-loader-0.20.4.tgz#f8d727f2ae7dc0ae3c8975bad2a4f5365743127f"
+  integrity sha512-Zkf/HKatWGf3GPb+0yR7wNPqBHfKXQznpcKsqwFbbMu/SNp7dBcCuvqRVXO5BrJOfnyDeeDpB2+2XRocBnighg==
   dependencies:
-    "@cornerstonejs/core" "^0.46.2"
+    "@cornerstonejs/core" "^0.47.1"
 
-"@cornerstonejs/tools@^0.67.2":
-  version "0.67.2"
-  resolved "https://registry.npmjs.org/@cornerstonejs/tools/-/tools-0.67.2.tgz#7b7c6aac4ec7eaa84a438198837e657328e3c8a2"
-  integrity sha512-nOg2byAVrdMj3DqLYVT7qbrl2Sz6V82xtfFYJ4oQeGul/u/1AvHj4SSZs7MTV63Li3KP2ax/ZghCjral+exaVg==
+"@cornerstonejs/tools@^0.67.4":
+  version "0.67.4"
+  resolved "https://registry.yarnpkg.com/@cornerstonejs/tools/-/tools-0.67.4.tgz#5dfc2d3bacc2be600496cd4e230b1749de59b001"
+  integrity sha512-qeCCtK/xioEBv7l1zqicWQrHdzkFOX4fGNZ5D/TMkQMa+Ed5Zip8gDAcYTbmUvbYXdvkzhoOZeLcPVhoAkDykw==
   dependencies:
-    "@cornerstonejs/core" "^0.46.2"
+    "@cornerstonejs/core" "^0.47.1"
     lodash.clonedeep "4.5.0"
     lodash.get "^4.4.2"
 


### PR DESCRIPTION
### Context

Measurements added to volume viewports of non-acquisition plane display sets are NOT tracked and thus should be rendered with dashed lines.

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

Use dashed lines for measurements of viewports where getCurrentImageId returns undefined since in those cases the images have been generated.
<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

Using OHIF, launch MPR and add measurements to the non-acquisition views. Those should all be rendered with dashed lines. Measurements added to the acquisition plane display sets and tracked should continue to render with solid lines.

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://v3-docs.ohif.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] OS: Windows 11 <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [x] Node version: 16.14.0 <!--[e.g. 16.14.0]"-->
- [x] Browser: 113.0.5672.93
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
