### PR TITLE
fix(Image Download): various bug fixes for image download

### DIFF
--- a/extensions/cornerstone/src/commandsModule.ts
+++ b/extensions/cornerstone/src/commandsModule.ts
@@ -368,6 +368,21 @@ function commandsModule({
     },
     showDownloadViewportModal: () => {
       const { activeViewportIndex } = viewportGridService.getState();
+
+      if (
+        !cornerstoneViewportService.getCornerstoneViewportByIndex(
+          activeViewportIndex
+        )
+      ) {
+        // Cannot download a non-cornerstone viewport (image).
+        uiNotificationService.show({
+          title: 'Download Image',
+          message: 'Image cannot be downloaded',
+          type: 'error',
+        });
+        return;
+      }
+
       const { uiModalService } = servicesManager.services;
 
       if (uiModalService) {

--- a/extensions/cornerstone/src/utils/CornerstoneViewportDownloadForm.tsx
+++ b/extensions/cornerstone/src/utils/CornerstoneViewportDownloadForm.tsx
@@ -217,7 +217,7 @@ const CornerstoneViewportDownloadForm = ({
     );
 
     // add the viewport to the toolGroup
-    toolGroup.addViewport(downloadViewportId);
+    toolGroup.addViewport(downloadViewportId, renderingEngineId);
 
     Object.keys(toolGroup._toolInstances).forEach(toolName => {
       // make all tools Enabled so that they can not be interacted with

--- a/platform/ui/src/components/ViewportDownloadForm/ViewportDownloadForm.tsx
+++ b/platform/ui/src/components/ViewportDownloadForm/ViewportDownloadForm.tsx
@@ -95,11 +95,11 @@ const ViewportDownloadForm = ({
 
   const onKeepAspectToggle = () => {
     const { width, height } = dimensions;
-    const aspectMultiplier = { ...aspectMultiplier };
     if (!keepAspect) {
-      const base = Math.min(width, height);
-      aspectMultiplier.width = width / base;
-      aspectMultiplier.height = height / base;
+      const aspectMultiplier = {
+        width: width / height,
+        height: height / width,
+      };
       setAspectMultiplier(aspectMultiplier);
     }
 
@@ -379,7 +379,7 @@ const ViewportDownloadForm = ({
 
       <div className="mt-8">
         <div
-          className="p-4 rounded bg-secondary-dark border-secondary-primary"
+          className="p-4 rounded bg-secondary-dark border-secondary-primary w-max-content min-w-full"
           data-cy="image-preview"
         >
           <Typography variant="h5">{t('Image preview')}</Typography>


### PR DESCRIPTION

<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://v3-docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

There were various issues with the download image feature...
- pdf and video would crash the client
- keep/dismiss aspect ratio button did not work at all
- show annotations did not work at all; annotations were always excluded
- changing the size of the image made the dialogue a bit awkward

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

- prevented non-cornerstone viewports from showing the image download dialogue
- passed the rendering engine id to ToolGroup.addViewport to fix show annotations
- fixed the keep/dismiss aspect feature
- made some UI better scale to the image width

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

Attempt to use the download image feature with various image types including PDF and video. An error should display for PDF and video.
Use various features of the download image dialogue. They should all work as expected.

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://v3-docs.ohif.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] OS: Windows 11 <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [x] Node version:  16.14.0<!--[e.g. 16.14.0]"-->
- [x] Browser: Chrome 113.0.5672.9
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
