### PR TITLE
fix(Measurement): fixed line dashing of measurements in various scenarios

### DIFF
--- a/extensions/cornerstone-dicom-sr/package.json
+++ b/extensions/cornerstone-dicom-sr/package.json
@@ -46,7 +46,7 @@
     "@babel/runtime": "^7.20.13",
     "classnames": "^2.3.2",
     "@cornerstonejs/adapters": "^0.6.0",
-    "@cornerstonejs/core": "^0.47.1",
-    "@cornerstonejs/tools": "^0.67.4"
+    "@cornerstonejs/core": "^0.47.3",
+    "@cornerstonejs/tools": "^0.67.6"
   }
 }

--- a/extensions/cornerstone/package.json
+++ b/extensions/cornerstone/package.json
@@ -34,7 +34,7 @@
   "peerDependencies": {
     "@ohif/core": "^3.0.0",
     "@ohif/ui": "^2.0.0",
-    "@cornerstonejs/dicom-image-loader": "^0.6.6",
+    "@cornerstonejs/dicom-image-loader": "^0.6.8",
     "@cornerstonejs/codec-charls": "^1.2.3",
     "@cornerstonejs/codec-libjpeg-turbo-8bit": "^1.2.2",
     "@cornerstonejs/codec-openjpeg": "^1.2.2",
@@ -53,9 +53,9 @@
   "dependencies": {
     "@babel/runtime": "^7.20.13",
     "@cornerstonejs/adapters": "^0.6.0",
-    "@cornerstonejs/core": "^0.47.1",
-    "@cornerstonejs/streaming-image-volume-loader": "^0.20.4",
-    "@cornerstonejs/tools": "^0.67.4",
+    "@cornerstonejs/core": "^0.47.3",
+    "@cornerstonejs/streaming-image-volume-loader": "^0.20.6",
+    "@cornerstonejs/tools": "^0.67.6",
     "@kitware/vtk.js": "27.3.1",
     "html2canvas": "^1.4.1",
     "lodash.debounce": "4.0.8",

--- a/extensions/cornerstone/src/Viewport/OHIFCornerstoneViewport.tsx
+++ b/extensions/cornerstone/src/Viewport/OHIFCornerstoneViewport.tsx
@@ -335,13 +335,13 @@ const OHIFCornerstoneViewport = React.memo(props => {
 
       cleanUpServices();
 
+      const viewportInfo = cornerstoneViewportService.getViewportInfoByIndex(
+        viewportIndex
+      );
+
       cornerstoneViewportService.disableElement(viewportIndex);
 
       if (onElementDisabled) {
-        const viewportInfo = cornerstoneViewportService.getViewportInfoByIndex(
-          viewportIndex
-        );
-
         onElementDisabled(viewportInfo);
       }
 

--- a/extensions/measurement-tracking/package.json
+++ b/extensions/measurement-tracking/package.json
@@ -32,8 +32,8 @@
   "peerDependencies": {
     "@ohif/core": "^3.0.0",
     "classnames": "^2.3.2",
-    "@cornerstonejs/core": "^0.47.1",
-    "@cornerstonejs/tools": "^0.67.4",
+    "@cornerstonejs/core": "^0.47.3",
+    "@cornerstonejs/tools": "^0.67.6",
     "@ohif/extension-cornerstone-dicom-sr": "^3.0.0",
     "dcmjs": "^0.29.5",
     "lodash.debounce": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     ]
   },
   "resolutions": {
-    "@cornerstonejs/core": "^0.47.1",
+    "@cornerstonejs/core": "^0.47.3",
     "**/@babel/runtime": "^7.20.13",
     "nth-check": "^2.1.1",
     "trim-newlines": "^5.0.0",

--- a/platform/core/package.json
+++ b/platform/core/package.json
@@ -32,7 +32,7 @@
   },
   "peerDependencies": {
     "cornerstone-math": "0.1.9",
-    "@cornerstonejs/dicom-image-loader": "^0.6.6",
+    "@cornerstonejs/dicom-image-loader": "^0.6.8",
     "@cornerstonejs/codec-charls": "^1.2.3",
     "@cornerstonejs/codec-libjpeg-turbo-8bit": "^1.2.2",
     "@cornerstonejs/codec-openjpeg": "^1.2.2",

--- a/platform/viewer/package.json
+++ b/platform/viewer/package.json
@@ -68,7 +68,7 @@
     "config-point": "^0.4.8",
     "core-js": "^3.16.1",
     "cornerstone-math": "^0.1.9",
-    "@cornerstonejs/dicom-image-loader": "^0.6.6",
+    "@cornerstonejs/dicom-image-loader": "^0.6.8",
     "@cornerstonejs/codec-charls": "^1.2.3",
     "@cornerstonejs/codec-libjpeg-turbo-8bit": "^1.2.2",
     "@cornerstonejs/codec-openjpeg": "^1.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1469,43 +1469,43 @@
   resolved "https://registry.npmjs.org/@cornerstonejs/codec-openjph/-/codec-openjph-2.4.2.tgz#e96721d56f6ec96f7f95c16321d88cc8467d8d81"
   integrity sha512-lgdvBvvNezleY+4pIe2ceUsJzlZe/0PipdeubQ3vZZOz3xxtHHMR1XFCl4fgd8gosR8COHuD7h6q+MwgrwBsng==
 
-"@cornerstonejs/core@^0.47.1":
-  version "0.47.1"
-  resolved "https://registry.yarnpkg.com/@cornerstonejs/core/-/core-0.47.1.tgz#8bbb9d5d8a6cd8a4c0fbf0b20bc0f56808d4fa40"
-  integrity sha512-bA69qo2WkMd5lkFFegYQ1UWHbnOADF0TD6DHiOnabFxHMQYZLB9CkCy4lT/tPAYL2w9WKm6b52ScUPNLTirWeA==
+"@cornerstonejs/core@^0.47.3":
+  version "0.47.3"
+  resolved "https://registry.yarnpkg.com/@cornerstonejs/core/-/core-0.47.3.tgz#3ba0157564b23c3f7f961f35ed8cacb4f3b9b581"
+  integrity sha512-bSJEzrC6xmcwU7zaTl0NqQ9T5n2CYlsDJERKZIn2oTVzwzBMxWEAsFs5v5HuMj4/JrOsE7QkrYSLQpk9c3qX6g==
   dependencies:
     "@kitware/vtk.js" "27.3.1"
     detect-gpu "^5.0.22"
     gl-matrix "^3.4.3"
     lodash.clonedeep "4.5.0"
 
-"@cornerstonejs/dicom-image-loader@^0.6.6":
-  version "0.6.6"
-  resolved "https://registry.yarnpkg.com/@cornerstonejs/dicom-image-loader/-/dicom-image-loader-0.6.6.tgz#086b14e93e67923ea999d7f80c42bf766db3918f"
-  integrity sha512-pdJ5f7/JEX4BAXR2keAAGf6RUfuyzB3vhEvk0T4yDv960TdpT4RZqRjs5acZMs9bkGqY8zAb+c9+Gdz5vypfvg==
+"@cornerstonejs/dicom-image-loader@^0.6.8":
+  version "0.6.8"
+  resolved "https://registry.yarnpkg.com/@cornerstonejs/dicom-image-loader/-/dicom-image-loader-0.6.8.tgz#e9d5c24959d74981b3ccca3641617b2c34106355"
+  integrity sha512-wYKPXprDYgHrsz2tNf2o0UL0Mr4YcUF4xalQqdLxfrgyUExQKHoDigXmEAwNVokSlS7rNz6NplLXeTbNJ2QSwg==
   dependencies:
     "@cornerstonejs/codec-charls" "^1.2.3"
     "@cornerstonejs/codec-libjpeg-turbo-8bit" "^1.2.2"
     "@cornerstonejs/codec-openjpeg" "^1.2.2"
     "@cornerstonejs/codec-openjph" "^2.4.2"
-    "@cornerstonejs/core" "^0.47.1"
+    "@cornerstonejs/core" "^0.47.3"
     dicom-parser "^1.8.9"
     pako "^2.0.4"
     uuid "^9.0.0"
 
-"@cornerstonejs/streaming-image-volume-loader@^0.20.4":
-  version "0.20.4"
-  resolved "https://registry.yarnpkg.com/@cornerstonejs/streaming-image-volume-loader/-/streaming-image-volume-loader-0.20.4.tgz#f8d727f2ae7dc0ae3c8975bad2a4f5365743127f"
-  integrity sha512-Zkf/HKatWGf3GPb+0yR7wNPqBHfKXQznpcKsqwFbbMu/SNp7dBcCuvqRVXO5BrJOfnyDeeDpB2+2XRocBnighg==
+"@cornerstonejs/streaming-image-volume-loader@^0.20.6":
+  version "0.20.6"
+  resolved "https://registry.yarnpkg.com/@cornerstonejs/streaming-image-volume-loader/-/streaming-image-volume-loader-0.20.6.tgz#7ab7905ca0ad9501397f553ce80fe0712971bac0"
+  integrity sha512-lFdCWSVOJR/oU76xOJ7kAfdZzQfSNtCYTcYjuJP1uTBiccwm/MQOdpPgEpgksca1p8qi1PE2zWaQJWtspNtosw==
   dependencies:
-    "@cornerstonejs/core" "^0.47.1"
+    "@cornerstonejs/core" "^0.47.3"
 
-"@cornerstonejs/tools@^0.67.4":
-  version "0.67.4"
-  resolved "https://registry.yarnpkg.com/@cornerstonejs/tools/-/tools-0.67.4.tgz#5dfc2d3bacc2be600496cd4e230b1749de59b001"
-  integrity sha512-qeCCtK/xioEBv7l1zqicWQrHdzkFOX4fGNZ5D/TMkQMa+Ed5Zip8gDAcYTbmUvbYXdvkzhoOZeLcPVhoAkDykw==
+"@cornerstonejs/tools@^0.67.6":
+  version "0.67.6"
+  resolved "https://registry.yarnpkg.com/@cornerstonejs/tools/-/tools-0.67.6.tgz#cb9170d63aa2ea67a452b6184d30333a5024b3c7"
+  integrity sha512-Kq00AQ1/510miDMdl7cE/2pFasLQaQMZFssrkOMlkeX7VYVOePd6ErTiAz/yfSVxxBeocGyquA1ZwWqBxRK1jA==
   dependencies:
-    "@cornerstonejs/core" "^0.47.1"
+    "@cornerstonejs/core" "^0.47.3"
     lodash.clonedeep "4.5.0"
     lodash.get "^4.4.2"
 


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://v3-docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

For a stack viewport, when swapping in a new series either by double click or drag and drop, if the swapped in series had tracked measurements, they were still being rendered with a dashed line.

For a volume viewport (like MPR), the acquisition plane viewport with tracked measurements would render the measurements with dashed lines on first entering MPR; double clicking to/from one up in MPR and swapping in a different series into the MPR view.

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

For a StackViewport simply rely on the SeriesInstanceUID being part of the tracked measurements or not.

For a VolumeViewport first check the image id of the current image in the viewport and then check the SeriesInstanceUID (like for a StackViewport) if an id is returned. To reliably get the id of the current image, listen for the VOLUME_VIEWPORT_NEW_VOLUME event.


<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

Track measurements and swap in a different series and return to the tracked series ensuring measurements are always rendered with the correct dashing.

In MPR, ensure that the plane of acquisition view displays solid line measurements when it is being tracked.
<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://v3-docs.ohif.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] OS: Windows 11 <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [x] Node version: 16.14.0<!--[e.g. 16.14.0]"-->
- [x] Browser: 113.0.5672.127
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
