### PR TITLE
fix(command): Added command and hotkey binding for navigate to next and previous display set.

### DIFF
--- a/extensions/default/src/commandsModule.ts
+++ b/extensions/default/src/commandsModule.ts
@@ -560,7 +560,8 @@ const commandsModule = ({
         'RTDOSE',
       ];
 
-      // Sort the display sets as per the hanging protocol service which is also consistent with the thumbnail list.
+      // Sort the display sets as per the hanging protocol service viewport/display set scoring system.
+      // The thumbnail list uses the same sorting.
       const dsSortFn = hangingProtocolService.getDisplaySetSortFunction();
       const currentDisplaySets = [...displaySetService.activeDisplaySets];
 

--- a/extensions/default/src/commandsModule.ts
+++ b/extensions/default/src/commandsModule.ts
@@ -560,10 +560,11 @@ const commandsModule = ({
         'RTDOSE',
       ];
 
-      const currentDisplaySets = displaySetService.activeDisplaySets;
+      // Sort the display sets as per the hanging protocol service which is also consistent with the thumbnail list.
+      const dsSortFn = hangingProtocolService.getDisplaySetSortFunction();
+      const currentDisplaySets = [...displaySetService.activeDisplaySets];
 
-      // Sort the display sets as per the thumbnail/study browser list
-      utils.sortBySeriesDate(currentDisplaySets);
+      currentDisplaySets.sort(dsSortFn);
 
       const { activeViewportIndex, viewports } = viewportGridService.getState();
 

--- a/extensions/default/src/commandsModule.ts
+++ b/extensions/default/src/commandsModule.ts
@@ -547,6 +547,27 @@ const commandsModule = ({
       }
     },
 
+    scrollActiveThumbnailIntoView: () => {
+      const { activeViewportIndex, viewports } = viewportGridService.getState();
+
+      if (
+        !viewports ||
+        activeViewportIndex < 0 ||
+        activeViewportIndex > viewports.length - 1
+      ) {
+        return;
+      }
+
+      const activeViewport = viewports[activeViewportIndex];
+      const activeDisplaySetInstanceUID =
+        activeViewport.displaySetInstanceUIDs[0];
+
+      const thumbnail = document.querySelector(
+        `#thumbnail-${activeDisplaySetInstanceUID}`
+      );
+      thumbnail.scrollIntoView({ behavior: 'smooth' });
+    },
+
     updateViewportDisplaySet: ({
       direction,
       excludeNonImageModalities,
@@ -623,6 +644,8 @@ const commandsModule = ({
       }
 
       viewportGridService.setDisplaySetsForViewports(updatedViewports);
+
+      setTimeout(() => actions.scrollActiveThumbnailIntoView(), 0);
     },
   };
 

--- a/extensions/default/src/commandsModule.ts
+++ b/extensions/default/src/commandsModule.ts
@@ -565,7 +565,7 @@ const commandsModule = ({
       const thumbnail = document.querySelector(
         `#thumbnail-${activeDisplaySetInstanceUID}`
       );
-      thumbnail.scrollIntoView({ behavior: 'smooth' });
+      thumbnail?.scrollIntoView({ behavior: 'smooth' });
     },
 
     updateViewportDisplaySet: ({

--- a/extensions/default/src/commandsModule.ts
+++ b/extensions/default/src/commandsModule.ts
@@ -562,10 +562,33 @@ const commandsModule = ({
       const activeDisplaySetInstanceUID =
         activeViewport.displaySetInstanceUIDs[0];
 
+      const thumbnailList = document.querySelector('#ohif-thumbnail-list');
+
+      if (!thumbnailList) {
+        return;
+      }
+
+      const thumbnailListBounds = thumbnailList.getBoundingClientRect();
+
       const thumbnail = document.querySelector(
         `#thumbnail-${activeDisplaySetInstanceUID}`
       );
-      thumbnail?.scrollIntoView({ behavior: 'smooth' });
+
+      if (!thumbnail) {
+        return;
+      }
+
+      const thumbnailBounds = thumbnail.getBoundingClientRect();
+
+      // This only handles a vertical thumbnail list.
+      if (
+        thumbnailBounds.top >= thumbnailListBounds.top &&
+        thumbnailBounds.top <= thumbnailListBounds.bottom
+      ) {
+        return;
+      }
+
+      thumbnail.scrollIntoView({ behavior: 'smooth' });
     },
 
     updateViewportDisplaySet: ({

--- a/extensions/measurement-tracking/src/panels/PanelStudyBrowserTracking/PanelStudyBrowserTracking.tsx
+++ b/extensions/measurement-tracking/src/panels/PanelStudyBrowserTracking/PanelStudyBrowserTracking.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { utils } from '@ohif/core';
+import { HangingProtocolService, utils } from '@ohif/core';
 import {
   StudyBrowser,
   useImageViewer,
@@ -292,7 +292,8 @@ function PanelStudyBrowserTracking({
   const tabs = _createStudyBrowserTabs(
     StudyInstanceUIDs,
     studyDisplayList,
-    displaySets
+    displaySets,
+    hangingProtocolService
   );
 
   // TODO: Should not fire this on "close"
@@ -601,7 +602,8 @@ function _getComponentType(Modality) {
 function _createStudyBrowserTabs(
   primaryStudyInstanceUIDs,
   studyDisplayList,
-  displaySets
+  displaySets,
+  hangingProtocolService
 ) {
   const primaryStudies = [];
   const recentStudies = [];
@@ -615,9 +617,8 @@ function _createStudyBrowserTabs(
     );
 
     // Sort them
-    const sortedDisplaySetsForStudy = utils.sortBySeriesDate(
-      displaySetsForStudy
-    );
+    const dsSortFn = hangingProtocolService.getDisplaySetSortFunction();
+    displaySetsForStudy.sort(dsSortFn);
 
     /* Sort by series number, then by series date
       displaySetsForStudy.sort((a, b) => {

--- a/platform/core/src/defaults/hotkeyBindings.js
+++ b/platform/core/src/defaults/hotkeyBindings.js
@@ -76,18 +76,24 @@ const bindings = [
     keys: ['left'],
     isEditable: true,
   },
-  // {
-  //   commandName: 'nextViewportDisplaySet',
-  //   label: 'Next Series',
-  //   keys: ['pageup'],
-  //   isEditable: true,
-  // },
-  // {
-  //   commandName: 'previousViewportDisplaySet',
-  //   label: 'Previous Series',
-  //   keys: ['pagedown'],
-  //   isEditable: true,
-  // },
+  {
+    commandName: 'updateViewportDisplaySet',
+    commandOptions: {
+      direction: -1,
+    },
+    label: 'Previous Series',
+    keys: ['pageup'],
+    isEditable: true,
+  },
+  {
+    commandName: 'updateViewportDisplaySet',
+    commandOptions: {
+      direction: 1,
+    },
+    label: 'Next Series',
+    keys: ['pagedown'],
+    isEditable: true,
+  },
   {
     commandName: 'nextStage',
     context: 'DEFAULT',

--- a/platform/core/src/services/HangingProtocolService/HangingProtocolService.ts
+++ b/platform/core/src/services/HangingProtocolService/HangingProtocolService.ts
@@ -1034,6 +1034,25 @@ export default class HangingProtocolService extends PubSubService {
   }
 
   /**
+   * Gets a sort function that is consistent with the display set sorting performed
+   * to match display sets to viewports.
+   * @returns a display set sort function
+   */
+  public getDisplaySetSortFunction(): (
+    displaySetA: IDisplaySet,
+    displaySetB: IDisplaySet
+  ) => number {
+    const sortingFunction = (displaySetA, displaySetB) => {
+      const seriesA = this._getDisplaySetSortInfo(displaySetA);
+      const seriesB = this._getDisplaySetSortInfo(displaySetB);
+
+      return sortBy(this._getDisplaySetSortByField())(seriesA, seriesB);
+    };
+
+    return sortingFunction;
+  }
+
+  /**
    * Updates the viewports with the selected protocol stage.
    */
   _updateViewports(options = null as HangingProtocol.SetProtocolOptions): void {
@@ -1461,7 +1480,7 @@ export default class HangingProtocolService extends PubSubService {
           sortingInfo: {
             score: totalMatchScore,
             study: study.StudyInstanceUID,
-            series: parseInt(displaySet.SeriesNumber),
+            ...this._getDisplaySetSortInfo(displaySet),
           },
         };
 
@@ -1484,9 +1503,7 @@ export default class HangingProtocolService extends PubSubService {
         name: 'study',
         reverse: true,
       },
-      {
-        name: 'series',
-      }
+      this._getDisplaySetSortByField()
     );
     matchingScores.sort((a, b) =>
       sortingFunction(a.sortingInfo, b.sortingInfo)
@@ -1504,6 +1521,19 @@ export default class HangingProtocolService extends PubSubService {
       bestMatch,
       matchingScores,
     };
+  }
+
+  private _getDisplaySetSortInfo(displaySet) {
+    return {
+      [this._getDisplaySetSortByField().name]:
+        displaySet.SeriesNumber != null
+          ? parseInt(displaySet.SeriesNumber)
+          : parseInt(displaySet.seriesNumber),
+    };
+  }
+
+  private _getDisplaySetSortByField() {
+    return { name: 'series' };
   }
 
   /**

--- a/platform/core/src/services/HangingProtocolService/HangingProtocolService.ts
+++ b/platform/core/src/services/HangingProtocolService/HangingProtocolService.ts
@@ -1042,14 +1042,12 @@ export default class HangingProtocolService extends PubSubService {
     displaySetA: IDisplaySet,
     displaySetB: IDisplaySet
   ) => number {
-    const sortingFunction = (displaySetA, displaySetB) => {
-      const seriesA = this._getDisplaySetSortInfo(displaySetA);
-      const seriesB = this._getDisplaySetSortInfo(displaySetB);
+    return (displaySetA, displaySetB) => {
+      const seriesA = this._getSeriesSortInfoForDisplaySetSort(displaySetA);
+      const seriesB = this._getSeriesSortInfoForDisplaySetSort(displaySetB);
 
-      return sortBy(this._getDisplaySetSortByField())(seriesA, seriesB);
+      return sortBy(this._getSeriesFieldForDisplaySetSort())(seriesA, seriesB);
     };
-
-    return sortingFunction;
   }
 
   /**
@@ -1480,7 +1478,7 @@ export default class HangingProtocolService extends PubSubService {
           sortingInfo: {
             score: totalMatchScore,
             study: study.StudyInstanceUID,
-            ...this._getDisplaySetSortInfo(displaySet),
+            ...this._getSeriesSortInfoForDisplaySetSort(displaySet),
           },
         };
 
@@ -1503,7 +1501,7 @@ export default class HangingProtocolService extends PubSubService {
         name: 'study',
         reverse: true,
       },
-      this._getDisplaySetSortByField()
+      this._getSeriesFieldForDisplaySetSort()
     );
     matchingScores.sort((a, b) =>
       sortingFunction(a.sortingInfo, b.sortingInfo)
@@ -1523,16 +1521,16 @@ export default class HangingProtocolService extends PubSubService {
     };
   }
 
-  private _getDisplaySetSortInfo(displaySet) {
+  private _getSeriesSortInfoForDisplaySetSort(displaySet) {
     return {
-      [this._getDisplaySetSortByField().name]:
+      [this._getSeriesFieldForDisplaySetSort().name]:
         displaySet.SeriesNumber != null
           ? parseInt(displaySet.SeriesNumber)
           : parseInt(displaySet.seriesNumber),
     };
   }
 
-  private _getDisplaySetSortByField() {
+  private _getSeriesFieldForDisplaySetSort() {
     return { name: 'series' };
   }
 

--- a/platform/ui/src/components/ThumbnailList/ThumbnailList.tsx
+++ b/platform/ui/src/components/ThumbnailList/ThumbnailList.tsx
@@ -12,7 +12,10 @@ const ThumbnailList = ({
   activeDisplaySetInstanceUIDs = [],
 }) => {
   return (
-    <div className="py-3 bg-black overflow-y-hidden ohif-scrollbar study-min-height">
+    <div
+      id="ohif-thumbnail-list"
+      className="py-3 bg-black overflow-y-hidden ohif-scrollbar study-min-height"
+    >
       {thumbnails.map(
         ({
           displaySetInstanceUID,


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://v3-docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

In prior versions of OHIF, it was possible to associate a button with a command to navigate the series in the active viewport forward or backward.

See https://github.com/OHIF/Viewers/issues/3112
<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

The `updateViewportDisplaySet` command was added to match the equivalent command in v2. `PgUp` and `PgDn` hotkey bindings were added to navigate to the previous and next display sets respectively. An option was included to exclude non-image modalities for the navigation.

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

View a multi-series study in OHIF and use the `PgUp` and `PgDn` keys to navigate the series in the active viewport.
<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://v3-docs.ohif.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] OS: Windows 11 <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [x] Node version: 16.14.0<!--[e.g. 16.14.0]"-->
- [x] Browser: Chrome 113.0.5672.127
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
