### PR TITLE
Fix saving of SR with calibration

### DIFF
--- a/extensions/cornerstone/src/tools/CalibrationLineTool.ts
+++ b/extensions/cornerstone/src/tools/CalibrationLineTool.ts
@@ -70,29 +70,14 @@ export function onCompletedCalibrationLine(servicesManager, csToolsEvent) {
       ) * 100
     ) / 100;
 
-  // calculate the currently applied pixel spacing on the viewport
-  const calibratedPixelSpacing = metaData.get(
-    'calibratedPixelSpacing',
-    imageId
-  );
-  const imagePlaneModule = metaData.get('imagePlaneModule', imageId);
-  const currentRowPixelSpacing =
-    calibratedPixelSpacing?.[0] || imagePlaneModule?.rowPixelSpacing || 1;
-  const currentColumnPixelSpacing =
-    calibratedPixelSpacing?.[1] || imagePlaneModule?.columnPixelSpacing || 1;
-
   const adjustCalibration = newLength => {
     const spacingScale = newLength / length;
-    const rowSpacing = spacingScale * currentRowPixelSpacing;
-    const colSpacing = spacingScale * currentColumnPixelSpacing;
 
     // trigger resize of the viewport to adjust the world/pixel mapping
-    calibrateImageSpacing(
-      imageId,
-      viewport.getRenderingEngine(),
-      rowSpacing,
-      colSpacing
-    );
+    calibrateImageSpacing(imageId, viewport.getRenderingEngine(), {
+      type: 'User',
+      scale: 1 / spacingScale,
+    });
   };
 
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
### Context

Update to go along with changes to how the calibration gets applied - just use a scale value instead of messing around with units.

### Changes & Results

Call the new scale API.
Needs the updated CS3D libraries.

### Testing

Use the calibraiton line tool, it should work as expected (no functional change)
Save a DICOM SR after calibrating.  The SR viewport should show exactly what was saved, but the calibration will not be restored after loading.

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] OS: <!--[e.g. Windows 10, macOS 10.15.4]-->
- [] Node version: <!--[e.g. 16.14.0]-->
- [] Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
