### PR TITLE
Add edit prevention in OHIF

### DIFF
--- a/extensions/cornerstone-dicom-rt/src/index.tsx
+++ b/extensions/cornerstone-dicom-rt/src/index.tsx
@@ -36,12 +36,14 @@ const extension: Types.Extensions.Extension = {
   getViewportModule({
     servicesManager,
     extensionManager,
+    appConfig,
   }: Types.Extensions.ExtensionParams) {
     const ExtendedOHIFCornerstoneRTViewport = props => {
       return (
         <OHIFCornerstoneRTViewport
           servicesManager={servicesManager}
           extensionManager={extensionManager}
+          appConfig={appConfig}
           {...props}
         />
       );

--- a/extensions/cornerstone-dicom-rt/src/viewports/OHIFCornerstoneRTViewport.tsx
+++ b/extensions/cornerstone-dicom-rt/src/viewports/OHIFCornerstoneRTViewport.tsx
@@ -25,6 +25,7 @@ function OHIFCornerstoneRTViewport(props) {
     viewportLabel,
     servicesManager,
     extensionManager,
+    appConfig,
   } = props;
 
   const {
@@ -42,6 +43,7 @@ function OHIFCornerstoneRTViewport(props) {
     throw new Error('RT viewport should only have a single display set');
   }
 
+  const disableHydration = appConfig?.disableHydration;
   const rtDisplaySet = displaySets[0];
 
   const [viewportGrid, viewportGridService] = useViewportGrid();
@@ -151,15 +153,17 @@ function OHIFCornerstoneRTViewport(props) {
       return;
     }
 
-    promptHydrateRT({
-      servicesManager,
-      viewportIndex,
-      rtDisplaySet,
-    }).then(isHydrated => {
-      if (isHydrated) {
-        setIsHydrated(true);
-      }
-    });
+    if (!disableHydration) {
+      promptHydrateRT({
+        servicesManager,
+        viewportIndex,
+        rtDisplaySet,
+      }).then(isHydrated => {
+        if (isHydrated) {
+          setIsHydrated(true);
+        }
+      });
+    }
   }, [servicesManager, viewportIndex, rtDisplaySet, rtIsLoading]);
 
   useEffect(() => {
@@ -266,6 +270,12 @@ function OHIFCornerstoneRTViewport(props) {
     };
   }, [rtDisplaySet]);
 
+  const isSegmentationReady = () => {
+    return segmentationService.getSegmentation(
+      rtDisplaySet.displaySetInstanceUID
+    );
+  };
+
   // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   let childrenWithProps = null;
 
@@ -312,6 +322,9 @@ function OHIFCornerstoneRTViewport(props) {
     setIsHydrated(isHydrated);
   };
 
+  if (isSegmentationReady() && disableHydration) {
+    onStatusClick();
+  }
   return (
     <>
       <ViewportActionBar

--- a/extensions/cornerstone-dicom-seg/src/index.tsx
+++ b/extensions/cornerstone-dicom-seg/src/index.tsx
@@ -65,12 +65,13 @@ const extension = {
     ];
   },
 
-  getViewportModule({ servicesManager, extensionManager }) {
+  getViewportModule({ servicesManager, extensionManager, appConfig }) {
     const ExtendedOHIFCornerstoneSEGViewport = props => {
       return (
         <OHIFCornerstoneSEGViewport
           servicesManager={servicesManager}
           extensionManager={extensionManager}
+          appConfig={appConfig}
           {...props}
         />
       );

--- a/extensions/cornerstone-dicom-seg/src/index.tsx
+++ b/extensions/cornerstone-dicom-seg/src/index.tsx
@@ -41,6 +41,7 @@ const extension = {
     servicesManager,
     commandsManager,
     extensionManager,
+    appConfig,
   }): Types.Panel[] => {
     const wrappedPanelSegmentation = () => {
       return (
@@ -48,6 +49,7 @@ const extension = {
           commandsManager={commandsManager}
           servicesManager={servicesManager}
           extensionManager={extensionManager}
+          appConfig={appConfig}
         />
       );
     };

--- a/extensions/cornerstone-dicom-seg/src/panels/PanelSegmentation.tsx
+++ b/extensions/cornerstone-dicom-seg/src/panels/PanelSegmentation.tsx
@@ -2,20 +2,16 @@ import React, { useEffect, useState, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { SegmentationGroupTable } from '@ohif/ui';
 import callInputDialog from './callInputDialog';
-
 import { useTranslation } from 'react-i18next';
 
 export default function PanelSegmentation({
   servicesManager,
   commandsManager,
   extensionManager,
+  appConfig,
 }) {
-  const {
-    segmentationService,
-    uiDialogService,
-    uiNotificationService,
-  } = servicesManager.services;
-  const disableEditing = extensionManager._appConfig?.disableEditing;
+  const { segmentationService, uiDialogService } = servicesManager.services;
+  const disableEditing = appConfig?.disableEditing;
 
   const { t } = useTranslation('PanelSegmentation');
   const [selectedSegmentationId, setSelectedSegmentationId] = useState(null);
@@ -73,13 +69,6 @@ export default function PanelSegmentation({
     };
   }, []);
 
-  const disableEditingNotification = () => {
-    uiNotificationService.show({
-      title: 'Segmentation Edit',
-      message: 'Segmentation editing is disabled in this viewer.',
-      type: 'error',
-    });
-  };
   const onSegmentationClick = (segmentationId: string) => {
     segmentationService.setActiveSegmentationForToolGroup(segmentationId);
   };
@@ -225,13 +214,10 @@ export default function PanelSegmentation({
           activeSegmentationId={selectedSegmentationId || ''}
           onSegmentationClick={onSegmentationClick}
           onSegmentationDelete={onSegmentationDelete}
-          onSegmentationEdit={
-            disableEditing ? disableEditingNotification : onSegmentationEdit
-          }
+          onSegmentationEdit={onSegmentationEdit}
           onSegmentClick={onSegmentClick}
-          onSegmentEdit={
-            disableEditing ? disableEditingNotification : onSegmentEdit
-          }
+          onSegmentEdit={onSegmentEdit}
+          disableEditing={disableEditing}
           onSegmentColorClick={onSegmentColorClick}
           onSegmentDelete={onSegmentDelete}
           onToggleSegmentVisibility={onToggleSegmentVisibility}
@@ -297,6 +283,8 @@ PanelSegmentation.propTypes = {
   commandsManager: PropTypes.shape({
     runCommand: PropTypes.func.isRequired,
   }),
+  appConfig: PropTypes.object.isRequired,
+  extensionManager: PropTypes.object,
   servicesManager: PropTypes.shape({
     services: PropTypes.shape({
       segmentationService: PropTypes.shape({

--- a/extensions/cornerstone-dicom-seg/src/panels/PanelSegmentation.tsx
+++ b/extensions/cornerstone-dicom-seg/src/panels/PanelSegmentation.tsx
@@ -8,8 +8,14 @@ import { useTranslation } from 'react-i18next';
 export default function PanelSegmentation({
   servicesManager,
   commandsManager,
+  extensionManager,
 }) {
-  const { segmentationService, uiDialogService } = servicesManager.services;
+  const {
+    segmentationService,
+    uiDialogService,
+    uiNotificationService,
+  } = servicesManager.services;
+  const disableEditing = extensionManager._appConfig?.disableEditing;
 
   const { t } = useTranslation('PanelSegmentation');
   const [selectedSegmentationId, setSelectedSegmentationId] = useState(null);
@@ -67,6 +73,13 @@ export default function PanelSegmentation({
     };
   }, []);
 
+  const disableEditingNotification = () => {
+    uiNotificationService.show({
+      title: 'Segmentation Edit',
+      message: 'Segmentation editing is disabled in this viewer.',
+      type: 'error',
+    });
+  };
   const onSegmentationClick = (segmentationId: string) => {
     segmentationService.setActiveSegmentationForToolGroup(segmentationId);
   };
@@ -111,37 +124,49 @@ export default function PanelSegmentation({
     const segment = segmentation.segments[segmentIndex];
     const { label } = segment;
 
-    callInputDialog(uiDialogService, label, (label, actionId) => {
-      if (label === '') {
-        return;
-      }
+    callInputDialog(
+      uiDialogService,
+      'Segment',
+      'Enter the segment label',
+      label,
+      (label, actionId) => {
+        if (label === '') {
+          return;
+        }
 
-      segmentationService.setSegmentLabelForSegmentation(
-        segmentationId,
-        segmentIndex,
-        label
-      );
-    });
+        segmentationService.setSegmentLabelForSegmentation(
+          segmentationId,
+          segmentIndex,
+          label
+        );
+      }
+    );
   };
 
   const onSegmentationEdit = segmentationId => {
     const segmentation = segmentationService.getSegmentation(segmentationId);
     const { label } = segmentation;
 
-    callInputDialog(uiDialogService, label, (label, actionId) => {
-      if (label === '') {
-        return;
-      }
+    callInputDialog(
+      uiDialogService,
+      'Segmentation',
+      'Enter the segmentation label',
+      label,
+      (label, actionId) => {
+        if (label === '') {
+          return;
+        }
 
-      segmentationService.addOrUpdateSegmentation(
-        {
-          id: segmentationId,
-          label,
-        },
-        false, // suppress event
-        true // notYetUpdatedAtSource
-      );
-    });
+        segmentationService.addOrUpdateSegmentation(
+          {
+            id: segmentationId,
+            label,
+          },
+          false, // suppress event
+          true // notYetUpdatedAtSource
+        );
+      }
+    );
   };
 
   const onSegmentColorClick = (segmentationId, segmentIndex) => {
@@ -200,9 +225,13 @@ export default function PanelSegmentation({
           activeSegmentationId={selectedSegmentationId || ''}
           onSegmentationClick={onSegmentationClick}
           onSegmentationDelete={onSegmentationDelete}
-          onSegmentationEdit={onSegmentationEdit}
+          onSegmentationEdit={
+            disableEditing ? disableEditingNotification : onSegmentationEdit
+          }
           onSegmentClick={onSegmentClick}
-          onSegmentEdit={onSegmentEdit}
+          onSegmentEdit={
+            disableEditing ? disableEditingNotification : onSegmentEdit
+          }
           onSegmentColorClick={onSegmentColorClick}
           onSegmentDelete={onSegmentDelete}
           onToggleSegmentVisibility={onToggleSegmentVisibility}

--- a/extensions/cornerstone-dicom-seg/src/panels/callInputDialog.tsx
+++ b/extensions/cornerstone-dicom-seg/src/panels/callInputDialog.tsx
@@ -1,7 +1,13 @@
 import React from 'react';
 import { Input, Dialog, ButtonEnums } from '@ohif/ui';
 
-function callInputDialog(uiDialogService, label, callback) {
+function callInputDialog(
+  uiDialogService,
+  dialogTitle,
+  dialogLabel,
+  inputLabel,
+  callback
+) {
   const dialogId = 'enter-segment-label';
 
   const onSubmitHandler = ({ action, value }) => {
@@ -24,8 +30,8 @@ function callInputDialog(uiDialogService, label, callback) {
       showOverlay: true,
       content: Dialog,
       contentProps: {
-        title: 'Segment',
-        value: { label },
+        title: dialogTitle,
+        value: { inputLabel },
         noCloseButton: true,
         onClose: () => uiDialogService.dismiss({ id: dialogId }),
         actions: [
@@ -36,7 +42,7 @@ function callInputDialog(uiDialogService, label, callback) {
         body: ({ value, setValue }) => {
           return (
             <Input
-              label="Enter the segment label"
+              label={dialogLabel}
               labelClassName="text-white text-[14px] leading-[1.2]"
               autoFocus
               className="bg-black border-primary-main"

--- a/extensions/cornerstone-dicom-sr/src/index.tsx
+++ b/extensions/cornerstone-dicom-sr/src/index.tsx
@@ -43,12 +43,13 @@ const dicomSRExtension = {
    * @param {object} [configuration={}]
    * @param {object|array} [configuration.csToolsConfig] - Passed directly to `initCornerstoneTools`
    */
-  getViewportModule({ servicesManager, extensionManager }) {
+  getViewportModule({ servicesManager, extensionManager, appConfig }) {
     const ExtendedOHIFCornerstoneSRViewport = props => {
       return (
         <OHIFCornerstoneSRViewport
           servicesManager={servicesManager}
           extensionManager={extensionManager}
+          appConfig={appConfig}
           {...props}
         />
       );

--- a/extensions/cornerstone-dicom-sr/src/utils/hydrateStructuredReport.js
+++ b/extensions/cornerstone-dicom-sr/src/utils/hydrateStructuredReport.js
@@ -2,6 +2,8 @@ import { utilities, metaData } from '@cornerstonejs/core';
 import OHIF, { DicomMetadataStore } from '@ohif/core';
 import getLabelFromDCMJSImportedToolData from './getLabelFromDCMJSImportedToolData';
 import { adaptersSR } from '@cornerstonejs/adapters';
+import { annotation as CsAnnotation } from '@cornerstonejs/tools';
+const { locking } = CsAnnotation;
 
 const { guid } = OHIF.utils;
 const { MeasurementReport, CORNERSTONE_3D_TAG } = adaptersSR.Cornerstone3D;
@@ -35,9 +37,10 @@ const convertSites = (codingValues, sites) => {
  *
  */
 export default function hydrateStructuredReport(
-  { servicesManager, extensionManager },
+  { servicesManager, extensionManager, appConfig },
   displaySetInstanceUID
 ) {
+  const annotationManager = CsAnnotation.state.getAnnotationManager();
   const dataSource = extensionManager.getActiveDataSource()[0];
   const {
     measurementService,
@@ -45,6 +48,7 @@ export default function hydrateStructuredReport(
     customizationService,
   } = servicesManager.services;
 
+  const disableEditing = appConfig?.disableEditing;
   const codingValues = customizationService.getCustomization(
     'codingValues',
     {}
@@ -212,13 +216,20 @@ export default function hydrateStructuredReport(
         m => m.annotationType === annotationType
       );
 
-      measurementService.addRawMeasurement(
+      const newAnnotationUID = measurementService.addRawMeasurement(
         source,
         annotationType,
         { annotation },
         matchingMapping.toMeasurementSchema,
         dataSource
       );
+
+      if (disableEditing) {
+        const addedAnnotation = annotationManager.getAnnotation(
+          newAnnotationUID
+        );
+        locking.setAnnotationLocked(addedAnnotation, true);
+      }
 
       if (!imageIds.includes(imageId)) {
         imageIds.push(imageId);

--- a/extensions/cornerstone-dicom-sr/src/viewports/OHIFCornerstoneSRViewport.tsx
+++ b/extensions/cornerstone-dicom-sr/src/viewports/OHIFCornerstoneSRViewport.tsx
@@ -33,6 +33,7 @@ function OHIFCornerstoneSRViewport(props) {
     cornerstoneViewportService,
     measurementService,
   } = servicesManager.services;
+  const disableHydration = appConfig?.disableHydration;
 
   // SR viewport will always have a single display set
   if (displaySets.length > 1) {
@@ -376,6 +377,7 @@ function OHIFCornerstoneSRViewport(props) {
             isRehydratable: srDisplaySet.isRehydratable,
             isLocked,
             sendTrackedMeasurementsEvent,
+            disableHydration,
           })
         }
         studyData={{
@@ -465,6 +467,7 @@ function _getStatusComponent({
   isRehydratable,
   isLocked,
   sendTrackedMeasurementsEvent,
+  disableHydration,
 }) {
   const handleMouseUp = () => {
     sendTrackedMeasurementsEvent('HYDRATE_SR', {
@@ -535,6 +538,9 @@ function _getStatusComponent({
     </div>
   );
 
+  if (disableHydration) {
+    handleMouseUp();
+  }
   return (
     <>
       {ToolTipMessage && (

--- a/extensions/cornerstone-dicom-sr/src/viewports/OHIFCornerstoneSRViewport.tsx
+++ b/extensions/cornerstone-dicom-sr/src/viewports/OHIFCornerstoneSRViewport.tsx
@@ -25,6 +25,7 @@ function OHIFCornerstoneSRViewport(props) {
     viewportOptions,
     servicesManager,
     extensionManager,
+    appConfig,
   } = props;
 
   const {
@@ -76,7 +77,7 @@ function OHIFCornerstoneSRViewport(props) {
     sendTrackedMeasurementsEvent = (eventName, { displaySetInstanceUID }) => {
       measurementService.clearMeasurements();
       const { SeriesInstanceUIDs } = hydrateStructuredReport(
-        { servicesManager, extensionManager },
+        { servicesManager, extensionManager, appConfig },
         displaySetInstanceUID
       );
       const displaySets = displaySetService.getDisplaySetsForSeries(
@@ -417,6 +418,7 @@ OHIFCornerstoneSRViewport.propTypes = {
   customProps: PropTypes.object,
   viewportOptions: PropTypes.object,
   viewportLabel: PropTypes.string,
+  appConfig: PropTypes.object,
   servicesManager: PropTypes.instanceOf(ServicesManager).isRequired,
   extensionManager: PropTypes.instanceOf(ExtensionManager).isRequired,
 };

--- a/extensions/measurement-tracking/src/contexts/TrackedMeasurementsContext/TrackedMeasurementsContext.tsx
+++ b/extensions/measurement-tracking/src/contexts/TrackedMeasurementsContext/TrackedMeasurementsContext.tsx
@@ -26,7 +26,7 @@ const SR_SOPCLASSHANDLERID =
  * @param {*} param0
  */
 function TrackedMeasurementsContextProvider(
-  { servicesManager, commandsManager, extensionManager }, // Bound by consumer
+  { servicesManager, commandsManager, extensionManager, appConfig }, // Bound by consumer
   { children } // Component props
 ) {
   const [viewportGrid, viewportGridService] = useViewportGrid();
@@ -142,6 +142,7 @@ function TrackedMeasurementsContextProvider(
     promptHydrateStructuredReport: promptHydrateStructuredReport.bind(null, {
       servicesManager,
       extensionManager,
+      appConfig,
     }),
     hydrateStructuredReport: hydrateStructuredReport.bind(null, {
       servicesManager,
@@ -245,6 +246,7 @@ TrackedMeasurementsContextProvider.propTypes = {
   servicesManager: PropTypes.object.isRequired,
   commandsManager: PropTypes.object.isRequired,
   extensionManager: PropTypes.object.isRequired,
+  appConfig: PropTypes.object,
 };
 
 export {

--- a/extensions/measurement-tracking/src/contexts/TrackedMeasurementsContext/promptHydrateStructuredReport.js
+++ b/extensions/measurement-tracking/src/contexts/TrackedMeasurementsContext/promptHydrateStructuredReport.js
@@ -12,7 +12,7 @@ const RESPONSE = {
 };
 
 function promptHydrateStructuredReport(
-  { servicesManager, extensionManager },
+  { servicesManager, extensionManager, appConfig },
   ctx,
   evt
 ) {
@@ -25,7 +25,7 @@ function promptHydrateStructuredReport(
     displaySetInstanceUID
   );
 
-  return new Promise(async function(resolve, reject) {
+  return new Promise(async function (resolve, reject) {
     const promptResult = await _askTrackMeasurements(
       uiViewportDialogService,
       viewportIndex
@@ -37,7 +37,7 @@ function promptHydrateStructuredReport(
     if (promptResult === RESPONSE.HYDRATE_REPORT) {
       console.warn('!! HYDRATING STRUCTURED REPORT');
       const hydrationResult = hydrateStructuredReport(
-        { servicesManager, extensionManager },
+        { servicesManager, extensionManager, appConfig },
         displaySetInstanceUID
       );
 
@@ -57,7 +57,7 @@ function promptHydrateStructuredReport(
 }
 
 function _askTrackMeasurements(uiViewportDialogService, viewportIndex) {
-  return new Promise(function(resolve, reject) {
+  return new Promise(function (resolve, reject) {
     const message =
       'Do you want to continue tracking measurements for this study?';
     const actions = [

--- a/extensions/measurement-tracking/src/contexts/TrackedMeasurementsContext/promptHydrateStructuredReport.js
+++ b/extensions/measurement-tracking/src/contexts/TrackedMeasurementsContext/promptHydrateStructuredReport.js
@@ -26,10 +26,15 @@ function promptHydrateStructuredReport(
   );
 
   return new Promise(async function (resolve, reject) {
-    const promptResult = await _askTrackMeasurements(
-      uiViewportDialogService,
-      viewportIndex
-    );
+    let promptResult;
+    if (appConfig?.disableHydration) {
+      promptResult = RESPONSE.HYDRATE_REPORT;
+    } else {
+      promptResult = await _askTrackMeasurements(
+        uiViewportDialogService,
+        viewportIndex
+      );
+    }
 
     // Need to do action here... So we can set state...
     let StudyInstanceUID, SeriesInstanceUIDs;

--- a/extensions/measurement-tracking/src/getContextModule.tsx
+++ b/extensions/measurement-tracking/src/getContextModule.tsx
@@ -8,10 +8,11 @@ function getContextModule({
   servicesManager,
   extensionManager,
   commandsManager,
+  appConfig,
 }) {
   const BoundTrackedMeasurementsContextProvider = TrackedMeasurementsContextProvider.bind(
     null,
-    { servicesManager, extensionManager, commandsManager }
+    { servicesManager, extensionManager, commandsManager, appConfig }
   );
 
   return [

--- a/platform/app/public/config/default.js
+++ b/platform/app/public/config/default.js
@@ -1,4 +1,5 @@
 window.config = {
+  disableHydration: true,
   disableEditing: true,
   routerBasename: '/',
   // whiteLabeling: {},

--- a/platform/app/public/config/default.js
+++ b/platform/app/public/config/default.js
@@ -1,4 +1,5 @@
 window.config = {
+  disableEditing: true,
   routerBasename: '/',
   // whiteLabeling: {},
   extensions: [],

--- a/platform/app/src/routes/Mode/Mode.tsx
+++ b/platform/app/src/routes/Mode/Mode.tsx
@@ -329,12 +329,6 @@ export default function ModeRoute({
         commandsManager,
       });
 
-      const disableEditing = extensionManager._appConfig?.disableEditing;
-      if (disableEditing) {
-        const { toolbarService } = servicesManager.services;
-        toolbarService.disableButtonInSection('primary', 'MeasurementTools');
-      }
-
       /**
        * The next line should get all the query parameters provided by the URL
        * - except the StudyInstanceUIDs - and create an object called filters

--- a/platform/app/src/routes/Mode/Mode.tsx
+++ b/platform/app/src/routes/Mode/Mode.tsx
@@ -329,6 +329,12 @@ export default function ModeRoute({
         commandsManager,
       });
 
+      const disableEditing = extensionManager._appConfig?.disableEditing;
+      if (disableEditing) {
+        const { toolbarService } = servicesManager.services;
+        toolbarService.disableButtonInSection('primary', 'MeasurementTools');
+      }
+
       /**
        * The next line should get all the query parameters provided by the URL
        * - except the StudyInstanceUIDs - and create an object called filters

--- a/platform/core/src/services/MeasurementService/MeasurementService.ts
+++ b/platform/core/src/services/MeasurementService/MeasurementService.ts
@@ -484,7 +484,7 @@ class MeasurementService extends PubSubService {
       });
     }
 
-    return newMeasurement.id;
+    return newMeasurement.uid;
   }
 
   /**

--- a/platform/core/src/services/ToolBarService/ToolbarService.ts
+++ b/platform/core/src/services/ToolBarService/ToolbarService.ts
@@ -299,7 +299,12 @@ export default class ToolbarService extends PubSubService {
     };
   }
 
-  disableButtonInSection(section, buttonId) {
+  /**
+   * Removes a button section
+   * @param section
+   * @param buttonId
+   */
+  removeButtonSection(section, buttonId) {
     if (this.buttonSections[section]) {
       const buttonIndex = this.buttonSections[section].indexOf(buttonId);
       delete this.buttonSections[section][buttonIndex];

--- a/platform/core/src/services/ToolBarService/ToolbarService.ts
+++ b/platform/core/src/services/ToolBarService/ToolbarService.ts
@@ -299,6 +299,14 @@ export default class ToolbarService extends PubSubService {
     };
   }
 
+  disableButtonInSection(section, buttonId) {
+    if (this.buttonSections[section]) {
+      const buttonIndex = this.buttonSections[section].indexOf(buttonId);
+      delete this.buttonSections[section][buttonIndex];
+      this._broadcastEvent(this.EVENTS.TOOL_BAR_MODIFIED, {});
+    }
+  }
+
   getButtonComponentForUIType(uiType: string) {
     return uiType
       ? this._buttonTypes()[uiType]?.defaultComponent ?? null

--- a/platform/ui/src/components/SegmentationGroupTable/SegmentationGroup.tsx
+++ b/platform/ui/src/components/SegmentationGroupTable/SegmentationGroup.tsx
@@ -13,11 +13,12 @@ const AddNewSegmentRow = ({
   onSegmentAdd,
   isVisible,
   showAddSegment,
+  disableEditing,
 }) => {
   return (
     <div>
       <div className="flex items-center pl-[29px] bg-black text-primary-active hover:opacity-80 cursor-pointer text-[12px] py-1">
-        {showAddSegment && (
+        {showAddSegment && !disableEditing && (
           <div className="flex items-center" onClick={() => onSegmentAdd()}>
             <Icon name="row-add" className="w-5 h-5" />
             <div className="">Add Segment</div>
@@ -53,6 +54,7 @@ const SegmentGroupHeader = ({
   isActive,
   segmentCount,
   onSegmentationEdit,
+  disableEditing,
   onSegmentationDelete,
 }) => {
   return (
@@ -92,34 +94,36 @@ const SegmentGroupHeader = ({
           e.stopPropagation();
         }}
       >
-        <Dropdown
-          id="segmentation-dropdown"
-          showDropdownIcon={false}
-          list={[
-            {
-              title: 'Rename',
-              onClick: () => {
-                onSegmentationEdit(id);
+        {!disableEditing && (
+          <Dropdown
+            id="segmentation-dropdown"
+            showDropdownIcon={false}
+            list={[
+              {
+                title: 'Rename',
+                onClick: () => {
+                  onSegmentationEdit(id);
+                },
               },
-            },
-            {
-              title: 'Delete',
-              onClick: () => {
-                onSegmentationDelete(id);
+              {
+                title: 'Delete',
+                onClick: () => {
+                  onSegmentationDelete(id);
+                },
               },
-            },
-          ]}
-        >
-          <IconButton
-            id={''}
-            variant="text"
-            color="inherit"
-            size="initial"
-            className="text-primary-active"
+            ]}
           >
-            <Icon name="panel-group-more" />
-          </IconButton>
-        </Dropdown>
+            <IconButton
+              id={''}
+              variant="text"
+              color="inherit"
+              size="initial"
+              className="text-primary-active"
+            >
+              <Icon name="panel-group-more" />
+            </IconButton>
+          </Dropdown>
+        )}
       </div>
     </div>
   );
@@ -134,6 +138,7 @@ const SegmentationGroup = ({
   onSegmentClick,
   isMinimized,
   onSegmentColorClick,
+  disableEditing,
   showAddSegment,
   segments,
   activeSegmentIndex,
@@ -162,6 +167,7 @@ const SegmentationGroup = ({
         segmentCount={segmentCount}
         onSegmentationEdit={onSegmentationEdit}
         onSegmentationDelete={onSegmentationDelete}
+        disableEditing={disableEditing}
       />
       {!isMinimized && (
         <div className="flex flex-col flex-auto min-h-0">
@@ -171,6 +177,7 @@ const SegmentationGroup = ({
             isVisible={isVisible}
             onToggleSegmentationVisibility={onToggleSegmentationVisibility}
             id={id}
+            disableEditing={disableEditing}
             showAddSegment={showAddSegment}
           />
           <div className="flex flex-col min-h-0 ohif-scrollbar overflow-y-hidden">
@@ -197,6 +204,7 @@ const SegmentationGroup = ({
                       isActive={activeSegmentIndex === segmentIndex}
                       isLocked={isLocked}
                       isVisible={isVisible}
+                      disableEditing={disableEditing}
                       onClick={onSegmentClick}
                       onEdit={onSegmentEdit}
                       onDelete={onSegmentDelete}
@@ -241,6 +249,7 @@ SegmentationGroup.propTypes = {
   onSegmentationConfigChange: PropTypes.func.isRequired,
   onSegmentationDelete: PropTypes.func.isRequired,
   onSegmentEdit: PropTypes.func.isRequired,
+  disableEditing: PropTypes.bool,
 };
 
 SegmentationGroup.defaultProps = {

--- a/platform/ui/src/components/SegmentationGroupTable/SegmentationGroupSegment.tsx
+++ b/platform/ui/src/components/SegmentationGroupTable/SegmentationGroupSegment.tsx
@@ -12,6 +12,7 @@ const SegmentItem = ({
   isVisible,
   color,
   showSegmentDelete,
+  disableEditing,
   isLocked = false,
   onClick,
   onEdit,
@@ -116,17 +117,19 @@ const SegmentItem = ({
           )}
           {isHovering && (
             <div className={classnames('flex items-center')}>
-              <Icon
-                name="row-edit"
-                className={classnames('w-5 h-5', {
-                  'text-white': isLocked,
-                  'text-primary-light': !isLocked,
-                })}
-                onClick={e => {
-                  e.stopPropagation();
-                  onEdit(segmentationId, segmentIndex);
-                }}
-              />
+              {!disableEditing && (
+                <Icon
+                  name="row-edit"
+                  className={classnames('w-5 h-5', {
+                    'text-white': isLocked,
+                    'text-primary-light': !isLocked,
+                  })}
+                  onClick={e => {
+                    e.stopPropagation();
+                    onEdit(segmentationId, segmentIndex);
+                  }}
+                />
+              )}
               {isVisible ? (
                 <Icon
                   name="row-hide"
@@ -224,6 +227,7 @@ SegmentItem.propTypes = {
   segmentIndex: PropTypes.number.isRequired,
   segmentationId: PropTypes.string.isRequired,
   label: PropTypes.string,
+  disableEditing: PropTypes.bool,
   // color as array
   color: PropTypes.array,
   isActive: PropTypes.bool.isRequired,

--- a/platform/ui/src/components/SegmentationGroupTable/SegmentationGroupTable.tsx
+++ b/platform/ui/src/components/SegmentationGroupTable/SegmentationGroupTable.tsx
@@ -15,6 +15,7 @@ const SegmentationGroupTable = ({
   onSegmentClick,
   onSegmentAdd,
   segmentationConfig,
+  disableEditing,
   onSegmentDelete,
   onSegmentEdit,
   onToggleSegmentationVisibility,
@@ -60,6 +61,7 @@ const SegmentationGroupTable = ({
                 id={id}
                 key={id}
                 label={label}
+                disableEditing={disableEditing}
                 isMinimized={isMinimized[id]}
                 segments={segments}
                 showAddSegment={showAddSegment}
@@ -82,7 +84,7 @@ const SegmentationGroupTable = ({
             );
           })}
       </div>
-      {showAddSegmentation && (
+      {showAddSegmentation && !disableEditing && (
         <div
           className="flex items-center cursor-pointer hover:opacity-80 text-primary-active bg-black text-[12px] pl-1 h-[45px]"
           onClick={() => onSegmentationAdd()}
@@ -106,6 +108,7 @@ SegmentationGroupTable.propTypes = {
   onToggleVisibility: PropTypes.func.isRequired,
   onToggleVisibilityAll: PropTypes.func.isRequired,
   segmentationConfig: PropTypes.object,
+  disableEditing: PropTypes.bool,
 };
 
 SegmentationGroupTable.defaultProps = {


### PR DESCRIPTION
This PR is related to issue IDC #3357 , that want to prevent editing in OHIF by disabling renaming of Segmentation and Segments and the use of measurements tools. It adds a new attribute in the configuration called disableEditing to control the feature.