### PR TITLE
fix(Worklist): use the flexbox gap style property for spacing between mode buttons

### DIFF
--- a/platform/app/src/routes/WorkList/WorkList.tsx
+++ b/platform/app/src/routes/WorkList/WorkList.tsx
@@ -336,47 +336,56 @@ function WorkList({
               : []
           }
         >
-          {appConfig.loadedModes.map((mode, i) => {
-            const isFirst = i === 0;
+          <div className="flex flex-row gap-2">
+            {appConfig.loadedModes.map((mode, i) => {
+              const isFirst = i === 0;
 
-            const modalitiesToCheck = modalities.replaceAll('/', '\\');
+              const modalitiesToCheck = modalities.replaceAll('/', '\\');
 
-            const isValidMode = mode.isValidMode({
-              modalities: modalitiesToCheck,
-              study,
-            });
-            // TODO: Modes need a default/target route? We mostly support a single one for now.
-            // We should also be using the route path, but currently are not
-            // mode.routeName
-            // mode.routes[x].path
-            // Don't specify default data source, and it should just be picked up... (this may not currently be the case)
-            // How do we know which params to pass? Today, it's just StudyInstanceUIDs and configUrl if exists
-            const query = new URLSearchParams();
-            if (filterValues.configUrl) {
-              query.append('configUrl', filterValues.configUrl);
-            }
-            query.append('StudyInstanceUIDs', studyInstanceUid);
-            return (
-              <Link
-                key={i}
-                to={`${dataPath ? '../../' : ''}${mode.routeName}${dataPath ||
-                  ''}?${query.toString()}`}
-                // to={`${mode.routeName}/dicomweb?StudyInstanceUIDs=${studyInstanceUid}`}
-              >
-                {/* TODO revisit the completely rounded style of buttons used for launching a mode from the worklist later - for now use LegacyButton*/}
-                <LegacyButton
-                  rounded="full"
-                  variant={isValidMode ? 'contained' : 'disabled'}
-                  disabled={!isValidMode}
-                  endIcon={<Icon name="launch-arrow" />} // launch-arrow | launch-info
-                  className={classnames({ 'ml-2': !isFirst })}
-                  onClick={() => {}}
+              const isValidMode = mode.isValidMode({
+                modalities: modalitiesToCheck,
+                study,
+              });
+              // TODO: Modes need a default/target route? We mostly support a single one for now.
+              // We should also be using the route path, but currently are not
+              // mode.routeName
+              // mode.routes[x].path
+              // Don't specify default data source, and it should just be picked up... (this may not currently be the case)
+              // How do we know which params to pass? Today, it's just StudyInstanceUIDs and configUrl if exists
+              const query = new URLSearchParams();
+              if (filterValues.configUrl) {
+                query.append('configUrl', filterValues.configUrl);
+              }
+              query.append('StudyInstanceUIDs', studyInstanceUid);
+              return (
+                <Link
+                  className={isValidMode ? '' : 'cursor-not-allowed'}
+                  key={i}
+                  to={`${dataPath ? '../../' : ''}${mode.routeName}${dataPath ||
+                    ''}?${query.toString()}`}
+                  onClick={event => {
+                    // In case any event bubbles up for an invalid mode, prevent the navigation.
+                    // For example, the event bubbles up when the icon embedded in the disabled button is clicked.
+                    if (!isValidMode) {
+                      event.preventDefault();
+                    }
+                  }}
+                  // to={`${mode.routeName}/dicomweb?StudyInstanceUIDs=${studyInstanceUid}`}
                 >
-                  {t(`Modes:${mode.displayName}`)}
-                </LegacyButton>
-              </Link>
-            );
-          })}
+                  {/* TODO revisit the completely rounded style of buttons used for launching a mode from the worklist later - for now use LegacyButton*/}
+                  <LegacyButton
+                    rounded="full"
+                    variant={isValidMode ? 'contained' : 'disabled'}
+                    disabled={!isValidMode}
+                    endIcon={<Icon name="launch-arrow" />} // launch-arrow | launch-info
+                    onClick={() => {}}
+                  >
+                    {t(`Modes:${mode.displayName}`)}
+                  </LegacyButton>
+                </Link>
+              );
+            })}
+          </div>
         </StudyListExpandedRow>
       ),
       onClickRow: () =>


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

Fixes #3531

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results
Use the flexbox gap style property for spacing between mode buttons
Call preventDefault when the icon embedded in the disabled button is clicked.

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

Ensure the incorrect behaviour in #3531 is fixed.

Attempt to click the arrow icon inside a disabled mode button. No navigation should occur.

All the area surrounding/near disabled mode buttons should show the 'not allowed' mouse cursor and NOT the pointer cursor.
<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] OS: Windows 11 <!--[e.g. Windows 10, macOS 10.15.4]-->
- [x] Node version: 16.14.0<!--[e.g. 16.14.0]-->
- [x] Browser: Chrome 114.0.5735.199 
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
