### PR TITLE
test: Integration test wait until rendered/queried instead of timed

### DIFF
--- a/platform/app/cypress/support/commands.js
+++ b/platform/app/cypress/support/commands.js
@@ -46,7 +46,7 @@ Cypress.Commands.add('openStudy', PatientName => {
   cy.openStudyList();
   cy.get('#filter-patientNameOrId').type(PatientName);
   // cy.get('@getStudies').then(() => {
-  cy.wait(1000);
+  cy.waitQueryList();
 
   cy.get('[data-cy="study-list-results"]', { timeout: 5000 })
     .contains(PatientName)
@@ -65,7 +65,6 @@ Cypress.Commands.add(
       ) {
         cy.openStudyInViewer(StudyInstanceUID, otherParams);
         cy.waitDicomImage();
-        cy.wait(2000);
       }
     });
   }
@@ -78,6 +77,9 @@ Cypress.Commands.add(
   }
 );
 
+Cypress.Commands.add('waitQueryList', () => {
+  cy.get('[data-querying="false"]');
+});
 /**
  * Command to search for a Modality and open the study.
  *
@@ -89,7 +91,7 @@ Cypress.Commands.add('openStudyModality', Modality => {
 
   cy.get('#filter-accessionOrModalityOrDescription')
     .type(Modality)
-    .wait(2000);
+    .waitQueryList();
 
   cy.get('[data-cy="study-list-results"]')
     .contains(Modality)
@@ -113,7 +115,7 @@ Cypress.Commands.add('openStudyList', () => {
   // For some reason cypress 12.x does not like to stub the network request
   // so we just wait herer for 1 second
   // cy.wait('@getStudies');
-  cy.wait(1000);
+  cy.waitQueryList();
 });
 
 Cypress.Commands.add('waitStudyList', () => {
@@ -198,54 +200,24 @@ Cypress.Commands.add('expectMinimumThumbnails', (seriesToWait = 1) => {
 });
 
 //Command to wait DICOM image to load into the viewport
-Cypress.Commands.add('waitDicomImage', (timeout = 50000) => {
-  const loaded = cy.isPageLoaded();
-
-  if (loaded) {
-    cy.window()
-      .its('cornerstone')
-      .then({ timeout }, $cornerstone => {
-        return new Cypress.Promise(resolve => {
-          const onEvent = renderedEvt => {
-            const element = renderedEvt.detail.element;
-
-            element.removeEventListener(
-              $cornerstone.Enums.Events.IMAGE_RENDERED,
-              onEvent
-            );
-            $cornerstone.eventTarget.removeEventListener(
-              $cornerstone.Enums.Events.IMAGE_RENDERED,
-              onEvent
-            );
-            resolve();
-          };
-          const onEnabled = enabledEvt => {
-            const element = enabledEvt.detail.element;
-
-            element.addEventListener(
-              $cornerstone.Enums.Events.IMAGE_RENDERED,
-              onEvent
-            );
-
-            $cornerstone.eventTarget.removeEventListener(
-              $cornerstone.Enums.Events.ELEMENT_ENABLED,
-              onEnabled
-            );
-          };
-          const enabledElements = $cornerstone.getEnabledElements();
-          if (enabledElements && enabledElements.length) {
-            // Sometimes the page finishes rendering before this gets run,
-            // if so, just resolve immediately.
-            resolve();
-          } else {
-            $cornerstone.eventTarget.addEventListener(
-              $cornerstone.Enums.Events.ELEMENT_ENABLED,
-              onEnabled
+Cypress.Commands.add('waitDicomImage', () => {
+  cy.window()
+    .its('cornerstone')
+    .should($cornerstone => {
+      const enabled = $cornerstone.getEnabledElements();
+      if (enabled?.length) {
+        enabled.forEach((item, i) => {
+          if (item.viewport.renderedState !== 'rendered') {
+            throw new Error(
+              `Viewport ${i} in state ${item.viewport.renderedState}`
             );
           }
         });
-      });
-  }
+      } else {
+        throw new Error('No enabled elements');
+      }
+    });
+  cy.log('DICOM image loaded');
 });
 
 //Command to reset and clear all the changes made to the viewport
@@ -401,7 +373,8 @@ Cypress.Commands.add('setLayout', (columns = 1, rows = 1) => {
     .eq(columns - 1)
     .click();
 
-  cy.wait(1000);
+  cy.wait(10);
+  cy.waitDicomImage();
 });
 
 function convertCanvas(documentClone) {

--- a/platform/app/src/routes/WorkList/WorkList.tsx
+++ b/platform/app/src/routes/WorkList/WorkList.tsx
@@ -64,6 +64,7 @@ function WorkList({
     ...defaultFilterValues,
     ...queryFilterValues,
   });
+  const [querying, setQuerying] = useState(true);
 
   const debouncedFilterValues = useDebounce(filterValues, 200);
   const { resultsPerPage, pageNumber, sortBy, sortDirection } = filterValues;
@@ -117,6 +118,7 @@ function WorkList({
     if (filterValues.pageNumber === val.pageNumber) {
       val.pageNumber = 1;
     }
+    setQuerying(true);
     _setFilterValues(val);
     setExpandedRows([]);
   };
@@ -218,6 +220,8 @@ function WorkList({
 
       fetchSeries(studyInstanceUid);
     }
+    setQuerying(false);
+
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [expandedRows, studies]);
 
@@ -501,6 +505,7 @@ function WorkList({
             <StudyListTable
               tableDataSource={tableDataSource.slice(offset, offsetAndTake)}
               numOfStudies={numOfStudies}
+              querying={querying}
               filtersMeta={filtersMeta}
             />
             <div className="grow">

--- a/platform/ui/src/components/StudyListTable/StudyListTable.tsx
+++ b/platform/ui/src/components/StudyListTable/StudyListTable.tsx
@@ -3,12 +3,12 @@ import PropTypes from 'prop-types';
 
 import StudyListTableRow from './StudyListTableRow';
 
-const StudyListTable = ({ tableDataSource }) => {
+const StudyListTable = ({ tableDataSource, querying }) => {
   return (
     <div className="bg-black">
       <div className="container m-auto relative">
         <table className="w-full text-white">
-          <tbody data-cy="study-list-results">
+          <tbody data-cy="study-list-results" data-querying={querying}>
             {tableDataSource.map((tableData, i) => {
               return <StudyListTableRow tableData={tableData} key={i} />;
             })}
@@ -24,6 +24,7 @@ StudyListTable.propTypes = {
     PropTypes.shape({
       row: PropTypes.array.isRequired,
       expandedContent: PropTypes.node.isRequired,
+      querying: PropTypes.bool,
       onClickRow: PropTypes.func.isRequired,
       isExpanded: PropTypes.bool.isRequired,
     })


### PR DESCRIPTION
### Context

Added support to directly use the rendered/queried results.  

### Changes & Results

Use the cornerstone renderedState to wait for dicom image load instead of timing it.
Added a querying parameter to the worklist to record whether a query is in progress or not.  Exposed as a data-querying element (this is already re-rendering, so no significant change on render timing).

### Testing

Run the integration tests - they should pass (once new CS3D is incorporated)

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] OS: <!--[e.g. Windows 10, macOS 10.15.4]-->
- [] Node version: <!--[e.g. 16.14.0]-->
- [] Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
