### PR TITLE
feat(viewportGrid): simplifying ViewportGrid and enhancing performance by aligning with hanging protocol viewportIds

### DIFF
--- a/extensions/cornerstone/src/Viewport/OHIFCornerstoneViewport.tsx
+++ b/extensions/cornerstone/src/Viewport/OHIFCornerstoneViewport.tsx
@@ -407,8 +407,6 @@ const OHIFCornerstoneViewport = React.memo(props => {
     };
   }, [displaySets, elementRef, viewportIndex]);
 
-  console.debug('OHIFCornerstoneViewport rendering');
-
   return (
     <React.Fragment>
       <div className="viewport-wrapper">

--- a/extensions/cornerstone/src/Viewport/OHIFCornerstoneViewport.tsx
+++ b/extensions/cornerstone/src/Viewport/OHIFCornerstoneViewport.tsx
@@ -257,14 +257,15 @@ const OHIFCornerstoneViewport = React.memo(props => {
 
     return () => {
       storePresentation();
-
       cleanUpServices();
 
-      const viewportInfo = cornerstoneViewportService.getViewportInfoByIndex(
-        viewportIndex
+      const viewportId = viewportOptions.viewportId;
+
+      const viewportInfo = cornerstoneViewportService.getViewportInfo(
+        viewportId
       );
 
-      cornerstoneViewportService.disableElement(viewportIndex);
+      cornerstoneViewportService.disableElement(viewportId);
 
       if (onElementDisabled) {
         onElementDisabled(viewportInfo);

--- a/extensions/cornerstone/src/services/ViewportService/CornerstoneViewportService.ts
+++ b/extensions/cornerstone/src/services/ViewportService/CornerstoneViewportService.ts
@@ -171,21 +171,22 @@ class CornerstoneViewportService extends PubSubService
    * created for every new viewport, this will be called whenever the set of
    * viewports is changed, but NOT when the viewport position changes only.
    *
-   * @param viewportIndex
+   * @param viewportId - The viewportId to disable
    */
-  public disableElement(viewportIndex: number): void {
-    const viewportInfo = this.viewportsInfo.get(viewportIndex);
-    if (!viewportInfo) {
-      return;
-    }
+  public disableElement(viewportId: string): void {
+    this.renderingEngine?.disableElement(viewportId);
 
-    const viewportId = viewportInfo.getViewportId();
-
-    this.renderingEngine && this.renderingEngine.disableElement(viewportId);
-
-    this.viewportsInfo.get(viewportIndex).destroy();
-    this.viewportsInfo.delete(viewportIndex);
+    // clean up
     this.viewportsById.delete(viewportId);
+
+    this.viewportsInfo = new Map(
+      // @ts-ignore
+      [...this.viewportsInfo].filter(
+        ([, value]) => value.viewportId !== viewportId
+      )
+    );
+
+    this.viewportsDisplaySets.delete(viewportId);
   }
 
   public setPresentations(viewport, presentations?: Presentations): void {

--- a/extensions/cornerstone/src/services/ViewportService/IViewportService.ts
+++ b/extensions/cornerstone/src/services/ViewportService/IViewportService.ts
@@ -54,9 +54,9 @@ export interface IViewportService {
   /**
    * Disables the viewport inside the renderingEngine, if no viewport is left
    * it destroys the renderingEngine.
-   * @param viewportIndex
+   * @param viewportId
    */
-  disableElement(viewportIndex: number): void;
+  disableElement(viewportId: string): void;
   /**
    * Uses the renderingEngine to enable the element for the given viewport index
    * and sets the displaySet data to the viewport

--- a/extensions/test-extension/src/hpTestSwitch.ts
+++ b/extensions/test-extension/src/hpTestSwitch.ts
@@ -55,6 +55,34 @@ const viewport3d = {
   ],
 };
 
+const viewport4e = {
+  viewportOptions: {
+    viewportId: 'viewportE',
+    toolGroupId: 'default',
+    allowUnmatchedView: true,
+  },
+  displaySets: [
+    {
+      matchedDisplaySetsIndex: 4,
+      id: 'defaultDisplaySetId',
+    },
+  ],
+};
+
+const viewport5f = {
+  viewportOptions: {
+    viewportId: 'viewportF',
+    toolGroupId: 'default',
+    allowUnmatchedView: true,
+  },
+  displaySets: [
+    {
+      matchedDisplaySetsIndex: 5,
+      id: 'defaultDisplaySetId',
+    },
+  ],
+};
+
 const viewport3a = {
   viewportOptions: {
     viewportId: 'viewportA',
@@ -115,6 +143,14 @@ const viewportStructure = {
   properties: {
     rows: 2,
     columns: 2,
+  },
+};
+
+const viewportStructure32 = {
+  layoutType: 'grid',
+  properties: {
+    rows: 2,
+    columns: 3,
   },
 };
 
@@ -180,9 +216,18 @@ const hpTestSwitch: Types.HangingProtocol.Protocol = {
       viewports: [viewport0a, viewport1b, viewport2c, viewport3d],
     },
     {
-      name: '2x2 2c3d0a1b',
-      viewportStructure,
-      viewports: [viewport2c, viewport3d, viewport0a, viewport1b],
+      name: '3x2 0a1b4e2c3d5f',
+      viewportStructure: viewportStructure32,
+      // Note the following structure simply preserves the viewportId for
+      // a given screen position
+      viewports: [
+        viewport0a,
+        viewport1b,
+        viewport4e,
+        viewport2c,
+        viewport3d,
+        viewport5f,
+      ],
     },
     {
       name: '2x2 1c0d3a2b',

--- a/extensions/test-extension/src/hpTestSwitch.ts
+++ b/extensions/test-extension/src/hpTestSwitch.ts
@@ -1,0 +1,201 @@
+import { Types } from '@ohif/core';
+
+const viewport0a = {
+  viewportOptions: {
+    viewportId: 'viewportA',
+    toolGroupId: 'default',
+    allowUnmatchedView: true,
+  },
+  displaySets: [
+    {
+      id: 'defaultDisplaySetId',
+    },
+  ],
+};
+
+const viewport1b = {
+  viewportOptions: {
+    viewportId: 'viewportB',
+    toolGroupId: 'default',
+    allowUnmatchedView: true,
+  },
+  displaySets: [
+    {
+      matchedDisplaySetsIndex: 1,
+      id: 'defaultDisplaySetId',
+    },
+  ],
+};
+
+const viewport2c = {
+  viewportOptions: {
+    viewportId: 'viewportC',
+    toolGroupId: 'default',
+    allowUnmatchedView: true,
+  },
+  displaySets: [
+    {
+      matchedDisplaySetsIndex: 2,
+      id: 'defaultDisplaySetId',
+    },
+  ],
+};
+
+const viewport3d = {
+  viewportOptions: {
+    viewportId: 'viewportD',
+    toolGroupId: 'default',
+    allowUnmatchedView: true,
+  },
+  displaySets: [
+    {
+      matchedDisplaySetsIndex: 3,
+      id: 'defaultDisplaySetId',
+    },
+  ],
+};
+
+const viewport3a = {
+  viewportOptions: {
+    viewportId: 'viewportA',
+    toolGroupId: 'default',
+    allowUnmatchedView: true,
+  },
+  displaySets: [
+    {
+      matchedDisplaySetsIndex: 3,
+      id: 'defaultDisplaySetId',
+    },
+  ],
+};
+
+const viewport2b = {
+  viewportOptions: {
+    viewportId: 'viewportB',
+    toolGroupId: 'default',
+    allowUnmatchedView: true,
+  },
+  displaySets: [
+    {
+      matchedDisplaySetsIndex: 2,
+      id: 'defaultDisplaySetId',
+    },
+  ],
+};
+
+const viewport1c = {
+  viewportOptions: {
+    viewportId: 'viewportC',
+    toolGroupId: 'default',
+    allowUnmatchedView: true,
+  },
+  displaySets: [
+    {
+      matchedDisplaySetsIndex: 1,
+      id: 'defaultDisplaySetId',
+    },
+  ],
+};
+const viewport0d = {
+  viewportOptions: {
+    viewportId: 'viewportD',
+    toolGroupId: 'default',
+    allowUnmatchedView: true,
+  },
+  displaySets: [
+    {
+      matchedDisplaySetsIndex: 0,
+      id: 'defaultDisplaySetId',
+    },
+  ],
+};
+
+const viewportStructure = {
+  layoutType: 'grid',
+  properties: {
+    rows: 2,
+    columns: 2,
+  },
+};
+
+/**
+ * This hanging protocol is a test hanging protocol used to apply various
+ * layouts in different positions for display, re-using earlier names in
+ * various orders.
+ */
+const hpTestSwitch: Types.HangingProtocol.Protocol = {
+  hasUpdatedPriorsInformation: false,
+  id: '@ohif/mnTestSwitch',
+  description: 'Has various hanging protocol grid layouts',
+  name: 'Test Switch',
+  protocolMatchingRules: [
+    {
+      id: 'OneOrMoreSeries',
+      weight: 25,
+      attribute: 'numberOfDisplaySetsWithImages',
+      constraint: {
+        greaterThan: 0,
+      },
+    },
+  ],
+  toolGroupIds: ['default'],
+  displaySetSelectors: {
+    defaultDisplaySetId: {
+      seriesMatchingRules: [
+        {
+          attribute: 'numImageFrames',
+          constraint: {
+            greaterThan: { value: 0 },
+          },
+        },
+        // This display set will select the specified items by preference
+        // It has no affect if nothing is specified in the URL.
+        {
+          attribute: 'isDisplaySetFromUrl',
+          weight: 10,
+          constraint: {
+            equals: true,
+          },
+        },
+      ],
+    },
+  },
+  defaultViewport: {
+    viewportOptions: {
+      viewportType: 'stack',
+      toolGroupId: 'default',
+      allowUnmatchedView: true,
+    },
+    displaySets: [
+      {
+        id: 'defaultDisplaySetId',
+        matchedDisplaySetsIndex: -1,
+      },
+    ],
+  },
+  stages: [
+    {
+      name: '2x2 0a1b2c3d',
+      viewportStructure,
+      viewports: [viewport0a, viewport1b, viewport2c, viewport3d],
+    },
+    {
+      name: '2x2 2c3d0a1b',
+      viewportStructure,
+      viewports: [viewport2c, viewport3d, viewport0a, viewport1b],
+    },
+    {
+      name: '2x2 1c0d3a2b',
+      viewportStructure,
+      viewports: [viewport1c, viewport0d, viewport3a, viewport2b],
+    },
+    {
+      name: '2x2 3a2b1c0d',
+      viewportStructure,
+      viewports: [viewport3a, viewport2b, viewport1c, viewport0d],
+    },
+  ],
+  numberOfPriorsReferenced: -1,
+};
+
+export default hpTestSwitch;

--- a/extensions/test-extension/src/index.tsx
+++ b/extensions/test-extension/src/index.tsx
@@ -2,6 +2,8 @@ import { Types } from '@ohif/core';
 
 import { id } from './id';
 
+import hpTestSwitch from './hpTestSwitch';
+
 import getCustomizationModule from './getCustomizationModule';
 // import {setViewportZoomPan, storeViewportZoomPan } from './custom-viewport/setViewportZoomPan';
 import sameAs from './custom-attribute/sameAs';
@@ -47,6 +49,16 @@ const testExtension: Types.Extensions.Extension = {
 
   /** Registers some customizations */
   getCustomizationModule,
+
+  getHangingProtocolModule: () => {
+    return [
+      // Create a MxN hanging protocol available by default
+      {
+        name: hpTestSwitch.id,
+        protocol: hpTestSwitch,
+      },
+    ];
+  },
 };
 
 export default testExtension;

--- a/extensions/tmtv/src/utils/hpViewports.ts
+++ b/extensions/tmtv/src/utils/hpViewports.ts
@@ -114,6 +114,9 @@ const ptAXIAL = {
         id: 'ptFusionWLSync',
         source: true,
         target: false,
+        options: {
+          syncInvertState: false,
+        },
       },
     ],
   },
@@ -155,6 +158,9 @@ const ptSAGITTAL = {
         id: 'ptFusionWLSync',
         source: true,
         target: false,
+        options: {
+          syncInvertState: false,
+        },
       },
     ],
   },
@@ -196,6 +202,9 @@ const ptCORONAL = {
         id: 'ptFusionWLSync',
         source: true,
         target: false,
+        options: {
+          syncInvertState: false,
+        },
       },
     ],
   },
@@ -246,6 +255,9 @@ const fusionAXIAL = {
         id: 'ptFusionWLSync',
         source: false,
         target: true,
+        options: {
+          syncInvertState: false,
+        },
       },
     ],
   },
@@ -306,6 +318,9 @@ const fusionSAGITTAL = {
         id: 'ptFusionWLSync',
         source: false,
         target: true,
+        options: {
+          syncInvertState: false,
+        },
       },
     ],
   },
@@ -366,6 +381,9 @@ const fusionCORONAL = {
         id: 'ptFusionWLSync',
         source: false,
         target: true,
+        options: {
+          syncInvertState: false,
+        },
       },
     ],
   },
@@ -411,6 +429,9 @@ const mipSAGITTAL = {
         id: 'ptFusionWLSync',
         source: true,
         target: false,
+        options: {
+          syncInvertState: false,
+        },
       },
     ],
 

--- a/platform/app/src/components/ViewportGrid.tsx
+++ b/platform/app/src/components/ViewportGrid.tsx
@@ -254,10 +254,6 @@ function ViewerViewportGrid(props) {
       const viewportIndex = i;
       const isActive = activeViewportIndex === viewportIndex;
       const paneMetadata = viewports[i] || {};
-      const viewportId = paneMetadata.viewportId || `viewport-${i}`;
-      if (!paneMetadata.viewportId) {
-        paneMetadata.viewportId = viewportId;
-      }
       const {
         displaySetInstanceUIDs,
         viewportOptions,
@@ -307,7 +303,16 @@ function ViewerViewportGrid(props) {
 
       viewportPanes[i] = (
         <ViewportPane
-          key={viewportId}
+          // Note: It is highly important that the key is the viewportId here,
+          // since it is used to determine if the component should be re-rendered
+          // by React, and also in the hanging protocol and stage changes if the
+          // same viewportId is used, React, by default, will only move (not re-render)
+          // those components. For instance, if we have a 2x3 layout, and we move
+          // from 2x3 to 1x1 (second viewport), if the key is the viewportIndex,
+          // React will RE-RENDER the resulting viewport as the key will be different.
+          // however, if the key is the viewportId, React will only move the component
+          // and not re-render it.
+          key={paneMetadata.viewportOptions.viewportId}
           acceptDropsFor="displayset"
           onDrop={onDropHandler.bind(null, viewportIndex)}
           onInteraction={onInteractionHandler}

--- a/platform/core/src/services/HangingProtocolService/HangingProtocolService.ts
+++ b/platform/core/src/services/HangingProtocolService/HangingProtocolService.ts
@@ -393,7 +393,7 @@ export default class HangingProtocolService extends PubSubService {
   /**
    * Returns true, if the hangingProtocol has a custom loading strategy for the images
    * and its callback has been added to the HangingProtocolService
-   * @returns {boolean} true
+   * @returns A boolean indicating whether a custom image load strategy has been added or not.
    */
   public hasCustomImageLoadStrategy(): boolean {
     return (
@@ -404,8 +404,29 @@ export default class HangingProtocolService extends PubSubService {
     );
   }
 
+  /**
+   * Returns a boolean indicating whether a custom image load has been performed or not.
+   * A custom image load is performed when a custom image load strategy is used to load images.
+   * This method is used internally by the HangingProtocolService to determine whether to perform
+   * a custom image load or not.
+   *
+   * @returns A boolean indicating whether a custom image load has been performed or not.
+   */
   public getCustomImageLoadPerformed(): boolean {
     return this.customImageLoadPerformed;
+  }
+
+  /**
+   * Returns a boolean indicating whether a custom image load should be performed or not.
+   * A custom image load should be performed if a custom image load strategy has been added to the HangingProtocolService
+   * and it has not been performed yet.
+   *
+   * @returns A boolean indicating whether a custom image load should be performed or not.
+   */
+  public getShouldPerformCustomImageLoad(): boolean {
+    return (
+      this.hasCustomImageLoadStrategy() && !this.getCustomImageLoadPerformed()
+    );
   }
 
   /**
@@ -697,7 +718,9 @@ export default class HangingProtocolService extends PubSubService {
       const { id } = displaySet;
       const displaySetMatchDetail = displaySetMatchDetails.get(id);
 
-      const { displaySetInstanceUID: oldDisplaySetInstanceUID } = displaySetMatchDetail;
+      const {
+        displaySetInstanceUID: oldDisplaySetInstanceUID,
+      } = displaySetMatchDetail;
 
       const displaySetInstanceUID =
         displaySet.id === displaySetSelectorId
@@ -1066,7 +1089,7 @@ export default class HangingProtocolService extends PubSubService {
     // matching applied
     this.viewportMatchDetails = new Map();
     this.displaySetMatchDetails = new Map();
-    this.customImageLoadPerformed = false;
+    // this.customImageLoadPerformed = false;
 
     // Retrieve the current stage
     const stageModel = this._getCurrentStageModel();
@@ -1394,18 +1417,18 @@ export default class HangingProtocolService extends PubSubService {
       if (matchActiveOnly && this.activeStudy !== study) return;
 
       const studyDisplaySets = this.displaySets.filter(
-          it => it.StudyInstanceUID === study.StudyInstanceUID
+        it => it.StudyInstanceUID === study.StudyInstanceUID
       );
 
       const studyMatchDetails = this.protocolEngine.findMatch(
-          study,
-          studyMatchingRules,
-          {
-            studies: this.studies,
-            displaySets: studyDisplaySets,
-            allDisplaySets: this.displaySets,
-            displaySetMatchDetails: this.displaySetMatchDetails,
-          }
+        study,
+        studyMatchingRules,
+        {
+          studies: this.studies,
+          displaySets: studyDisplaySets,
+          allDisplaySets: this.displaySets,
+          displaySetMatchDetails: this.displaySetMatchDetails,
+        }
       );
 
       // Prevent bestMatch from being updated if the matchDetails' required attribute check has failed
@@ -1414,10 +1437,10 @@ export default class HangingProtocolService extends PubSubService {
       }
 
       this.debug(
-          'study',
-          study.StudyInstanceUID,
-          'display sets #',
-          studyDisplaySets.length
+        'study',
+        study.StudyInstanceUID,
+        'display sets #',
+        studyDisplaySets.length
       );
       studyDisplaySets.forEach(displaySet => {
         const {
@@ -1426,15 +1449,15 @@ export default class HangingProtocolService extends PubSubService {
           displaySetInstanceUID,
         } = displaySet;
         const seriesMatchDetails = this.protocolEngine.findMatch(
-            displaySet,
-            seriesMatchingRules,
-            // Todo: why we have images here since the matching type does not have it
-            {
-              studies: this.studies,
-              instance: displaySet.images?.[0],
-              displaySetMatchDetails: this.displaySetMatchDetails,
-              displaySets: studyDisplaySets,
-            }
+          displaySet,
+          seriesMatchingRules,
+          // Todo: why we have images here since the matching type does not have it
+          {
+            studies: this.studies,
+            instance: displaySet.images?.[0],
+            displaySetMatchDetails: this.displaySetMatchDetails,
+            displaySets: studyDisplaySets,
+          }
         );
 
         // Prevent bestMatch from being updated if the matchDetails' required attribute check has failed

--- a/platform/core/src/types/HangingProtocol.ts
+++ b/platform/core/src/types/HangingProtocol.ts
@@ -263,6 +263,8 @@ export type ProtocolNotifications = {
 export type Protocol = {
   // Mandatory
   id: string;
+  /** A description of this protocol.  Used as a tool tip for the user. */
+  description?: string;
   /** Maps ids to display set selectors to choose display sets */
   displaySetSelectors: Record<string, DisplaySetSelector>;
   /** A default viewport to use for any stage to select new viewport layouts. */

--- a/platform/ui/src/contextProviders/ViewportGridProvider.tsx
+++ b/platform/ui/src/contextProviders/ViewportGridProvider.tsx
@@ -141,7 +141,7 @@ export function ViewportGridProvider({ children, service }) {
 
             // If the viewport doesn't have a viewportId, we create one
             if (!viewport.viewportOptions?.viewportId) {
-              viewport.viewportOptions.viewportId = `viewport-${pos}`;
+              viewport.viewportOptions.viewportId = `viewport-${positionId}`;
             }
 
             // Create a new viewport object as it is getting updated here

--- a/platform/ui/src/contextProviders/ViewportGridProvider.tsx
+++ b/platform/ui/src/contextProviders/ViewportGridProvider.tsx
@@ -64,8 +64,7 @@ export function ViewportGridProvider({ children, service }) {
 
           const displaySetOptions = updatedViewport.displaySetOptions || [];
           if (!displaySetOptions.length) {
-            // Copy all the display set options, assuming a full set of displa
-            // set UID's is provided.
+            // Copy all the display set options, assuming a full set of displayset UID's is provided.
             displaySetOptions.push(...previousViewport.displaySetOptions);
             if (!displaySetOptions.length) {
               displaySetOptions.push({});
@@ -79,6 +78,7 @@ export function ViewportGridProvider({ children, service }) {
             displaySetOptions,
             viewportLabel: viewportLabels[viewportIndex],
           };
+
           viewportOptions.presentationIds = ViewportGridService.getPresentationIds(
             newViewport,
             viewports
@@ -87,6 +87,7 @@ export function ViewportGridProvider({ children, service }) {
           if (!newViewport.viewportOptions?.viewportId) {
             newViewport.viewportOptions.viewportId = `viewport-${viewportIndex}`;
           }
+
           newViewport.viewportIndex = previousViewport.viewportIndex;
 
           viewports[viewportIndex] = {
@@ -146,8 +147,8 @@ export function ViewportGridProvider({ children, service }) {
             // Create a new viewport object as it is getting updated here
             // and it is part of the read only state
             viewports.push(viewport);
-            let xPos, yPos, w, h;
 
+            let xPos, yPos, w, h;
             if (layoutOptions && layoutOptions[pos]) {
               ({ x: xPos, y: yPos, width: w, height: h } = layoutOptions[pos]);
             } else {
@@ -157,10 +158,12 @@ export function ViewportGridProvider({ children, service }) {
               yPos = row * h;
             }
 
-            viewport.width = w;
-            viewport.height = h;
-            viewport.x = xPos;
-            viewport.y = yPos;
+            Object.assign(viewport, {
+              width: w,
+              height: h,
+              x: xPos,
+              y: yPos,
+            });
 
             //     if (!viewport.viewportOptions.presentationIds) {
             //     viewport.viewportOptions.presentationIds = ViewportGridService.getPresentationIds(

--- a/platform/ui/src/contextProviders/ViewportGridProvider.tsx
+++ b/platform/ui/src/contextProviders/ViewportGridProvider.tsx
@@ -141,7 +141,7 @@ export function ViewportGridProvider({ children, service }) {
 
             // If the viewport doesn't have a viewportId, we create one
             if (!viewport.viewportOptions?.viewportId) {
-              viewport.viewportOptions.viewportId = `viewport-${positionId}`;
+              viewport.viewportOptions.viewportId = `viewport-${pos}`;
             }
 
             // Create a new viewport object as it is getting updated here


### PR DESCRIPTION
### Context

ViewportGrid has grown to be a complex piece with viewportIds being almost random, and also not following the defined Hanging Protocol Ids. 

This PR will fix this issue and remove various pieces to make the viewportGrid simple as before and also following hanging protocol defined ids. 

### Changes & Results

- Changes are removing the useViewportId logic which was barely hit (as it required various conditions to be true)
- making the disableElement based on viewportId

**Results**

**Bringing back the meaningfull viewportIds** 

Before (right now) 

https://github.com/OHIF/Viewers/assets/7490180/135bf67d-5731-491c-ad56-245ab5d4d8a8



After: 

https://github.com/OHIF/Viewers/assets/7490180/6cf977b3-42db-4ae5-b141-7610eb26a39c

---

**Enable change of protocol during volume loading**

Before(now)


https://github.com/OHIF/Viewers/assets/7490180/e04938ed-bfaa-49fd-a10c-4d18f4b980ff



After: 


https://github.com/OHIF/Viewers/assets/7490180/c7a936ec-5418-4902-90ba-d33b109ef1a8




---

**No unnecessary re-rendering when not required**

Going from default tmtv (10 viewports) to its next stage, there are viewports that are picked for the next stage (nothing is added, some are removed). Assigning the `viewportId` to the key will help react to manage the move for the viewports without the need for rendering. So going from HP0 to HP1 in tmtv will not even hit the `setViewportData` inside the `cornerstoneViewportService` which means better performance



****


### Testing



### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] OS: <!--[e.g. Windows 10, macOS 10.15.4]-->
- [] Node version: <!--[e.g. 16.14.0]-->
- [] Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
