### PR TITLE
feat(MetadataLoading) : enable metadata loading from images

### DIFF
--- a/extensions/cornerstone/src/init.tsx
+++ b/extensions/cornerstone/src/init.tsx
@@ -134,6 +134,7 @@ export default async function init({
   );
 
   const metadataProvider = OHIF.classes.MetadataProvider;
+  metadataProvider.setLoadDicomMetadata(appConfig.automaticallyLoadDicomMetadata)
 
   volumeLoader.registerVolumeLoader(
     'cornerstoneStreamingImageVolume',

--- a/extensions/default/src/DicomJSONDataSource/index.js
+++ b/extensions/default/src/DicomJSONDataSource/index.js
@@ -206,6 +206,9 @@ function createDicomJSONApi(dicomJsonConfig) {
                 imageId: instance.url,
                 ...series,
                 ...study,
+                // We need to force this flag to false in case the client wants to load the metadata from the image
+                // directly with automaticallyLoadDicomMetadata
+                imageMetadataLoaded: false
               };
               delete obj.instances;
               delete obj.series;

--- a/platform/app/public/config/default.js
+++ b/platform/app/public/config/default.js
@@ -22,6 +22,8 @@ window.config = {
     // above, the number of requests can be go a lot higher.
     prefetch: 25,
   },
+  // Allow Metadataprovider to parse dicom images as it retrieves it
+  automaticallyLoadDicomMetadata: true,
   // filterQueryParam: false,
   defaultDataSourceName: 'dicomweb',
   /* Dynamic config allows user to pass "configUrl" query string this allows to load config without recompiling application. The regex will ensure valid configuration source */

--- a/platform/app/public/config/default.js
+++ b/platform/app/public/config/default.js
@@ -23,6 +23,7 @@ window.config = {
     prefetch: 25,
   },
   // Allow Metadataprovider to parse dicom images as it retrieves it
+  // Only works with dicom json datasource for now
   automaticallyLoadDicomMetadata: true,
   // filterQueryParam: false,
   defaultDataSourceName: 'dicomweb',

--- a/platform/core/src/classes/MetadataProvider.js
+++ b/platform/core/src/classes/MetadataProvider.js
@@ -7,6 +7,10 @@ import fetchPaletteColorLookupTableData from '../utils/metadataProvider/fetchPal
 import toNumber from '../utils/toNumber';
 import combineFrameInstance from '../utils/combineFrameInstance';
 
+import dicomImageLoader from '@cornerstonejs/dicom-image-loader';
+import dcmjs from 'dcmjs';
+
+
 class MetadataProvider {
   constructor() {
     // Define the main "metadataLookup" private property as an immutable property.
@@ -32,6 +36,22 @@ class MetadataProvider {
       writable: false,
       value: new Map(),
     });
+
+    Object.defineProperty(this, 'automaticallyLoadDicomMetadata', {
+      configurable: false,
+      enumerable: false,
+      writable: true,
+      value: false,
+    });
+  }
+
+  setLoadDicomMetadata(option) {
+    if (option === undefined)
+      return
+
+    console.log("mdr" + option)
+
+    this.automaticallyLoadDicomMetadata = option
   }
 
   addImageIdToUIDs(imageId, uids) {
@@ -65,11 +85,12 @@ class MetadataProvider {
       frameNumber,
     } = uids;
 
-    const instance = DicomMetadataStore.getInstance(
+    let instance = DicomMetadataStore.getInstance(
       StudyInstanceUID,
       SeriesInstanceUID,
       SOPInstanceUID
     );
+
     return (
       (frameNumber && combineFrameInstance(frameNumber, instance)) || instance
     );
@@ -125,6 +146,47 @@ class MetadataProvider {
 
   _getCornerstoneDICOMImageLoaderTag(wadoImageLoaderTag, instance) {
     let metadata;
+
+    if (this.automaticallyLoadDicomMetadata && (instance.imageMetadataLoaded === undefined || !instance.imageMetadataLoaded)) {
+
+      const dataSetCacheManager = dicomImageLoader.wadouri.dataSetCacheManager
+      const parsedImageId = dicomImageLoader.wadouri.parseImageId(instance.imageId);
+      let url = parsedImageId.url;
+
+      if (parsedImageId.frame) {
+        url = `${url}&frame=${parsedImageId.frame}`;
+      }
+
+      const rawDataSet = dataSetCacheManager.get(url);
+
+      if (!rawDataSet) {
+        return;
+      }
+
+      const dicomData = dcmjs.data.DicomMessage.readFile(rawDataSet.byteArray.buffer);
+      const dataset = dcmjs.data.DicomMetaDictionary.naturalizeDataset(dicomData.dict);
+
+      instance = {
+        ...instance,
+        ...dataset,
+        imageMetadataLoaded: true
+      }
+
+      const uids = this.getUIDsFromImageID(instance.imageId);
+
+      if (!uids) {
+        return;
+      }
+
+      const {
+        StudyInstanceUID,
+        SeriesInstanceUID,
+        SOPInstanceUID
+      } = uids;
+
+      DicomMetadataStore.updateInstance(StudyInstanceUID, SeriesInstanceUID, SOPInstanceUID, instance)
+    }
+
 
     switch (wadoImageLoaderTag) {
       case WADO_IMAGE_LOADER_TAGS.GENERAL_SERIES_MODULE:
@@ -405,14 +467,6 @@ class MetadataProvider {
         };
 
         break;
-      case WADO_IMAGE_LOADER_TAGS.PER_SERIES_MODULE:
-        metadata = {
-          correctedImage: instance.CorrectedImage,
-          units: instance.Units,
-          decayCorrection: instance.DecayCorrection,
-        };
-        break;
-
       default:
         return;
     }
@@ -516,7 +570,6 @@ const WADO_IMAGE_LOADER_TAGS = {
   MODALITY_LUT_MODULE: 'modalityLutModule',
   SOP_COMMON_MODULE: 'sopCommonModule',
   PET_ISOTOPE_MODULE: 'petIsotopeModule',
-  PER_SERIES_MODULE: 'petSeriesModule',
   OVERLAY_PLANE_MODULE: 'overlayPlaneModule',
   PATIENT_DEMOGRAPHIC_MODULE: 'patientDemographicModule',
 

--- a/platform/core/src/classes/MetadataProvider.js
+++ b/platform/core/src/classes/MetadataProvider.js
@@ -147,7 +147,12 @@ class MetadataProvider {
   _getCornerstoneDICOMImageLoaderTag(wadoImageLoaderTag, instance) {
     let metadata;
 
-    if (this.automaticallyLoadDicomMetadata && (instance.imageMetadataLoaded === undefined || !instance.imageMetadataLoaded)) {
+    // NOTE : we only check if the flag is set and set to false to prevent other
+    // non compatible data source to work even if automaticallyLoadDicomMetadata
+    // is set.
+    // To make your data source compatible with this you'll have to explicitly
+    // set the instance.imageMetadataLoaded to false
+    if (this.automaticallyLoadDicomMetadata && (instance.imageMetadataLoaded === false)) {
 
       const dataSetCacheManager = dicomImageLoader.wadouri.dataSetCacheManager
       const parsedImageId = dicomImageLoader.wadouri.parseImageId(instance.imageId);

--- a/platform/core/src/services/DicomMetadataStore/DicomMetadataStore.ts
+++ b/platform/core/src/services/DicomMetadataStore/DicomMetadataStore.ts
@@ -95,6 +95,29 @@ function _getInstanceByImageId(imageId) {
   }
 }
 
+function _updateInstance(StudyInstanceUID, SeriesInstanceUID, SOPInstanceUID, metadata) {
+  const study = _getStudy(StudyInstanceUID);
+
+  if (!study) {
+    return;
+  }
+
+  const series = study.series.find(
+    aSeries => aSeries.SeriesInstanceUID === SeriesInstanceUID
+  );
+
+  const { instances } = series;
+  // update all instances metadata for this series with the new metadata
+  instances.forEach(instance => {
+    if (instance.SOPInstanceUID === SOPInstanceUID) {
+      Object.keys(metadata).forEach(key => {
+        instance[key] = metadata[key];
+      });
+    }
+  });
+}
+
+
 /**
  * Update the metadata of a specific series
  * @param {*} StudyInstanceUID
@@ -260,6 +283,7 @@ const BaseImplementation = {
   getInstance: _getInstance,
   getInstanceByImageId: _getInstanceByImageId,
   updateMetadataForSeries: _updateMetadataForSeries,
+  updateInstance: _updateInstance,
 };
 const DicomMetadataStore = Object.assign(
   // get study


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

The goal of this PR is to allow the MetadataProvider to read the metadata of dicom images directly without making an extra WADO-RS Metadata request to the PACS.
Internaly it uses dataSetCacheManager of dicomImageLoader to access the DICOM dataset. Then dcmjs parse the dataset and add the metadata to the MetadataStore.
This PR allow the DicomJSON source to provide only the image UID + instance number without the need of putting all the image metadata into the final .json.

You can enable or disable this behavior with the variable automaticallyLoadDicomMetadata in the config file.

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->
This can be tested using a regular JSON DataSource where only SeriesInstanceUID, StudyInstanceUID, SOPClassUID and InstanceNumber must be present.

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] OS:  Windows 10
- [] Node version: <!--[e.g. 16.14.0]-->
- [x] Browser: Chrome 115.0.5790.110, Firefox 115.0.3


<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
