### PR TITLE
feat(data source UI config): Popup the configuration dialogue whenever a data source is not fully configured

### DIFF
--- a/extensions/default/src/Components/DataSourceConfigurationComponent.tsx
+++ b/extensions/default/src/Components/DataSourceConfigurationComponent.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useEffect, useState } from 'react';
+import React, { ReactElement, useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Icon, useModal } from '@ohif/ui';
 import { ExtensionManager, ServicesManager, Types } from '@ohif/core';
@@ -48,6 +48,9 @@ function DataSourceConfigurationComponent({
       const configAPI = configurationAPIFactory(activeDataSourceDef.sourceName);
       setConfigurationAPI(configAPI);
 
+      // New configuration API means that the existing configured items must be cleared.
+      setConfiguredItems(undefined);
+
       configAPI.getConfiguredItems().then(list => {
         if (shouldUpdate) {
           setConfiguredItems(list);
@@ -68,22 +71,35 @@ function DataSourceConfigurationComponent({
     };
   }, []);
 
+  const showConfigurationModal = useCallback(() => {
+    show({
+      content: DataSourceConfigurationModalComponent,
+      title: t('Configure Data Source'),
+      contentProps: {
+        configurationAPI,
+        configuredItems,
+        onHide: hide,
+      },
+    });
+  }, [configurationAPI, configuredItems]);
+
+  useEffect(() => {
+    if (!configurationAPI || !configuredItems) {
+      return;
+    }
+
+    if (configuredItems.length !== configurationAPI.getItemLabels().length) {
+      // Not the correct number of configured items, so show the modal to configure the data source.
+      showConfigurationModal();
+    }
+  }, [configurationAPI, configuredItems, showConfigurationModal]);
+
   return configuredItems ? (
     <div className="flex text-aqua-pale overflow-hidden items-center">
       <Icon
         name="settings"
         className="cursor-pointer shrink-0 w-3.5 h-3.5 mr-2.5"
-        onClick={() =>
-          show({
-            content: DataSourceConfigurationModalComponent,
-            title: t('Configure Data Source'),
-            contentProps: {
-              configurationAPI,
-              configuredItems,
-              onHide: hide,
-            },
-          })
-        }
+        onClick={showConfigurationModal}
       ></Icon>
       {configuredItems.map((item, itemIndex) => {
         return (

--- a/extensions/default/src/Components/DataSourceConfigurationModalComponent.tsx
+++ b/extensions/default/src/Components/DataSourceConfigurationModalComponent.tsx
@@ -27,13 +27,16 @@ function DataSourceConfigurationModalComponent({
 
   const [selectedItems, setSelectedItems] = useState(configuredItems);
 
-  // Determines whether to show the full configuration for the data source.
-  // This typically occurs when the configuration component is first displayed.
-  const [showFullConfig, setShowFullConfig] = useState(true);
-
   const [errorMessage, setErrorMessage] = useState<string>();
 
   const [itemLabels] = useState(configurationAPI.getItemLabels());
+
+  // Determines whether to show the full/existing configuration for the data source.
+  // If the data source is fully configured, then it is shown, otherwise
+  // configuration starts from scratch.
+  const [showFullConfig, setShowFullConfig] = useState(
+    itemLabels.length === configuredItems.length
+  );
 
   /**
    * The index of the selected item that is considered current and for which

--- a/extensions/default/src/DataSourceConfigurationAPI/GoogleCloudDataSourceConfigurationAPI.ts
+++ b/extensions/default/src/DataSourceConfigurationAPI/GoogleCloudDataSourceConfigurationAPI.ts
@@ -148,7 +148,12 @@ class GoogleCloudDataSourceConfigurationAPI
     const urlSplit = url.substring(projectsIndex).split('/');
 
     const configuredItems = [];
-    for (let itemType = 0; itemType < 4; itemType += 1) {
+
+    for (
+      let itemType = 0;
+      itemType < 4 && (itemType + 1) * 2 < urlSplit.length;
+      itemType += 1
+    ) {
       if (itemType === ItemType.projects) {
         const projectId = urlSplit[1];
         const projectUrl = `${initialUrl}/projects/${projectId}`;

--- a/platform/app/src/routes/DataSourceWrapper.tsx
+++ b/platform/app/src/routes/DataSourceWrapper.tsx
@@ -125,6 +125,7 @@ function DataSourceWrapper(props) {
 
   useEffect(() => {
     const dataSourceChangedCallback = () => {
+      setIsLoading(false);
       setIsDataSourceInitialized(false);
       setDataSourcePath('');
       setDataSource(extensionManager.getActiveDataSource()[0]);
@@ -191,7 +192,16 @@ function DataSourceWrapper(props) {
         (!isLoading && (newOffset !== previousOffset || isLocationUpdated));
 
       if (isDataInvalid) {
-        getData().catch(() => navigate('/notfoundserver', '_self'));
+        getData().catch(() => {
+          // If there is a data source configuration API, then the Worklist will popup the dialog to attempt to configure it
+          // and attempt to resolve this issue.
+          if (dataSource.getConfig().configurationAPI) {
+            return;
+          }
+
+          // No data source configuration API, so navigate to the not found server page.
+          navigate('/notfoundserver', '_self');
+        });
       }
     } catch (ex) {
       console.warn(ex);


### PR DESCRIPTION
### Context

If a data source is not fully configured (e.g. the various wado, qido, etc roots are not set), then OHIF should popup the data source configuration modal to configure the data source.

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

Instead of navigating to the server not found page, give any data source with a configuration API the chance to configure itself via the UI.

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

1. Check out the branch for this PR.
2. Remove the various configuration paths for the 'dicomweb' data source from the `config/google.js` configuration file.
3. Set the configuration file to be google.js.
4. Start OHIF and navigate to the client.
5. The 'Configure Data Source' modal should be displayed and should allow the Google Cloud Healthcare data source to be configured.

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] OS: Windows 11<!--[e.g. Windows 10, macOS 10.15.4]-->
- [x] Node version: 16.14.0<!--[e.g. 16.14.0]-->
- [x] Browser: Chrome 115.0.5790.171
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
