### PR TITLE
Fix(health imaing): studies not loading from healthimaging if imagepositionpatient is missing

### DIFF
--- a/extensions/default/src/utils/validations/areAllImagePositionsEqual.ts
+++ b/extensions/default/src/utils/validations/areAllImagePositionsEqual.ts
@@ -38,6 +38,9 @@ export default function areAllImagePositionsEqual(instances: Array<any>): boolea
     return false;
   }
   const firstImageOrientationPatient = toNumber(instances[0].ImageOrientationPatient);
+  if (!firstImageOrientationPatient) {
+    return false;
+  }
   const scanAxisNormal = calculateScanAxisNormal(firstImageOrientationPatient);
   const firstImagePositionPatient = toNumber(instances[0].ImagePositionPatient);
   const lastIpp = toNumber(instances[instances.length - 1].ImagePositionPatient);

--- a/extensions/default/src/utils/validations/areAllImageSpacingEqual.ts
+++ b/extensions/default/src/utils/validations/areAllImageSpacingEqual.ts
@@ -20,6 +20,9 @@ export default function areAllImageSpacingEqual(
     return;
   }
   const firstImagePositionPatient = toNumber(instances[0].ImagePositionPatient);
+  if (!firstImagePositionPatient) {
+    return;
+  }
   const lastIpp = toNumber(instances[instances.length - 1].ImagePositionPatient);
 
   const averageSpacingBetweenFrames =

--- a/platform/app/src/routes/Mode/Mode.tsx
+++ b/platform/app/src/routes/Mode/Mode.tsx
@@ -67,6 +67,13 @@ function defaultRouteInit(
     })
   );
 
+  // log the error if this fails, otherwise it's so difficult to tell what went wrong...
+  allRetrieves.forEach(retrieve => {
+    retrieve.catch(error => {
+      console.error(error);
+    });
+  });
+
   // The hanging protocol matching service is fairly expensive to run multiple
   // times, and doesn't allow partial matches to be made (it will simply fail
   // to display anything if a required match fails), so we wait here until all metadata
@@ -436,7 +443,7 @@ export default function ModeRoute({
     <ImageViewerProvider
       // initialState={{ StudyInstanceUIDs: StudyInstanceUIDs }}
       StudyInstanceUIDs={studyInstanceUIDs}
-      // reducer={reducer}
+    // reducer={reducer}
     >
       <CombinedContextProvider>
         <DragAndDropProvider>


### PR DESCRIPTION

### Context

The bug was introduced in the new feature "DisplaySet Messages." It didn't have proper error handling, causing promises not to settle, leading to infinite loading in the viewer.

I added proper error handling so this issue doesn't occur again and errors are correctly logged in the console.

