### PR TITLE
fix(DicomJson): retrieve.series.metadata method is async

### DIFF
--- a/extensions/default/src/DicomJSONDataSource/index.js
+++ b/extensions/default/src/DicomJSONDataSource/index.js
@@ -152,7 +152,7 @@ function createDicomJSONApi(dicomJsonConfig) {
         return getDirectURL(wadoRoot, params);
       },
       series: {
-        metadata: ({ StudyInstanceUID, madeInClient = false, customSort } = {}) => {
+        metadata: async ({ StudyInstanceUID, madeInClient = false, customSort } = {}) => {
           if (!StudyInstanceUID) {
             throw new Error('Unable to query for SeriesMetadata without StudyInstanceUID');
           }

--- a/extensions/default/src/DicomWebProxyDataSource/index.js
+++ b/extensions/default/src/DicomWebProxyDataSource/index.js
@@ -48,7 +48,7 @@ function createDicomWebProxyApi(dicomWebProxyConfig, UserAuthenticationService) 
     retrieve: {
       directURL: (...args) => dicomWebDelegate.retrieve.directURL(...args),
       series: {
-        metadata: (...args) => dicomWebDelegate.retrieve.series.metadata(...args),
+        metadata: async (...args) => dicomWebDelegate.retrieve.series.metadata(...args),
       },
     },
     store: {


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

Stemming from this community issue https://community.ohif.org/t/ohif-viewer-deployed-on-azure-blob-storage-does-not-work-for-dicomjson/1023, I discovered that DICOM JSON loading was broken.  For instance, try this URL...

https://viewer-dev.ohif.org/viewer/dicomjson?url=https://ohif-dicom-json-example.s3.amazonaws.com/LIDC-IDRI-0001.json

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

The data source method retrieve.series.metadata was not declared as `async` for the DICOM JSON data source and there was code recently added in `Mode.tsx` that assumed a promise was being returned.

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

Try loading DICOM JSON and it should work.  In particular, this link should work...

https://deploy-preview-3659--ohif-dev.netlify.app/viewer/dicomjson?url=https://ohif-dicom-json-example.s3.amazonaws.com/LIDC-IDRI-0001.json
<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] OS: Windows 11 <!--[e.g. Windows 10, macOS 10.15.4]-->
- [x] Node version: 16.14.0<!--[e.g. 16.14.0]-->
- [x] Browser: Chrome 117.0.5938.89
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
