### PR TITLE
fix(StackSync): Miscellaneous fixes for stack image sync

### DIFF
--- a/extensions/cornerstone/src/commandsModule.ts
+++ b/extensions/cornerstone/src/commandsModule.ts
@@ -267,6 +267,18 @@ function commandsModule({
       toolbarService.recordInteraction(props);
     },
 
+    // Enable or disable a toggleable command, without calling the activation
+    // Used to setup already active tools from hanging protocols
+    toolbarSetActive: props => {
+      toolbarService.setActive(props.toolId, props.isActive ?? true);
+    },
+
+    // Enable stack prefetch on the given element
+    stackPrefetch: props => {
+      const { element } = props;
+      cstUtils.stackPrefetch.enable(element);
+    },
+
     setToolActive: ({ toolName, toolGroupId = null, toggledState }) => {
       if (toolName === 'Crosshairs') {
         const activeViewportToolGroup = toolGroupService.getToolGroup(null);
@@ -344,6 +356,28 @@ function commandsModule({
           },
         ],
       });
+    },
+    toggleReferenceLines: ({ toggledState }) => {
+      try {
+        const { viewportId } = _getActiveViewportEnabledElement();
+        const toolGroup = toolGroupService.getToolGroupForViewport(viewportId);
+
+        if (!toggledState) {
+          toolGroup.setToolDisabled(ReferenceLinesTool.toolName);
+          return;
+        }
+
+        toolGroup.setToolConfiguration(
+          ReferenceLinesTool.toolName,
+          {
+            sourceViewportId: viewportId,
+          },
+          true // overwrite
+        );
+        toolGroup.setToolEnabled(ReferenceLinesTool.toolName);
+      } catch (e) {
+        console.log("Couldn't activate reference lines");
+      }
     },
     showDownloadViewportModal: () => {
       const { activeViewportId } = viewportGridService.getState();
@@ -551,7 +585,6 @@ function commandsModule({
 
     toggleStackImageSync: ({ toggledState }) => {
       toggleStackImageSync({
-        getEnabledElement,
         servicesManager,
         toggledState,
       });
@@ -562,6 +595,11 @@ function commandsModule({
 
       const viewportId = viewportInfo.getViewportId();
       const toolGroup = toolGroupService.getToolGroupForViewport(viewportId);
+
+      if (!toggledState) {
+        toolGroup.setToolDisabled(ReferenceLinesTool.toolName);
+        return;
+      }
 
       toolGroup.setToolConfiguration(
         ReferenceLinesTool.toolName,
@@ -701,8 +739,15 @@ function commandsModule({
     },
     storePresentation: {
       commandFn: actions.storePresentation,
-      storeContexts: [],
-      options: {},
+    },
+    stackPrefetch: {
+      commandFn: actions.stackPrefetch,
+    },
+    toolbarSetActive: {
+      commandFn: actions.toolbarSetActive,
+    },
+    toggleReferenceLines: {
+      commandFn: actions.toggleReferenceLines,
     },
   };
 

--- a/extensions/cornerstone/src/utils/CornerstoneViewportDownloadForm.tsx
+++ b/extensions/cornerstone/src/utils/CornerstoneViewportDownloadForm.tsx
@@ -142,12 +142,16 @@ const CornerstoneViewportDownloadForm = ({
           const properties = viewport.getProperties();
 
           downloadViewport.setStack([imageId]).then(() => {
-            downloadViewport.setProperties(properties);
+            try {
+              downloadViewport.setProperties(properties);
+              const newWidth = Math.min(width || image.width, MAX_TEXTURE_SIZE);
+              const newHeight = Math.min(height || image.height, MAX_TEXTURE_SIZE);
 
-            const newWidth = Math.min(width || image.width, MAX_TEXTURE_SIZE);
-            const newHeight = Math.min(height || image.height, MAX_TEXTURE_SIZE);
-
-            resolve({ width: newWidth, height: newHeight });
+              resolve({ width: newWidth, height: newHeight });
+            } catch (e) {
+              // Happens on clicking the cancel button
+              console.warn('Unable to set properties', e);
+            }
           });
         } else if (downloadViewport instanceof VolumeViewport) {
           const actors = viewport.getActors();

--- a/extensions/cornerstone/src/utils/stackSync/toggleStackImageSync.ts
+++ b/extensions/cornerstone/src/utils/stackSync/toggleStackImageSync.ts
@@ -1,90 +1,81 @@
-import calculateViewportRegistrations from './calculateViewportRegistrations';
+const disableSync = (syncName, servicesManager) => {
+  const { syncGroupService, viewportGridService, displaySetService, cornerstoneViewportService } =
+    servicesManager.services;
+  const viewports = getViewports(viewportGridService, displaySetService);
+  viewports.forEach(gridViewport => {
+    const { viewportId } = gridViewport.viewportOptions;
+    const viewport = cornerstoneViewportService.getCornerstoneViewport(viewportId);
+    if (!viewport) {
+      return;
+    }
+    syncGroupService.removeViewportFromSyncGroup(
+      viewport.id,
+      viewport.getRenderingEngine().id,
+      syncName
+    );
+  });
+};
 
-// [ {
-//   synchronizerId: string,
-//   viewports: [ { viewportId: string, renderingEngineId: string, index: number } , ...]
-// ]}
-let STACK_IMAGE_SYNC_GROUPS_INFO = [];
+const getViewports = (viewportGridService, displaySetService) => {
+  let { viewports } = viewportGridService.getState();
 
-export default function toggleStackImageSync({ toggledState, servicesManager, getEnabledElement }) {
+  viewports = [...viewports.values()];
+  // filter empty viewports
+  viewports = viewports.filter(
+    viewport => viewport.displaySetInstanceUIDs && viewport.displaySetInstanceUIDs.length
+  );
+
+  // filter reconstructable viewports
+  viewports = viewports.filter(viewport => {
+    const { displaySetInstanceUIDs } = viewport;
+
+    for (const displaySetInstanceUID of displaySetInstanceUIDs) {
+      const displaySet = displaySetService.getDisplaySetByUID(displaySetInstanceUID);
+
+      // TODO - add a better test than isReconstructable
+      if (displaySet && displaySet.isReconstructable) {
+        return true;
+      }
+
+      return false;
+    }
+  });
+
+  // viewports = viewports.filter(viewport => viewport.viewportOptions.viewportType === 'stack');
+
+  console.log('viewports=', viewports);
+  return viewports;
+};
+
+const STACK_SYNC_NAME = 'stackImageSync';
+
+export default function toggleStackImageSync({
+  toggledState,
+  servicesManager,
+  viewports: providedViewports,
+}) {
+  if (!toggledState) {
+    return disableSync(STACK_SYNC_NAME, servicesManager);
+  }
+
+  console.log('Toggling stack image sync');
   const { syncGroupService, viewportGridService, displaySetService, cornerstoneViewportService } =
     servicesManager.services;
 
-  if (!toggledState) {
-    STACK_IMAGE_SYNC_GROUPS_INFO.forEach(syncGroupInfo => {
-      const { viewports, synchronizerId } = syncGroupInfo;
+  const viewports = providedViewports || getViewports(viewportGridService, displaySetService);
 
-      viewports.forEach(({ viewportId, renderingEngineId }) => {
-        syncGroupService.removeViewportFromSyncGroup(viewportId, renderingEngineId, synchronizerId);
-      });
-    });
-
-    return;
-  }
-
-  STACK_IMAGE_SYNC_GROUPS_INFO = [];
-
-  // create synchronization groups and add viewports
-  const { viewports } = viewportGridService.getState();
-
-  // filter empty viewports
-  const viewportsArray = Array.from(viewports.values())
-    .filter(viewport => viewport.displaySetInstanceUIDs?.length)
-    // filter reconstructable viewports
-    .filter(viewport => {
-      const { displaySetInstanceUIDs } = viewport;
-
-      for (const displaySetInstanceUID of displaySetInstanceUIDs) {
-        const displaySet = displaySetService.getDisplaySetByUID(displaySetInstanceUID);
-
-        return !!displaySet?.isReconstructable;
-      }
-    });
-
-  const viewportsByOrientation = viewportsArray.reduce((acc, viewport) => {
-    const { viewportId, viewportType } = viewport.viewportOptions;
-
-    if (viewportType !== 'stack') {
-      console.warn('Viewport is not a stack, cannot sync images yet');
-      return acc;
+  // create synchronization group and add the viewports to it.
+  viewports.forEach(gridViewport => {
+    const { viewportId } = gridViewport.viewportOptions;
+    const viewport = cornerstoneViewportService.getCornerstoneViewport(viewportId);
+    if (!viewport) {
+      return;
     }
-
-    const { element } = cornerstoneViewportService.getViewportInfo(viewportId);
-    const { viewport: csViewport, renderingEngineId } = getEnabledElement(element);
-    const { viewPlaneNormal } = csViewport.getCamera();
-
-    // Should we round here? I guess so, but not sure how much precision we need
-    const orientation = viewPlaneNormal.map(v => Math.round(v)).join(',');
-
-    if (!acc[orientation]) {
-      acc[orientation] = [];
-    }
-
-    acc[orientation].push({ viewportId, renderingEngineId });
-
-    return acc;
-  }, {});
-
-  // create synchronizer for each group
-  Object.values(viewportsByOrientation).map(viewports => {
-    let synchronizerId = viewports.map(({ viewportId }) => viewportId).join(',');
-
-    synchronizerId = `imageSync_${synchronizerId}`;
-
-    calculateViewportRegistrations(viewports);
-
-    viewports.forEach(({ viewportId, renderingEngineId }) => {
-      syncGroupService.addViewportToSyncGroup(viewportId, renderingEngineId, {
-        type: 'stackimage',
-        id: synchronizerId,
-        source: true,
-        target: true,
-      });
-    });
-
-    STACK_IMAGE_SYNC_GROUPS_INFO.push({
-      synchronizerId,
-      viewports,
+    syncGroupService.addViewportToSyncGroup(viewportId, viewport.getRenderingEngine().id, {
+      type: 'stackimage',
+      id: STACK_SYNC_NAME,
+      source: true,
+      target: true,
     });
   });
 }

--- a/modes/basic-test-mode/src/toolbarButtons.js
+++ b/modes/basic-test-mode/src/toolbarButtons.js
@@ -15,28 +15,15 @@ const { windowLevelPresets } = defaults;
  * @param {*} icon
  * @param {*} label
  */
-function _createButton(type, id, icon, label, commands, tooltip, uiType) {
+function _createButton(type, id, icon, label, commands, tooltip, extraOptions = undefined) {
   return {
     id,
     icon,
     label,
     type,
     commands,
-    tooltip,
-    uiType,
+    ...extraOptions,
   };
-}
-
-function _createCommands(commandName, toolName, toolGroupIds) {
-  return toolGroupIds.map(toolGroupId => ({
-    /* It's a command that is being run when the button is clicked. */
-    commandName,
-    commandOptions: {
-      toolName,
-      toolGroupId,
-    },
-    context: 'CORNERSTONE',
-  }));
 }
 
 const _createActionButton = _createButton.bind(null, 'action');
@@ -66,6 +53,88 @@ function _createWwwcPreset(preset, title, subtitle) {
     ],
   };
 }
+
+const toolGroupIds = ['default', 'mpr', 'SRToolGroup'];
+
+/**
+ * Creates an array of 'setToolActive' commands for the given toolName - one for
+ * each toolGroupId specified in toolGroupIds.
+ * @param {string} toolName
+ * @returns {Array} an array of 'setToolActive' commands
+ */
+function _createSetToolActiveCommands(toolName) {
+  const temp = toolGroupIds.map(toolGroupId => ({
+    commandName: 'setToolActive',
+    commandOptions: {
+      toolGroupId,
+      toolName,
+    },
+    context: 'CORNERSTONE',
+  }));
+  return temp;
+}
+
+const StackImageSync = _createToggleButton(
+  'StackImageSync',
+  'link',
+  'Stack Image Sync',
+  [
+    {
+      commandName: 'toggleStackImageSync',
+    },
+  ],
+  'Enable position synchronization on stack viewports',
+  {
+    listeners: {
+      newStack: {
+        commandName: 'toggleStackImageSync',
+        commandOptions: { toggledState: true },
+      },
+    },
+  }
+);
+
+const StackPrefetch = _createToggleButton(
+  'StackPrefetch',
+  'link',
+  'Stack Prefetch',
+  [],
+  'Enable Complete Stack Prefetch',
+  {
+    listeners: {
+      newStack: {
+        commandName: 'stackPrefetch',
+      },
+    },
+    isActive: true,
+  }
+);
+
+const ReferenceLines = _createToggleButton(
+  'ReferenceLines',
+  'tool-referenceLines', // change this with the new icon
+  'Reference Lines',
+  [
+    {
+      commandName: 'toggleReferenceLines',
+      commandOptions: {},
+      context: 'CORNERSTONE',
+    },
+  ],
+  'Show reference lines',
+  {
+    listeners: {
+      activeViewportIdChanged: {
+        commandName: 'toggleReferenceLines',
+        commandOptions: { toggledState: true },
+      },
+      newStack: {
+        commandName: 'toggleReferenceLines',
+        commandOptions: { toggledState: true },
+      },
+    },
+  }
+);
 
 const toolbarButtons = [
   // Measurement
@@ -234,15 +303,7 @@ const toolbarButtons = [
       type: 'tool',
       icon: 'tool-zoom',
       label: 'Zoom',
-      commands: [
-        {
-          commandName: 'setToolActive',
-          commandOptions: {
-            toolName: 'Zoom',
-          },
-          context: 'CORNERSTONE',
-        },
-      ],
+      commands: _createSetToolActiveCommands('Zoom'),
     },
   },
   // Window Level + Presets...
@@ -291,15 +352,7 @@ const toolbarButtons = [
       type: 'tool',
       icon: 'tool-move',
       label: 'Pan',
-      commands: [
-        {
-          commandName: 'setToolActive',
-          commandOptions: {
-            toolName: 'Pan',
-          },
-          context: 'CORNERSTONE',
-        },
-      ],
+      commands: _createSetToolActiveCommands('Pan'),
     },
   },
   {
@@ -320,96 +373,10 @@ const toolbarButtons = [
   },
   {
     id: 'Layout',
-    type: 'ohif.splitButton',
+    type: 'ohif.layoutSelector',
     props: {
-      groupId: 'LayoutTools',
-      isRadio: false,
-      primary: {
-        id: 'Layout',
-        type: 'action',
-        uiType: 'ohif.layoutSelector',
-        icon: 'tool-layout',
-        label: 'Grid Layout',
-        props: {
-          rows: 4,
-          columns: 4,
-          commands: [
-            {
-              commandName: 'setLayout',
-              commandOptions: {},
-              context: 'CORNERSTONE',
-            },
-          ],
-        },
-      },
-      secondary: {
-        icon: 'chevron-down',
-        label: '',
-        isActive: true,
-        tooltip: 'Hanging Protocols',
-      },
-      items: [
-        {
-          id: '2x2',
-          type: 'action',
-          label: '2x2',
-          commands: [
-            {
-              commandName: 'setHangingProtocol',
-              commandOptions: {
-                protocolId: '@ohif/mnGrid',
-                stageId: '2x2',
-              },
-              context: 'DEFAULT',
-            },
-          ],
-        },
-        {
-          id: '3x1',
-          type: 'action',
-          label: '3x1',
-          commands: [
-            {
-              commandName: 'setHangingProtocol',
-              commandOptions: {
-                protocolId: '@ohif/mnGrid',
-                stageId: '3x1',
-              },
-              context: 'DEFAULT',
-            },
-          ],
-        },
-        {
-          id: '2x1',
-          type: 'action',
-          label: '2x1',
-          commands: [
-            {
-              commandName: 'setHangingProtocol',
-              commandOptions: {
-                protocolId: '@ohif/mnGrid',
-                stageId: '2x1',
-              },
-              context: 'DEFAULT',
-            },
-          ],
-        },
-        {
-          id: '1x1',
-          type: 'action',
-          label: '1x1',
-          commands: [
-            {
-              commandName: 'setHangingProtocol',
-              commandOptions: {
-                protocolId: '@ohif/mnGrid',
-                stageId: '1x1',
-              },
-              context: 'DEFAULT',
-            },
-          ],
-        },
-      ],
+      rows: 3,
+      columns: 3,
     },
   },
   {
@@ -441,8 +408,8 @@ const toolbarButtons = [
         {
           commandName: 'setToolActive',
           commandOptions: {
-            toolGroupId: 'mpr',
             toolName: 'Crosshairs',
+            toolGroupId: 'mpr',
           },
           context: 'CORNERSTONE',
         },
@@ -515,24 +482,24 @@ const toolbarButtons = [
           ],
           'Flip Horizontal'
         ),
-        _createToggleButton('StackImageSync', 'link', 'Stack Image Sync', [
-          {
-            commandName: 'toggleStackImageSync',
-            commandOptions: {},
-            context: 'CORNERSTONE',
-          },
-        ]),
+        StackImageSync,
+        ReferenceLines,
         _createToggleButton(
-          'ReferenceLines',
-          'tool-referenceLines', // change this with the new icon
-          'Reference Lines',
+          'ImageOverlayViewer',
+          'toggle-dicom-overlay',
+          'Image Overlay',
           [
             {
-              commandName: 'toggleReferenceLines',
-              commandOptions: {},
+              commandName: 'setToolActive',
+              commandOptions: {
+                toolName: 'ImageOverlayViewer',
+              },
               context: 'CORNERSTONE',
             },
-          ]
+          ],
+          'Image Overlay',
+          null,
+          { isActive: true }
         ),
         _createToolButton(
           'StackScroll',
@@ -604,6 +571,38 @@ const toolbarButtons = [
           ],
           'Angle'
         ),
+
+        // Next two tools can be added once icons are added
+        // _createToolButton(
+        //   'Cobb Angle',
+        //   'tool-cobb-angle',
+        //   'Cobb Angle',
+        //   [
+        //     {
+        //       commandName: 'setToolActive',
+        //       commandOptions: {
+        //         toolName: 'CobbAngle',
+        //       },
+        //       context: 'CORNERSTONE',
+        //     },
+        //   ],
+        //   'Cobb Angle'
+        // ),
+        // _createToolButton(
+        //   'Planar Freehand ROI',
+        //   'tool-freehand',
+        //   'PlanarFreehandROI',
+        //   [
+        //     {
+        //       commandName: 'setToolActive',
+        //       commandOptions: {
+        //         toolName: 'PlanarFreehandROI',
+        //       },
+        //       context: 'CORNERSTONE',
+        //     },
+        //   ],
+        //   'Planar Freehand ROI'
+        // ),
         _createToolButton(
           'Magnify',
           'tool-magnify',
@@ -634,6 +633,21 @@ const toolbarButtons = [
           ],
           'Rectangle'
         ),
+        _createToolButton(
+          'CalibrationLine',
+          'tool-calibration',
+          'Calibration',
+          [
+            {
+              commandName: 'setToolActive',
+              commandOptions: {
+                toolName: 'CalibrationLine',
+              },
+              context: 'CORNERSTONE',
+            },
+          ],
+          'Calibration Line'
+        ),
         _createActionButton(
           'TagBrowser',
           'list-bullets',
@@ -650,6 +664,11 @@ const toolbarButtons = [
       ],
     },
   },
+
+  // Register buttons that are used for top level actions
+  StackImageSync,
+  StackPrefetch,
+  ReferenceLines,
 ];
 
 export default toolbarButtons;

--- a/modes/longitudinal/src/toolbarButtons.js
+++ b/modes/longitudinal/src/toolbarButtons.js
@@ -15,16 +15,14 @@ const { windowLevelPresets } = defaults;
  * @param {*} icon
  * @param {*} label
  */
-function _createButton(type, id, icon, label, commands, tooltip, uiType, isActive) {
+function _createButton(type, id, icon, label, commands, tooltip, extraOptions = undefined) {
   return {
     id,
     icon,
     label,
     type,
     commands,
-    tooltip,
-    uiType,
-    isActive,
+    ...extraOptions,
   };
 }
 
@@ -75,6 +73,68 @@ function _createSetToolActiveCommands(toolName) {
   }));
   return temp;
 }
+
+const StackImageSync = _createToggleButton(
+  'StackImageSync',
+  'link',
+  'Stack Image Sync',
+  [
+    {
+      commandName: 'toggleStackImageSync',
+    },
+  ],
+  'Enable position synchronization on stack viewports',
+  {
+    listeners: {
+      newStack: {
+        commandName: 'toggleStackImageSync',
+        commandOptions: { toggledState: true },
+      },
+    },
+  }
+);
+
+const StackPrefetch = _createToggleButton(
+  'StackPrefetch',
+  'link',
+  'Stack Prefetch',
+  [],
+  'Enable Complete Stack Prefetch',
+  {
+    listeners: {
+      newStack: {
+        commandName: 'stackPrefetch',
+      },
+    },
+    isActive: true,
+  }
+);
+
+const ReferenceLines = _createToggleButton(
+  'ReferenceLines',
+  'tool-referenceLines', // change this with the new icon
+  'Reference Lines',
+  [
+    {
+      commandName: 'toggleReferenceLines',
+      commandOptions: {},
+      context: 'CORNERSTONE',
+    },
+  ],
+  'Show reference lines',
+  {
+    listeners: {
+      activeViewportIdChanged: {
+        commandName: 'toggleReferenceLines',
+        commandOptions: { toggledState: true },
+      },
+      newStack: {
+        commandName: 'toggleReferenceLines',
+        commandOptions: { toggledState: true },
+      },
+    },
+  }
+);
 
 const toolbarButtons = [
   // Measurement
@@ -422,35 +482,8 @@ const toolbarButtons = [
           ],
           'Flip Horizontal'
         ),
-        _createToggleButton('StackImageSync', 'link', 'Stack Image Sync', [
-          {
-            commandName: 'toggleStackImageSync',
-            commandOptions: {},
-            context: 'CORNERSTONE',
-          },
-        ]),
-        _createToggleButton(
-          'ReferenceLines',
-          'tool-referenceLines', // change this with the new icon
-          'Reference Lines',
-          // two commands for the reference lines tool:
-          // - the first to set the source viewport for the tool when it is enabled
-          // - the second to toggle the tool
-          [
-            {
-              commandName: 'setSourceViewportForReferenceLinesTool',
-              commandOptions: {},
-              context: 'CORNERSTONE',
-            },
-            {
-              commandName: 'setToolActive',
-              commandOptions: {
-                toolName: 'ReferenceLines',
-              },
-              context: 'CORNERSTONE',
-            },
-          ]
-        ),
+        StackImageSync,
+        ReferenceLines,
         _createToggleButton(
           'ImageOverlayViewer',
           'toggle-dicom-overlay',
@@ -466,7 +499,7 @@ const toolbarButtons = [
           ],
           'Image Overlay',
           null,
-          true
+          { isActive: true }
         ),
         _createToolButton(
           'StackScroll',
@@ -631,6 +664,11 @@ const toolbarButtons = [
       ],
     },
   },
+
+  // Register buttons that are used for top level actions
+  StackImageSync,
+  StackPrefetch,
+  ReferenceLines,
 ];
 
 export default toolbarButtons;

--- a/platform/app/cypress/integration/measurement-tracking/OHIFCornerstoneToolbar.spec.js
+++ b/platform/app/cypress/integration/measurement-tracking/OHIFCornerstoneToolbar.spec.js
@@ -406,20 +406,42 @@ describe('OHIF Cornerstone Toolbar', () => {
     cy.get('@moreBtn').click();
     cy.get('.tooltip-toolbar-overlay').should('not.exist');
   });
-
-  it('check if Flip V tool will flip the image vertically in the viewport', () => {
-    //Click on More button
-    cy.get('@moreBtn').click();
-    //Verify if overlay is displayed
-    cy.get('.tooltip-toolbar-overlay').should('be.visible');
-
-    //Click on Flip V button
-    cy.get('[data-cy="flip v"]').click();
+*/
+  it('check if Flip tool will flip the image in the viewport', () => {
     cy.get('@viewportInfoMidLeft').should('contains.text', 'R');
-    cy.get('@viewportInfoMidTop').should('contains.text', 'F');
+    cy.get('@viewportInfoMidTop').should('contains.text', 'A');
 
-    //Click on More button to close it
-    cy.get('@moreBtn').click();
-    cy.get('.tooltip-toolbar-overlay').should('not.exist');
-  });*/
+    //Click on More button
+    cy.get('@moreBtnSecondary').click();
+
+    //Click on Flip button
+    cy.get('[data-cy="flip-horizontal"]').click();
+    cy.waitDicomImage();
+    cy.get('@viewportInfoMidLeft').should('contains.text', 'L');
+    cy.get('@viewportInfoMidTop').should('contains.text', 'A');
+  });
+
+  it('checks if stack sync is preserved on new display set and uses FOR', () => {
+    // Active stack image sync and reference lines
+    cy.get('[data-cy="MoreTools-split-button-secondary"]').click();
+    cy.get('[data-cy="StackImageSync"]').click();
+    // Add reference lines as that sometimes throws an exception
+    cy.get('[data-cy="MoreTools-split-button-secondary"]').click();
+    cy.get('[data-cy="ReferenceLines"]').click();
+
+    cy.get('[data-cy="study-browser-thumbnail"]:nth-child(2)').dblclick();
+    cy.get('body').type('{downarrow}{downarrow}');
+
+    // Change the layout and double load the first
+    cy.setLayout(2, 1);
+    cy.get('body').type('{rightarrow}');
+    cy.get('[data-cy="study-browser-thumbnail"]:nth-child(2)').dblclick();
+    cy.waitDicomImage();
+
+    // Now navigate down once and check that the left hand pane navigated
+    cy.get('body').type('{downarrow}');
+    cy.get('body').type('{leftarrow}');
+    cy.setLayout(1, 1);
+    cy.get('@viewportInfoTopRight').should('contains.text', 'I:2 (2/20)');
+  });
 });

--- a/platform/app/cypress/integration/measurement-tracking/OHIFDownloadSnapshotFile.spec.js
+++ b/platform/app/cypress/integration/measurement-tracking/OHIFDownloadSnapshotFile.spec.js
@@ -36,6 +36,8 @@ describe('OHIF Download Snapshot File', () => {
     // Check buttons
     cy.get('[data-cy="cancel-btn"]').scrollIntoView().should('be.visible');
     cy.get('[data-cy="download-btn"]').scrollIntoView().should('be.visible');
+
+    cy.get('[data-cy="cancel-btn"]').click();
   });
 
   /*it('cancel changes on download modal', function() {

--- a/platform/app/cypress/integration/measurement-tracking/OHIFGeneralViewer.spec.js
+++ b/platform/app/cypress/integration/measurement-tracking/OHIFGeneralViewer.spec.js
@@ -1,11 +1,9 @@
-describe('OHIF Study Viewer Page', function () {
-  beforeEach(function () {
-    cy.checkStudyRouteInViewer('1.2.840.113619.2.5.1762583153.215519.978957063.78');
-
-    cy.expectMinimumThumbnails(3);
-    cy.initCommonElementsAliases();
-    cy.initCornerstoneToolsAliases();
-  });
+describe('OHIF General Viewer', function () {
+  beforeEach(() =>
+    cy.initViewer('1.2.840.113619.2.5.1762583153.215519.978957063.78', {
+      minimumThumbnails: 3,
+    })
+  );
 
   it('scrolls series stack using scrollbar', function () {
     cy.scrollToIndex(13);

--- a/platform/app/cypress/integration/measurement-tracking/OHIFStudyBrowser.spec.js
+++ b/platform/app/cypress/integration/measurement-tracking/OHIFStudyBrowser.spec.js
@@ -1,4 +1,4 @@
-describe('OHIF Study Viewer Page', function () {
+describe('OHIF Study Browser', function () {
   beforeEach(function () {
     cy.checkStudyRouteInViewer('1.2.840.113619.2.5.1762583153.215519.978957063.78');
 

--- a/platform/app/cypress/support/commands.js
+++ b/platform/app/cypress/support/commands.js
@@ -69,6 +69,18 @@ Cypress.Commands.add(
   }
 );
 
+Cypress.Commands.add('initViewer', (StudyInstanceUID, other = {}) => {
+  const { mode = '/basic-test', minimumThumbnails = 1, params = '' } = other;
+  cy.openStudyInViewer(StudyInstanceUID, params, mode);
+  cy.waitDicomImage();
+  // Very short wait to ensure pending updates are handled
+  cy.wait(25);
+
+  cy.expectMinimumThumbnails(minimumThumbnails);
+  cy.initCommonElementsAliases();
+  cy.initCornerstoneToolsAliases();
+});
+
 Cypress.Commands.add(
   'openStudyInViewer',
   (StudyInstanceUID, otherParams = '', mode = '/basic-test') => {
@@ -357,14 +369,9 @@ Cypress.Commands.add('percyCanvasSnapshot', (name, options = {}) => {
 });
 
 Cypress.Commands.add('setLayout', (columns = 1, rows = 1) => {
-  cy.get('[data-cy="layout"]').click();
+  cy.get('[data-cy="Layout"]').click();
 
-  cy.get('.layoutChooser')
-    .find('tr')
-    .eq(rows - 1)
-    .find('td')
-    .eq(columns - 1)
-    .click();
+  cy.get(`[data-cy="Layout-${columns - 1}-${rows - 1}"]`).click();
 
   cy.wait(10);
   cy.waitDicomImage();

--- a/platform/core/src/services/ToolBarService/ToolbarService.ts
+++ b/platform/core/src/services/ToolBarService/ToolbarService.ts
@@ -172,7 +172,13 @@ export default class ToolbarService extends PubSubService {
   }
 
   getActiveTools() {
-    return [this.state.primaryToolId, ...Object.keys(this.state.toggles)];
+    const activeTools = [this.state.primaryToolId];
+    Object.keys(this.state.toggles).forEach(key => {
+      if (this.state.toggles[key]) {
+        activeTools.push(key);
+      }
+    });
+    return activeTools;
   }
 
   /** Sets the toggle state of a button to the isActive state */

--- a/platform/ui/src/components/LayoutSelector/LayoutSelector.tsx
+++ b/platform/ui/src/components/LayoutSelector/LayoutSelector.tsx
@@ -34,6 +34,7 @@ function LayoutSelector({ onSelection, rows, columns }) {
               border: '1px solid white',
               backgroundColor: isHovered(index) ? '#5acce6' : '#0b1a42',
             }}
+            data-cy={`Layout-${index % columns}-${Math.floor(index / columns)}`}
             className="cursor-pointer"
             onClick={() => {
               const x = index % columns;


### PR DESCRIPTION
### Context

The stack image sync has two major issues:
  1. The stack image sync stays active in the toolbar when navigating display sets, but is inactive in the new viewport
  2. The stack image sync was setting the navigation position for FOR linked series, which prevented FOR navigation 

### Changes & Results

Changed the toolbar buttons to contain the listeners for re-activation in various situations
Applied the re-activation to:
  * Stack Prefetch
  * Stack Image Sync
  * Reference Lines

Removed the calls to the navigation position so that the FOR linking works again

Added an integration test for preserving the stack syncing on display set navigation

### Testing
Display 2x2 layout

Activate stack sync
Navigate display sets to linked studies
Display a new display set
Ensure that the stack sync is still active in the toolbar and in the image
Note that stack sync does NOT apply until an image is navigated.  This is pre-existing and has not been fixed.

Activate reference lines
Change the layout
Click on different display sets
Reference lines should be active on the selected viewport

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] OS: <!--[e.g. Windows 10, macOS 10.15.4]-->
- [] Node version: <!--[e.g. 16.14.0]-->
- [] Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
