### PR TITLE
fix(overlay): Overlays aren't shown on undefined origin

### DIFF
--- a/extensions/cornerstone/src/tools/ImageOverlayViewerTool.tsx
+++ b/extensions/cornerstone/src/tools/ImageOverlayViewerTool.tsx
@@ -73,6 +73,12 @@ class ImageOverlayViewerTool extends AnnotationDisplayTool {
       return;
     }
 
+    // Fix the x, y positions
+    overlays.forEach(overlay => {
+      overlay.x ||= 0;
+      overlay.y ||= 0;
+    });
+
     this._cachedOverlayMetadata.set(imageId, overlays);
 
     this._getCachedStat(imageId, overlays, this.configuration.fillColor).then(cachedStat => {

--- a/modes/basic-test-mode/src/initToolGroups.ts
+++ b/modes/basic-test-mode/src/initToolGroups.ts
@@ -51,6 +51,7 @@ function initDefaultToolGroup(extensionManager, toolGroupService, commandsManage
       { toolName: toolNames.SegmentationDisplay },
     ],
     // enabled
+    enabled: [{ toolName: toolNames.ImageOverlayViewer }],
     // disabled
     disabled: [{ toolName: toolNames.ReferenceLines }],
   };

--- a/platform/app/public/config/e2e.js
+++ b/platform/app/public/config/e2e.js
@@ -30,6 +30,10 @@ window.config = {
         supportsWildcard: true,
         singlepart: 'video,thumbnail,pdf',
         omitQuotationForMultipartRequest: true,
+        bulkDataURI: {
+          enabled: true,
+          relativeResolution: 'studies',
+        },
       },
     },
     {
@@ -50,6 +54,10 @@ window.config = {
         supportsWildcard: true,
         staticWado: true,
         singlepart: 'bulkdata,video,pdf',
+        bulkDataURI: {
+          enabled: true,
+          relativeResolution: 'studies',
+        },
       },
     },
     {
@@ -70,6 +78,10 @@ window.config = {
         supportsWildcard: true,
         staticWado: true,
         singlepart: 'bulkdata,video,pdf',
+        bulkDataURI: {
+          enabled: true,
+          relativeResolution: 'studies',
+        },
       },
     },
     {
@@ -89,27 +101,35 @@ window.config = {
         supportsWildcard: true,
         staticWado: true,
         singlepart: 'bulkdata,video,pdf',
+        bulkDataURI: {
+          enabled: true,
+          relativeResolution: 'studies',
+        },
       },
     },
-    // {
-    //   friendlyName: 'StaticWado default data',
-    //   namespace: '@ohif/extension-default.dataSourcesModule.dicomweb',
-    //   sourceName: 'dicomweb',
-    //   configuration: {
-    //     name: 'DCM4CHEE',
-    //     wadoUriRoot: '/dicomweb',
-    //     qidoRoot: '/dicomweb',
-    //     wadoRoot: '/dicomweb',
-    //     qidoSupportsIncludeField: false,
-    //     supportsReject: false,
-    //     imageRendering: 'wadors',
-    //     thumbnailRendering: 'wadors',
-    //     enableStudyLazyLoad: true,
-    //     supportsFuzzyMatching: false,
-    //     supportsWildcard: true,
-    //     staticWado: true,
-    //   },
-    // },
+    {
+      friendlyName: 'StaticWado default data',
+      namespace: '@ohif/extension-default.dataSourcesModule.dicomweb',
+      sourceName: 'dicomweb',
+      configuration: {
+        name: 'DCM4CHEE',
+        wadoUriRoot: '/dicomweb',
+        qidoRoot: '/dicomweb',
+        wadoRoot: '/dicomweb',
+        qidoSupportsIncludeField: false,
+        supportsReject: false,
+        imageRendering: 'wadors',
+        thumbnailRendering: 'wadors',
+        enableStudyLazyLoad: true,
+        supportsFuzzyMatching: false,
+        supportsWildcard: true,
+        staticWado: true,
+        bulkDataURI: {
+          enabled: true,
+          relativeResolution: 'studies',
+        },
+      },
+    },
     {
       namespace: '@ohif/extension-default.dataSourcesModule.dicomjson',
       sourceName: 'dicomjson',


### PR DESCRIPTION
### Context

Overlays at position 0,0 were getting x,y undefined as the tag was missing.  
Default to 0,0 for these values.
Also, add settings to ensure overlays can be fetched.

### Changes & Results

Add set to 0 if undefined for origin of overlays
Add bulkdata retrieve for e2e tests (configuration only)
Add default enabled overlay viewer tool for basic test

### Testing

Find an image with an overlay
Display it, should see the overlay in the main viewer.
Overlays do not appear in the left hand thumbnail.

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] OS: <!--[e.g. Windows 10, macOS 10.15.4]-->
- [] Node version: <!--[e.g. 18.16.1]-->
- [] Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
