### PR TITLE
feat(overlay): add inline binary overlays

### DIFF
--- a/extensions/cornerstone/src/tools/ImageOverlayViewerTool.tsx
+++ b/extensions/cornerstone/src/tools/ImageOverlayViewerTool.tsx
@@ -1,7 +1,7 @@
 import { VolumeViewport, metaData, utilities } from '@cornerstonejs/core';
 import { IStackViewport, IVolumeViewport, Point3 } from '@cornerstonejs/core/dist/esm/types';
 import { AnnotationDisplayTool, drawing } from '@cornerstonejs/tools';
-import { guid } from '@ohif/core/src/utils';
+import { guid, b64toBlob } from '@ohif/core/src/utils';
 import OverlayPlaneModuleProvider from './OverlayPlaneModuleProvider';
 
 interface CachedStat {
@@ -46,7 +46,7 @@ class ImageOverlayViewerTool extends AnnotationDisplayTool {
     super(toolProps, defaultToolProps);
   }
 
-  onSetToolDisabled = (): void => { };
+  onSetToolDisabled = (): void => {};
 
   protected getReferencedImageId(viewport: IStackViewport | IVolumeViewport): string {
     if (viewport instanceof VolumeViewport) {
@@ -174,6 +174,10 @@ class ImageOverlayViewerTool extends AnnotationDisplayTool {
             pixelData = overlay.pixelData[0];
           } else if (overlay.pixelData.retrieveBulkData) {
             pixelData = await overlay.pixelData.retrieveBulkData();
+          } else if (overlay.pixelData.InlineBinary) {
+            const blob = b64toBlob(overlay.pixelData.InlineBinary);
+            const arrayBuffer = await blob.arrayBuffer();
+            pixelData = arrayBuffer;
           }
 
           if (!pixelData) {


### PR DESCRIPTION
### Context

Adding the ability of rendering inline binary overlays which wasn't previously supported.

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

Manually tested with a server that sends the overlays with an InlineBinary format.

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [X] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [X] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [X] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [X] OS: MacOS 14.0 (23A344)
- [X] Node version: 18.16.1
- [X] Browser: Chrome  119.0.6045.105
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
