### PR TITLE
fix: PDF display request in v3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ version: 2.1
 ##
 orbs:
   codecov: codecov/codecov@1.0.5
-  cypress: cypress-io/cypress@3.1.4
+  cypress: cypress-io/cypress@3.2.1
 
 executors:
   cypress-custom:

--- a/extensions/default/package.json
+++ b/extensions/default/package.json
@@ -33,7 +33,7 @@
     "@ohif/core": "3.8.0-beta.36",
     "@ohif/i18n": "3.8.0-beta.36",
     "dcmjs": "^0.29.12",
-    "dicomweb-client": "^0.10.2",
+    "dicomweb-client": "^0.10.4",
     "prop-types": "^15.6.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/extensions/default/src/DicomWebDataSource/index.js
+++ b/extensions/default/src/DicomWebDataSource/index.js
@@ -373,11 +373,12 @@ function createDicomWebApi(dicomWebConfig, servicesManager) {
           // in which case it isn't necessary to re-read this.
           if (value && value.BulkDataURI && !value.Value) {
             // Provide a method to fetch bulkdata
-            value.retrieveBulkData = () => {
+            value.retrieveBulkData = (options = {}) => {
               // handle the scenarios where bulkDataURI is relative path
               fixBulkDataURI(value, naturalized, dicomWebConfig);
 
-              const options = {
+              const { mediaType } = options;
+              const useOptions = {
                 // The bulkdata fetches work with either multipart or
                 // singlepart, so set multipart to false to let the server
                 // decide which type to respond with.
@@ -388,9 +389,13 @@ function createDicomWebApi(dicomWebConfig, servicesManager) {
                 // isn't well specified in the standard, but is needed in
                 // any implementation that stores static copies of the metadata
                 StudyInstanceUID: naturalized.StudyInstanceUID,
+                mediaTypes: mediaType
+                  ? [{ mediaType }, { mediaType: 'application/octet-stream' }]
+                  : undefined,
+                ...options,
               };
               // Todo: this needs to be from wado dicom web client
-              return qidoDicomWebClient.retrieveBulkData(options).then(val => {
+              return qidoDicomWebClient.retrieveBulkData(useOptions).then(val => {
                 // There are DICOM PDF cases where the first ArrayBuffer in the array is
                 // the bulk data and DICOM video cases where the second ArrayBuffer is
                 // the bulk data. Here we play it safe and do a find.

--- a/extensions/default/src/utils/getDirectURL.js
+++ b/extensions/default/src/utils/getDirectURL.js
@@ -37,7 +37,11 @@ const getDirectURL = (config, params) => {
   }
   if (!singlepart || (singlepart !== true && singlepart.indexOf(fetchPart) === -1)) {
     if (value.retrieveBulkData) {
-      return value.retrieveBulkData().then(arr => {
+      // Try the specified retrieve type.
+      const options = {
+        mediaType: defaultType,
+      };
+      return value.retrieveBulkData(options).then(arr => {
         value.DirectRetrieveURL = URL.createObjectURL(new Blob([arr], { type: defaultType }));
         return value.DirectRetrieveURL;
       });

--- a/platform/app/package.json
+++ b/platform/app/package.json
@@ -95,7 +95,7 @@
   "devDependencies": {
     "@babel/plugin-proposal-private-methods": "^7.18.6",
     "@percy/cypress": "^3.1.1",
-    "cypress": "^13.2.0",
+    "cypress": "13.6.2",
     "cypress-file-upload": "^3.5.3",
     "glob": "^8.0.3",
     "identity-obj-proxy": "3.0.x",

--- a/platform/app/public/config/e2e.js
+++ b/platform/app/public/config/e2e.js
@@ -53,7 +53,7 @@ window.config = {
         supportsFuzzyMatching: false,
         supportsWildcard: true,
         staticWado: true,
-        singlepart: 'bulkdata,video,pdf',
+        singlepart: 'video',
         bulkDataURI: {
           enabled: true,
           relativeResolution: 'studies',

--- a/platform/core/package.json
+++ b/platform/core/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@babel/runtime": "^7.20.13",
     "dcmjs": "^0.29.12",
-    "dicomweb-client": "^0.10.2",
+    "dicomweb-client": "^0.10.4",
     "gl-matrix": "^3.4.3",
     "isomorphic-base64": "^1.0.2",
     "lodash.clonedeep": "^4.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8832,10 +8832,10 @@ dicomicc@^0.1:
   resolved "https://registry.yarnpkg.com/dicomicc/-/dicomicc-0.1.0.tgz#c73acc60a8e2d73a20f462c8c7d0e1e0d977c486"
   integrity sha512-kZejPGjLQ9NsgovSyVsiAuCpq6LofNR9Erc8Tt/vQAYGYCoQnTyWDlg5D0TJJQATKul7cSr9k/q0TF8G9qdDkQ==
 
-dicomweb-client@^0.10.2:
-  version "0.10.3"
-  resolved "https://registry.yarnpkg.com/dicomweb-client/-/dicomweb-client-0.10.3.tgz#b4fe550037166dff5d8afd88db3800eb579c91f4"
-  integrity sha512-/fHNEAYiz8j+9TNOrNJ0k+hYqirbOT85B7vM7I4VkY8DeDQb4BDUeL3RX6huDVtn6ZQlR91dI+2tejLc5c99wA==
+dicomweb-client@^0.10.4:
+  version "0.10.4"
+  resolved "https://registry.yarnpkg.com/dicomweb-client/-/dicomweb-client-0.10.4.tgz#f32f8659e51fbaf3f924c81fe8b7ad80297f2bc5"
+  integrity sha512-TEt26c0JI37IGmSqoj1k1/Y/ZIyq33/ysVaUwE0/Haosn2IBM55NEIPkT+AnhFss2nFAMVtKKWKWLox4luthVw==
 
 dicomweb-client@^0.8:
   version "0.8.4"
@@ -14217,7 +14217,7 @@ media-typer@0.3.0:
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
   integrity sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==
 
-medium-zoom@^1.0.4:
+medium-zoom@^1.0.8:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/medium-zoom/-/medium-zoom-1.1.0.tgz#6efb6bbda861a02064ee71a2617a8dc4381ecc71"
   integrity sha512-ewyDsp7k4InCUp3jRmwHBRFGyjBimKps/AJLjRSox+2q/2H4p/PNpQf+pwONWlJiOudkBXtbdmVbFjqyybfTmQ==
@@ -16168,7 +16168,7 @@ plugin-image-zoom@ataft/plugin-image-zoom:
   version "1.1.0"
   resolved "https://codeload.github.com/ataft/plugin-image-zoom/tar.gz/8e1b866c79ed6d42cefc4c52f851f1dfd1d0c7de"
   dependencies:
-    medium-zoom "^1.0.4"
+    medium-zoom "^1.0.8"
 
 polished@^4.2.2:
   version "4.2.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8281,10 +8281,10 @@ cypress-file-upload@^3.5.3:
   resolved "https://registry.yarnpkg.com/cypress-file-upload/-/cypress-file-upload-3.5.3.tgz#cd706485de3fb2cbd4a8c2dd90fe96d537bb4311"
   integrity sha512-S/czzqAj1BYz6Xxnfpx2aSc6hXsj76fd8/iuycJ2RxoxCcQMliw8eQV0ugzVlkzr1GD5dKGviNFGYqv3nRJ+Tg==
 
-cypress@^13.2.0:
-  version "13.6.1"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-13.6.1.tgz#c5f714f08551666ed3ac1fa95718eabb23a416df"
-  integrity sha512-k1Wl5PQcA/4UoTffYKKaxA0FJKwg8yenYNYRzLt11CUR0Kln+h7Udne6mdU1cUIdXBDTVZWtmiUjzqGs7/pEpw==
+cypress@13.6.2:
+  version "13.6.2"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-13.6.2.tgz#c70df09db0a45063298b3cecba2fa21109768e08"
+  integrity sha512-TW3bGdPU4BrfvMQYv1z3oMqj71YI4AlgJgnrycicmPZAXtvywVFZW9DAToshO65D97rCWfG/kqMFsYB6Kp91gQ==
   dependencies:
     "@cypress/request" "^3.0.0"
     "@cypress/xvfb" "^1.2.4"
@@ -16168,7 +16168,7 @@ plugin-image-zoom@ataft/plugin-image-zoom:
   version "1.1.0"
   resolved "https://codeload.github.com/ataft/plugin-image-zoom/tar.gz/8e1b866c79ed6d42cefc4c52f851f1dfd1d0c7de"
   dependencies:
-    medium-zoom "^1.0.8"
+    medium-zoom "^1.0.4"
 
 polished@^4.2.2:
   version "4.2.2"


### PR DESCRIPTION
fixes #3826 

### Context

Some PACS systems required requesting encapsulated PDF using multipart/related;type=application/pdf instead of application/octet-stream.  This PR enables the required fetch to be completed.

### Changes & Results

Change the retrieveBulkdata to use the dicomweb-client 0.10.4 version which allows fetching bulkdata using application/pdf, with a backup of application/octet-stream

### Testing

Find an encapsulated PDF instance on a DCM4CHEE back end and ensure it displays in OHIF

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] OS: <!--[e.g. Windows 10, macOS 10.15.4]-->
- [] Node version: <!--[e.g. 18.16.1]-->
- [] Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
