### PR TITLE
fix: Microscopy bulkdata and image retrieve

### DIFF
--- a/extensions/default/src/DicomWebDataSource/utils/StaticWadoClient.ts
+++ b/extensions/default/src/DicomWebDataSource/utils/StaticWadoClient.ts
@@ -10,7 +10,7 @@ if (!anyDicomwebClient._orig_buildMultipartAcceptHeaderFieldValue) {
   anyDicomwebClient._orig_buildMultipartAcceptHeaderFieldValue =
     anyDicomwebClient._buildMultipartAcceptHeaderFieldValue;
   anyDicomwebClient._buildMultipartAcceptHeaderFieldValue = function (mediaTypes, acceptableTypes) {
-    if (mediaTypes.length === 1 && mediaTypes[0].mediaType === 'image/*') {
+    if (mediaTypes.length === 1 && mediaTypes[0].mediaType.endsWith('/*')) {
       return '*/*';
     } else {
       return anyDicomwebClient._orig_buildMultipartAcceptHeaderFieldValue(
@@ -66,8 +66,14 @@ export default class StaticWadoClient extends api.DICOMwebClient {
    */
   public retrieveBulkData(options): Promise<any[]> {
     const shouldFixMultipart = this.config.fixBulkdataMultipart !== false;
+    const useOptions = {
+      ...options,
+    };
+    if (this.staticWado) {
+      useOptions.mediaTypes = [{ mediaType: 'application/*' }];
+    }
     return super
-      .retrieveBulkData(options)
+      .retrieveBulkData(useOptions)
       .then(result => (shouldFixMultipart ? fixMultipart(result) : result));
   }
 

--- a/extensions/default/src/DicomWebDataSource/utils/StaticWadoClient.ts
+++ b/extensions/default/src/DicomWebDataSource/utils/StaticWadoClient.ts
@@ -1,4 +1,25 @@
 import { api } from 'dicomweb-client';
+import fixMultipart from './fixMultipart';
+
+const { DICOMwebClient } = api;
+
+const anyDicomwebClient = DICOMwebClient as any;
+
+// Ugly over-ride, but the internals aren't otherwise accessible.
+if (!anyDicomwebClient._orig_buildMultipartAcceptHeaderFieldValue) {
+  anyDicomwebClient._orig_buildMultipartAcceptHeaderFieldValue =
+    anyDicomwebClient._buildMultipartAcceptHeaderFieldValue;
+  anyDicomwebClient._buildMultipartAcceptHeaderFieldValue = function (mediaTypes, acceptableTypes) {
+    if (mediaTypes.length === 1 && mediaTypes[0].mediaType === 'image/*') {
+      return '*/*';
+    } else {
+      return anyDicomwebClient._orig_buildMultipartAcceptHeaderFieldValue(
+        mediaTypes,
+        acceptableTypes
+      );
+    }
+  };
+}
 
 /**
  * An implementation of the static wado client, that fetches data from
@@ -25,9 +46,44 @@ export default class StaticWadoClient extends api.DICOMwebClient {
     modality: '00080060',
   };
 
-  constructor(qidoConfig) {
-    super(qidoConfig);
-    this.staticWado = qidoConfig.staticWado;
+  protected config;
+  protected staticWado;
+
+  constructor(config) {
+    super(config);
+    this.staticWado = config.staticWado;
+    this.config = config;
+  }
+
+  /**
+   * Handle improperly specified multipart/related return type.
+   * Note if the response is SUPPOSED to be multipart encoded already, then this
+   * will double-decode it.
+   *
+   * @param options
+   * @returns De-multiparted response data.
+   *
+   */
+  public retrieveBulkData(options): Promise<any[]> {
+    const shouldFixMultipart = this.config.fixBulkdataMultipart !== false;
+    return super
+      .retrieveBulkData(options)
+      .then(result => (shouldFixMultipart ? fixMultipart(result) : result));
+  }
+
+  /**
+   * Retrieves instance frames using the image/* media type when configured
+   * to do so (static wado back end).
+   */
+  public retrieveInstanceFrames(options) {
+    if (this.staticWado) {
+      return super.retrieveInstanceFrames({
+        ...options,
+        mediaTypes: [{ mediaType: 'image/*' }],
+      });
+    } else {
+      return super.retrieveInstanceFrames(options);
+    }
   }
 
   /**

--- a/extensions/default/src/DicomWebDataSource/utils/findIndexOfString.ts
+++ b/extensions/default/src/DicomWebDataSource/utils/findIndexOfString.ts
@@ -1,0 +1,47 @@
+function checkToken(token, data, dataOffset): boolean {
+  if (dataOffset + token.length > data.length) {
+    return false;
+  }
+
+  let endIndex = dataOffset;
+
+  for (let i = 0; i < token.length; i++) {
+    if (token[i] !== data[endIndex++]) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function stringToUint8Array(str: string): Uint8Array {
+  const uint = new Uint8Array(str.length);
+
+  for (let i = 0, j = str.length; i < j; i++) {
+    uint[i] = str.charCodeAt(i);
+  }
+
+  return uint;
+}
+
+function findIndexOfString(
+  data: Uint8Array,
+  str: string,
+  offset?: number
+): number {
+  offset = offset || 0;
+
+  const token = stringToUint8Array(str);
+
+  for (let i = offset; i < data.length; i++) {
+    if (token[0] === data[i]) {
+      // console.log('match @', i);
+      if (checkToken(token, data, i)) {
+        return i;
+      }
+    }
+  }
+
+  return -1;
+}
+export default findIndexOfString;

--- a/extensions/default/src/DicomWebDataSource/utils/fixMultipart.ts
+++ b/extensions/default/src/DicomWebDataSource/utils/fixMultipart.ts
@@ -1,0 +1,70 @@
+import findIndexOfString from './findIndexOfString';
+
+/**
+ * Fix multipart data coming back from the retrieve bulkdata request, but
+ * incorrectly tagged as application/octet-stream.  Some servers don't handle
+ * the response type correctly, and this method is relatively robust about
+ * detecting multipart data correctly.  It will only extract one value.
+ */
+export default function fixMultipart(arrayData) {
+  const data = new Uint8Array(arrayData[0]);
+  // Don't know the exact minimum length, but it is at least 25 to encode multipart
+  if (data.length < 25) {
+    return arrayData;
+  }
+  const dashIndex = findIndexOfString(data, '--');
+  if (dashIndex > 6) {
+    return arrayData;
+  }
+  const tokenIndex = findIndexOfString(data, '\r\n\r\n', dashIndex);
+  if (tokenIndex > 512) {
+    // Allow for 512 characters in the header - there is no apriori limit, but
+    // this seems ok for now as we only expect it to have content type in it.
+    return arrayData;
+  }
+  const header = uint8ArrayToString(data, 0, tokenIndex);
+  // Now find the boundary  marker
+  const responseHeaders = header.split('\r\n');
+  const boundary = findBoundary(responseHeaders);
+
+  if (!boundary) {
+    return arrayData;
+  }
+  // Start of actual data is 4 characters after the token
+  const offset = tokenIndex + 4;
+
+  const endIndex = findIndexOfString(data, boundary, offset);
+  if (endIndex === -1) {
+    return arrayData;
+  }
+
+  return [data.slice(offset, endIndex - 2).buffer];
+}
+
+export function findBoundary(header: string[]): string {
+  for (let i = 0; i < header.length; i++) {
+    if (header[i].substr(0, 2) === '--') {
+      return header[i];
+    }
+  }
+}
+
+export function findContentType(header: string[]): string {
+  for (let i = 0; i < header.length; i++) {
+    if (header[i].substr(0, 13) === 'Content-Type:') {
+      return header[i].substr(13).trim();
+    }
+  }
+}
+
+export function uint8ArrayToString(data, offset, length) {
+  offset = offset || 0;
+  length = length || data.length - offset;
+  let str = '';
+
+  for (let i = offset; i < offset + length; i++) {
+    str += String.fromCharCode(data[i]);
+  }
+
+  return str;
+}

--- a/extensions/default/src/index.ts
+++ b/extensions/default/src/index.ts
@@ -15,6 +15,7 @@ import { ContextMenuController, CustomizableContextMenuTypes } from './Customiza
 import * as dicomWebUtils from './DicomWebDataSource/utils';
 import { createReportDialogPrompt } from './Panels';
 import createReportAsync from './Actions/createReportAsync';
+import StaticWadoClient from './DicomWebDataSource/utils/StaticWadoClient';
 
 const defaultExtension: Types.Extensions.Extension = {
   /**
@@ -52,4 +53,5 @@ export {
   dicomWebUtils,
   createReportDialogPrompt,
   createReportAsync,
+  StaticWadoClient,
 };

--- a/extensions/dicom-microscopy/src/utils/dicomWebClient.ts
+++ b/extensions/dicom-microscopy/src/utils/dicomWebClient.ts
@@ -1,11 +1,5 @@
-import { api } from 'dicomweb-client';
 import { errorHandler, DicomMetadataStore } from '@ohif/core';
-
-const { DICOMwebClient } = api;
-
-DICOMwebClient._buildMultipartAcceptHeaderFieldValue = () => {
-  return '*/*';
-};
+import { StaticWadoClient } from '@ohif/extension-default';
 
 /**
  * create a DICOMwebClient object to be used by Dicom Microscopy Viewer
@@ -31,7 +25,7 @@ export default function getDicomWebClient({ extensionManager, servicesManager })
     errorInterceptor: errorHandler.getHTTPErrorHandler(),
   };
 
-  const client = new api.DICOMwebClient(wadoConfig);
+  const client = new StaticWadoClient(wadoConfig);
   client.wadoURL = wadoConfig.url;
 
   if (extensionManager.activeDataSource === 'dicomlocal') {

--- a/platform/app/public/config/e2e.js
+++ b/platform/app/public/config/e2e.js
@@ -100,7 +100,7 @@ window.config = {
         supportsFuzzyMatching: false,
         supportsWildcard: true,
         staticWado: true,
-        singlepart: 'bulkdata,video,pdf',
+        singlepart: 'video,pdf',
         bulkDataURI: {
           enabled: true,
           relativeResolution: 'studies',


### PR DESCRIPTION
### Context

Some backends incorrectly report the type of the bulkdata.  This PR checks the bulkdata contents to see if it is multipart, and if so, demultiparts it when doing the retrieveBulkdata
Also, for many back ends, using the generic */* accept type works fine for retrieval, and that can be faster than having a full retrieve list.  

### Changes & Results

For all back ends, unless configured otherwise, retrieve bulkdata and de-multipart it
For static wado back ends, use '*/*' as the retrieve condition.

### Testing

Configure a back end with and without staticWado true in the datasource (eg datasources='ohif' has it true)
Display a microscopy study containing bulkdata incorrectly returned as 'application/octet-stream' - the SM modality studies on 'ohif' are examples.
The SM should display and the accept header should be '*/*'

If you remove the staticWado setting, then the SM should still display, and against a system which returns uncompressed data for images, should still return correctly.

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] OS: <!--[e.g. Windows 10, macOS 10.15.4]-->
- [] Node version: <!--[e.g. 18.16.1]-->
- [] Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
