### PR TITLE
fix: catch errors in getPTImageIdInstanceMetadata

### DIFF
--- a/extensions/default/src/init.ts
+++ b/extensions/default/src/init.ts
@@ -63,30 +63,29 @@ const handlePETImageMetadata = ({ SeriesInstanceUID, StudyInstanceUID }) => {
 
   const imageIds = instances.map(instance => instance.imageId);
   const instanceMetadataArray = [];
-  imageIds.forEach(imageId => {
-    const instanceMetadata = getPTImageIdInstanceMetadata(imageId);
-    if (instanceMetadata) {
-      instanceMetadataArray.push(instanceMetadata);
-    }
-  });
-
-  if (!instanceMetadataArray.length) {
-    return;
-  }
 
   // try except block to prevent errors when the metadata is not correct
-  let suvScalingFactors;
   try {
-    suvScalingFactors = calculateSUVScalingFactors(instanceMetadataArray);
+    imageIds.forEach(imageId => {
+      const instanceMetadata = getPTImageIdInstanceMetadata(imageId);
+      if (instanceMetadata) {
+        instanceMetadataArray.push(instanceMetadata);
+      }
+    });
+
+    if (!instanceMetadataArray.length) {
+      return;
+    }
+
+    const suvScalingFactors = calculateSUVScalingFactors(instanceMetadataArray);
+    instanceMetadataArray.forEach((instanceMetadata, index) => {
+      metadataProvider.addCustomMetadata(
+        imageIds[index],
+        'scalingModule',
+        suvScalingFactors[index]
+      );
+    });
   } catch (error) {
     console.log(error);
   }
-
-  if (!suvScalingFactors) {
-    return;
-  }
-
-  instanceMetadataArray.forEach((instanceMetadata, index) => {
-    metadataProvider.addCustomMetadata(imageIds[index], 'scalingModule', suvScalingFactors[index]);
-  });
 };


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

When loading a PT image with missing metadata, the viewer is stuck on the loading screen.

![Screenshot 2024-01-15 at 15 17 03](https://github.com/OHIF/Viewers/assets/24232962/6afa7936-0cd5-4fbd-b84b-4694c3437235)


### Changes & Results

#### Before:

When loading a PT image with missing metadata, `getPTImageIdInstanceMetadata` throws an error and viewer is stuck on loading screen.

#### After:

Errors from `getPTImageIdInstanceMetadata` are caught and logged. Image is shown without SUV scaling. 

There are already a few early return statements in `handlePETImageMetadata`. If `getPTImageIdInstanceMetadata` throws an error, the behavior is now the same as in those early returns.

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] OS: macOS <!--[e.g. Windows 10, macOS 10.15.4]-->
- [x] Node version: 18.18.2 <!--[e.g. 18.16.1]-->
- [x] Browser: Firefox
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
