### PR TITLE
feat(HangingProtocolService): add custom attributes callbacks from customization service

### DIFF
--- a/platform/core/src/services/HangingProtocolService/HangingProtocolService.ts
+++ b/platform/core/src/services/HangingProtocolService/HangingProtocolService.ts
@@ -400,10 +400,17 @@ export default class HangingProtocolService extends PubSubService {
     this.displaySets = displaySets;
     this.setActiveStudyUID((activeStudy || studies[0])?.StudyInstanceUID);
 
-    this.protocolEngine = new ProtocolEngine(
-      this.getProtocols(),
-      this.customAttributeRetrievalCallbacks
-    );
+    const { customizationService } = this._servicesManager.services;
+    const customAttributeRetrievalCallbacks = customizationService.get(
+      'HPCustomAttributeRetrievalCallbacks'
+    ) || { content: {} };
+
+    const mergedCallbacks = {
+      ...this.customAttributeRetrievalCallbacks,
+      ...customAttributeRetrievalCallbacks.content,
+    };
+
+    this.protocolEngine = new ProtocolEngine(this.getProtocols(), mergedCallbacks);
 
     if (protocolId && typeof protocolId === 'string') {
       const protocol = this.getProtocolById(protocolId);


### PR DESCRIPTION
### Context

One might want to create hanging protocols that use custom attribute callbacks and not only the ones that are already available in OHIF core. Theses changes allow those to be added with the customization service.

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

Tested manually.

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [X] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [X] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [X] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] OS: <!--[e.g. Windows 10, macOS 10.15.4]-->
- [] Node version: <!--[e.g. 18.16.1]-->
- [] Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
