### PR TITLE
feat(errorboundary): format stack trace properly

### DIFF
--- a/platform/ui/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/platform/ui/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -24,8 +24,12 @@ const DefaultFallback = ({ error, context, resetErrorBoundary, fallbackRoute }) 
       <p className="text-primary-light text-base">{subtitle}</p>
       {!isProduction && (
         <div className="bg-secondary-dark mt-5 space-y-2 rounded-md p-5 font-mono">
-          <p className="text-primary-light">{t('Context')}: {context}</p>
-          <p className="text-primary-light">{t('Error Message')}: {error.message}</p>
+          <p className="text-primary-light">
+            {t('Context')}: {context}
+          </p>
+          <p className="text-primary-light">
+            {t('Error Message')}: {error.message}
+          </p>
 
           <IconButton
             variant="contained"
@@ -44,7 +48,9 @@ const DefaultFallback = ({ error, context, resetErrorBoundary, fallbackRoute }) 
             </React.Fragment>
           </IconButton>
 
-          {showDetails && <p className="text-primary-light px-4">Stack: {error.stack}</p>}
+          {showDetails && (
+            <pre className="text-primary-light whitespace-pre-wrap px-4">Stack: {error.stack}</pre>
+          )}
         </div>
       )}
     </div>

--- a/platform/ui/src/components/Modal/Modal.tsx
+++ b/platform/ui/src/components/Modal/Modal.tsx
@@ -53,7 +53,7 @@ const Modal = ({
 
   return (
     <ReactModal
-      className="relative max-h-full w-11/12 text-white outline-none lg:w-10/12  xl:w-1/2"
+      className="relative max-h-full w-11/12 text-white outline-none lg:w-10/12  xl:w-9/12"
       overlayClassName="fixed top-0 left-0 right-0 bottom-0 z-50 bg-overlay flex items-start justify-center py-16"
       shouldCloseOnEsc={shouldCloseOnEsc}
       onRequestClose={handleClose}


### PR DESCRIPTION
### Context

This makes the stack trace appear line by line instead of a big block of text.

### Changes & Results


```html
<p className="text-primary-light px-4">Stack: {error.stack}</p>

```
to

```html
<pre className="text-primary-light whitespace-pre-wrap px-4">Stack: {error.stack}</pre>
```

Before:

![Screenshot from 2024-02-13 23-18-20](https://github.com/OHIF/Viewers/assets/93064150/c4fb1307-4e95-4dc4-b9ee-fa397f607106)


After:

![Screenshot from 2024-02-13 23-08-41](https://github.com/OHIF/Viewers/assets/93064150/ca56c492-a130-4bea-80d5-536c43b1e1bc)
