### PR TITLE
fix(TMTV-colourmap): Fix fail colourmap change on non-HP PTs by changing getMatchingPTDisplaySet function in TMTV mode to get PT from viewer layout rather than hanging protocol match

### DIFF
--- a/extensions/tmtv/src/commandsModule.js
+++ b/extensions/tmtv/src/commandsModule.js
@@ -492,12 +492,10 @@ const commandsModule = ({ servicesManager, commandsManager, extensionManager }) 
     setFusionPTColormap: ({ toolGroupId, colormap }) => {
       const toolGroup = toolGroupService.getToolGroup(toolGroupId);
       const { viewportMatchDetails } = hangingProtocolService.getMatchDetails();
-      console.log(viewportMatchDetails);
 
       const ptDisplaySet = actions.getMatchingPTDisplaySet({
         viewportMatchDetails,
       });
-      console.log(ptDisplaySet);
 
       if (!ptDisplaySet) {
         return;


### PR DESCRIPTION


<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->
When PT image is changed in TMTV mode to one different from matched via hanging protocol, colour map breaks.

1. Load TMTV with multiple PT images
2. Change colourmap (works)
3. Load PT image that was not picked by hanging protocol
4. Change colourmap (fails)

Caused by getMatchingPTDisplaySet, which gets the ptDisplaySet from the hangingprotocol match rather than viewer layout.

Implemented one portion of Todo (getting PT from viewer layout), but attenuation corrected PT vs non-attenuation correct PT remains.

### Changes & Results
tmtv\commandsModule.js\getMatchingPTDisplaySet
-change ptDisplaySet to return PT from viewer layout rather than hanging protocol
<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing
1. Load TMTV with multiple PT images
2. Change colourmap (works)
3. Load PT image that was not picked by hanging protocol
4. Change colourmap (works)
<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] OS: <!--[e.g. Windows 10, macOS 10.15.4]-->
- [] Node version: <!--[e.g. 18.16.1]-->
- [] Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
