### PR TITLE
fix(auth): bind handleUnauthenticated to correct context

### DIFF
--- a/platform/app/src/routes/index.tsx
+++ b/platform/app/src/routes/index.tsx
@@ -149,7 +149,7 @@ const createRoutes = ({
             exact
             path={route.path}
             element={
-              <PrivateRoute handleUnauthenticated={userAuthenticationService.handleUnauthenticated}>
+              <PrivateRoute handleUnauthenticated={() => userAuthenticationService.handleUnauthenticated()}>
                 <RouteWithErrorBoundary route={route} />
               </PrivateRoute>
             }


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context
The issue was that the `handleUnauthenticated` function passed as a prop to the `PrivateRoute` component was a regular function, which caused a scope issue with `this`. In this function, `this` referred to the global object instead of the instance of `userAuthenticationService`.

-```public handleUnauthenticated() {
return this.serviceImplementation._handleUnauthenticated();
}```
The value of `this` was undefined instead of referring to the instance of `userAuthenticationService`.

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results
I modified the code to pass an arrow function instead of a regular function to the `PrivateRoute` component. This way, `this` is correctly bound to the context of `userAuthenticationService`.
#### Before:
-```<PrivateRoute handleUnauthenticated={userAuthenticationService.handleUnauthenticated}>```

#### After:
-```<PrivateRoute handleUnauthenticated={() => userAuthenticationService.handleUnauthenticated()}>```
<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies
What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] OS: <!--[e.g. Windows 10, macOS 10.15.4]-->
- [] Node version: <!--[e.g. 18.16.1]-->
- [] Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
