### PR TITLE
fix(tmtv): side panel crashing when activeToolOptions is not an array

### DIFF
--- a/platform/ui/src/components/Toolbox/ToolboxUI.tsx
+++ b/platform/ui/src/components/Toolbox/ToolboxUI.tsx
@@ -29,7 +29,7 @@ function ToolboxUI(props: withAppTypes) {
   const prevToolOptions = usePrevious(activeToolOptions);
 
   useEffect(() => {
-    if (!activeToolOptions) {
+    if (!activeToolOptions || Array.isArray(activeToolOptions) === false) {
       return;
     }
 


### PR DESCRIPTION

### Context

Fixes https://github.com/OHIF/Viewers/issues/4187#issue-2323456664