### PR TITLE
fix(seg): should be able to navigate outside toolbox and come back later

### DIFF
--- a/platform/ui/src/components/Toolbox/Toolbox.tsx
+++ b/platform/ui/src/components/Toolbox/Toolbox.tsx
@@ -26,8 +26,8 @@ function Toolbox({
     buttonSection: buttonSectionId,
   });
 
-  const prevButtonIdsRef = useRef();
-  const prevToolboxStateRef = useRef();
+  const prevButtonIdsRef = useRef('');
+  const prevToolboxStateRef = useRef('');
 
   useEffect(() => {
     const currentButtonIdsStr = JSON.stringify(
@@ -130,7 +130,7 @@ function Toolbox({
     );
 
     api.initializeToolOptions(initializeOptionsWithEnhancements);
-  }, [toolbarButtons, api, toolboxState]);
+  }, [toolbarButtons, api, toolboxState, commandsManager, servicesManager]);
 
   const handleToolOptionChange = (toolName, optionName, newValue) => {
     api.handleToolOptionChange(toolName, optionName, newValue);
@@ -147,7 +147,7 @@ function Toolbox({
       {...props}
       title={title}
       toolbarButtons={toolbarButtons}
-      activeToolOptions={toolboxState.toolOptions?.[toolboxState.activeTool]}
+      toolboxState={toolboxState}
       handleToolSelect={id => api.handleToolSelect(id)}
       handleToolOptionChange={handleToolOptionChange}
       onInteraction={onInteraction}

--- a/platform/ui/src/components/Toolbox/ToolboxUI.tsx
+++ b/platform/ui/src/components/Toolbox/ToolboxUI.tsx
@@ -19,12 +19,15 @@ function ToolboxUI(props: withAppTypes) {
   const {
     toolbarButtons,
     handleToolSelect,
-    activeToolOptions,
+    toolboxState,
     numRows,
     servicesManager,
     title,
     useCollapsedPanel = true,
   } = props;
+
+  const { activeTool, toolOptions, selectedEvent } = toolboxState;
+  const activeToolOptions = toolOptions?.[activeTool];
 
   const prevToolOptions = usePrevious(activeToolOptions);
 
@@ -35,7 +38,7 @@ function ToolboxUI(props: withAppTypes) {
 
     activeToolOptions.forEach((option, index) => {
       const prevOption = prevToolOptions ? prevToolOptions[index] : undefined;
-      if (!prevOption || option.value !== prevOption.value) {
+      if (!prevOption || option.value !== prevOption.value || selectedEvent) {
         const isOptionValid = option.condition
           ? option.condition({ options: activeToolOptions })
           : true;
@@ -45,7 +48,7 @@ function ToolboxUI(props: withAppTypes) {
         }
       }
     });
-  }, [activeToolOptions]);
+  }, [activeToolOptions, selectedEvent]);
 
   const render = () => {
     return (

--- a/platform/ui/src/contextProviders/Toolbox/ToolboxContext.tsx
+++ b/platform/ui/src/contextProviders/Toolbox/ToolboxContext.tsx
@@ -6,7 +6,7 @@ export const toolboxReducer = (state, action) => {
   const { toolbarSectionId } = action.payload;
 
   if (!state[toolbarSectionId]) {
-    state[toolbarSectionId] = { activeTool: null, toolOptions: {} };
+    state[toolbarSectionId] = { activeTool: null, toolOptions: {}, selectedEvent: false };
   }
 
   switch (action.type) {
@@ -16,6 +16,7 @@ export const toolboxReducer = (state, action) => {
         [toolbarSectionId]: {
           ...state[toolbarSectionId],
           activeTool: action.payload.activeTool,
+          selectedEvent: true,
         },
       };
     case 'UPDATE_TOOL_OPTION':
@@ -24,6 +25,7 @@ export const toolboxReducer = (state, action) => {
         ...state,
         [toolbarSectionId]: {
           ...state[toolbarSectionId],
+          selectedEvent: false,
           toolOptions: {
             ...state[toolbarSectionId].toolOptions,
             [toolName]: state[toolbarSectionId].toolOptions[toolName].map(option =>
@@ -36,6 +38,7 @@ export const toolboxReducer = (state, action) => {
       // Initialize tool options for each toolbarSectionId
       return {
         ...state,
+        selectedEvent: false,
         [action.toolbarSectionId]: {
           ...state[action.toolbarSectionId],
           toolOptions: action.payload,


### PR DESCRIPTION

### Context

Previouusly you could not click away from the toolbox and then comback but now you can

https://github.com/OHIF/Viewers/assets/7490180/14e92b73-786f-4abd-bb6b-9be8441d1aee



### Changes & Results

<!--
List all the changes that have been done, such as:
- Adayd new components
- Rawemove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] OS: <!--[e.g. Windows 10, macOS 10.15.4]-->
- [] Node version: <!--[e.g. 18.16.1]-->
- [] Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
