### PR TITLE
fix(createReport): early return on cancel in prompt

### DIFF
--- a/extensions/cornerstone-dicom-seg/src/commandsModule.ts
+++ b/extensions/cornerstone-dicom-seg/src/commandsModule.ts
@@ -339,7 +339,7 @@ const commandsModule = ({
         extensionManager,
       });
 
-      if (promptResult.action !== 1 && promptResult.value) {
+      if (promptResult.action !== 1 && !promptResult.value) {
         return;
       }
 

--- a/extensions/default/src/Actions/createReportAsync.tsx
+++ b/extensions/default/src/Actions/createReportAsync.tsx
@@ -21,6 +21,8 @@ async function createReportAsync({
   try {
     const naturalizedReport = await getReport();
 
+    if (!naturalizedReport) return;
+
     // The "Mode" route listens for DicomMetadataStore changes
     // When a new instance is added, it listens and
     // automatically calls makeDisplaySets


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

The createReportDialogPrompt is used to store/export DICOM SEGs. Currently, data is stored whether one click on 'Save' or 'Cancel'. The desired behaviour is that nothing happens if the "Cancel" button is clicked;

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

- Fixed a condition for an early return in storeSegmentation (the function that creates the report)
- Added an early return in createReportAsync if no report has been created
<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

- Open OHIF in segmentation mode (ex: https://viewer.ohif.org/segmentation?StudyInstanceUIDs=1.3.12.2.1107.5.2.32.35162.30000015050317233592200000046)
- Click "Add segmentation"
- Click on the "..." on the left of the segmentation name
- Click on "Export DICOM SEG"
- Click on "Cancel"
- There shouldn't be a notification indicating a success or failure 
<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] OS: Fedora 40 <!--[e.g. Windows 10, macOS 10.15.4]-->
- [x] Node version: 18.20.3 <!--[e.g. 18.16.1]-->
- [x] Browser: Chromium Version 126.0.6478.55 (Official Build) Fedora Project (64-bit)
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
