### PR TITLE
Add prettier tailwind

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "@babel/preset-env": "7.24.7",
     "@babel/preset-react": "^7.16.7",
     "@babel/preset-typescript": "^7.13.0",
+    "prettier": "^3.3.2",
     "prettier-plugin-tailwindcss": "^0.6.5"
   },
   "husky": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "link-list": "npm ls --depth=0 --link=true"
   },
   "dependencies": {
-    "execa" :"^8.0.1"
+    "execa": "^8.0.1"
   },
   "optionalDependencies": {
     "@percy/cypress": "^3.1.1",
@@ -85,7 +85,8 @@
     "@babel/plugin-transform-typescript": "^7.13.0",
     "@babel/preset-env": "7.24.7",
     "@babel/preset-react": "^7.16.7",
-    "@babel/preset-typescript": "^7.13.0"
+    "@babel/preset-typescript": "^7.13.0",
+    "prettier-plugin-tailwindcss": "^0.6.5"
   },
   "husky": {
     "hooks": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -17227,7 +17227,7 @@ prettier@^2.8.0:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
   integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
 
-prettier@^3.0.3:
+prettier@^3.0.3, prettier@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.3.2.tgz#03ff86dc7c835f2d2559ee76876a3914cec4a90a"
   integrity sha512-rAVeHYMcv8ATV5d508CFdn+8/pHPpXeIid1DdrPwXnaAdH7cqjVbpJaT5eq4yRAFU/lsbwYwSF/n5iNrdJHPQA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -17217,6 +17217,11 @@ prettier-plugin-tailwindcss@^0.5.4:
   resolved "https://registry.yarnpkg.com/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.5.14.tgz#4482eed357d5e22eac259541c70aca5a4c7b9d5c"
   integrity sha512-Puaz+wPUAhFp8Lo9HuciYKM2Y2XExESjeT+9NQoVFXZsPPnc9VYss2SpxdQ6vbatmt8/4+SN0oe0I1cPDABg9Q==
 
+prettier-plugin-tailwindcss@^0.6.5:
+  version "0.6.5"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.6.5.tgz#e05202784a3f41889711ae38c75c5b8cad72f368"
+  integrity sha512-axfeOArc/RiGHjOIy9HytehlC0ZLeMaqY09mm8YCkMzznKiDkwFzOpBvtuhuv3xG5qB73+Mj7OCe2j/L1ryfuQ==
+
 prettier@^2.8.0:
   version "2.8.8"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"


### PR DESCRIPTION
### Context

Link-extension was still broken due to prettier missing dependency, this PR add prettier and "prettier-plugin-tailwindcss" that are  used in extension template (the plugin needs prettier itself)

I'm not sure if these dev deps shall be add in the main package.json (as was earlier in OHIF and restaured in this PR) or in the extension / mode template

### Changes & Results
extension-link working again

### Testing


### Checklist

#### PR

#### Code

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

Linux, node 18
