### PR TITLE
fix: Tests run against e2e config for both playwright and older tests

### DIFF
--- a/platform/app/public/config/default.js
+++ b/platform/app/public/config/default.js
@@ -24,7 +24,7 @@ window.config = {
     prefetch: 25,
   },
   // filterQueryParam: false,
-  defaultDataSourceName: 'ohif',
+  defaultDataSourceName: 'dicomweb',
   /* Dynamic config allows user to pass "configUrl" query string this allows to load config without recompiling application. The regex will ensure valid configuration source */
   // dangerouslyUseDynamicConfig: {
   //   enabled: true,
@@ -38,10 +38,10 @@ window.config = {
   dataSources: [
     {
       namespace: '@ohif/extension-default.dataSourcesModule.dicomweb',
-      sourceName: 'ohif',
+      sourceName: 'dicomweb',
       configuration: {
-        friendlyName: 'OHIF Test Dataset',
-        name: 'ohif',
+        friendlyName: 'AWS S3 Static wado server',
+        name: 'aws',
         wadoUriRoot: 'https://d33do7qe4w26qo.cloudfront.net/dicomweb',
         qidoRoot: 'https://d33do7qe4w26qo.cloudfront.net/dicomweb',
         wadoRoot: 'https://d33do7qe4w26qo.cloudfront.net/dicomweb',
@@ -125,8 +125,8 @@ window.config = {
       namespace: '@ohif/extension-default.dataSourcesModule.dicomweb',
       sourceName: 'local5000',
       configuration: {
-        friendlyName: 'localhost port 5000',
-        name: 'local5000',
+        friendlyName: 'Static WADO Local Data',
+        name: 'DCM4CHEE',
         qidoRoot: 'http://localhost:5000/dicomweb',
         wadoRoot: 'http://localhost:5000/dicomweb',
         qidoSupportsIncludeField: false,

--- a/platform/app/public/config/default.js
+++ b/platform/app/public/config/default.js
@@ -24,7 +24,7 @@ window.config = {
     prefetch: 25,
   },
   // filterQueryParam: false,
-  defaultDataSourceName: 'dicomweb',
+  defaultDataSourceName: 'ohif',
   /* Dynamic config allows user to pass "configUrl" query string this allows to load config without recompiling application. The regex will ensure valid configuration source */
   // dangerouslyUseDynamicConfig: {
   //   enabled: true,
@@ -38,10 +38,10 @@ window.config = {
   dataSources: [
     {
       namespace: '@ohif/extension-default.dataSourcesModule.dicomweb',
-      sourceName: 'dicomweb',
+      sourceName: 'ohif',
       configuration: {
-        friendlyName: 'AWS S3 Static wado server',
-        name: 'aws',
+        friendlyName: 'OHIF Test Dataset',
+        name: 'ohif',
         wadoUriRoot: 'https://d33do7qe4w26qo.cloudfront.net/dicomweb',
         qidoRoot: 'https://d33do7qe4w26qo.cloudfront.net/dicomweb',
         wadoRoot: 'https://d33do7qe4w26qo.cloudfront.net/dicomweb',
@@ -125,8 +125,8 @@ window.config = {
       namespace: '@ohif/extension-default.dataSourcesModule.dicomweb',
       sourceName: 'local5000',
       configuration: {
-        friendlyName: 'Static WADO Local Data',
-        name: 'DCM4CHEE',
+        friendlyName: 'localhost port 5000',
+        name: 'local5000',
         qidoRoot: 'http://localhost:5000/dicomweb',
         wadoRoot: 'http://localhost:5000/dicomweb',
         qidoSupportsIncludeField: false,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -39,6 +39,6 @@ export default defineConfig({
     command: 'yarn test:e2e:serve',
     url: 'http://localhost:3000',
     reuseExistingServer: !process.env.CI,
-    timeout: 120 * 1000,
+    timeout: 240 * 1000,
   },
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,12 +8,7 @@ export default defineConfig({
   workers: process.env.CI ? 1 : undefined,
   snapshotPathTemplate: './tests/screenshots{/projectName}/{testFilePath}/{arg}{ext}',
   outputDir: './tests/test-results',
-  reporter: [
-    [
-      process.env.CI ? 'blob' : 'html',
-      { outputFolder: './tests/playwright-report' },
-    ],
-  ],
+  reporter: [[process.env.CI ? 'blob' : 'html', { outputFolder: './tests/playwright-report' }]],
   timeout: 720 * 1000,
   use: {
     baseURL: 'http://localhost:3000',
@@ -41,7 +36,7 @@ export default defineConfig({
     //},
   ],
   webServer: {
-    command: 'yarn start',
+    command: 'yarn test:e2e:serve',
     url: 'http://localhost:3000',
     reuseExistingServer: !process.env.CI,
     timeout: 120 * 1000,

--- a/tests/utils/visitStudy.ts
+++ b/tests/utils/visitStudy.ts
@@ -16,7 +16,6 @@ export async function visitStudy(
   datasources = 'ohif'
 ) {
   await page.goto(`/?resultsPerPage=100&datasources=${datasources}`);
-  // await page.getByTestId('confirm-and-hide-button').click();
   await page.getByTestId(studyInstanceUID).click();
   await page.getByRole('button', { name: mode }).click();
   await page.waitForLoadState('domcontentloaded');

--- a/tests/utils/visitStudy.ts
+++ b/tests/utils/visitStudy.ts
@@ -6,15 +6,17 @@ import { Page } from '@playwright/test';
  * @param title - The study instance UID of the study to visit
  * @param mode - The mode to visit the study in
  * @param delay - The delay to wait after visiting the study
+ * @param datasources - the data source to load the study from
  */
 export async function visitStudy(
   page: Page,
   studyInstanceUID: string,
   mode: string,
-  delay: number = 0
+  delay: number = 0,
+  datasources = 'ohif'
 ) {
-  await page.goto('/?resultsPerPage=100');
-  await page.getByTestId('confirm-and-hide-button').click();
+  await page.goto(`/?resultsPerPage=100&datasources=${datasources}`);
+  // await page.getByTestId('confirm-and-hide-button').click();
   await page.getByTestId(studyInstanceUID).click();
   await page.getByRole('button', { name: mode }).click();
   await page.waitForLoadState('domcontentloaded');


### PR DESCRIPTION
### Context

Runs tests against the
yarn test:e2e:serve
configuration e2e.js so that all tests run against the same configuration.

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] OS: <!--[e.g. Windows 10, macOS 10.15.4]-->
- [] Node version: <!--[e.g. 18.16.1]-->
- [] Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
