### PR TITLE
fix: 4D series loaded in basic mode #4232

### DIFF
--- a/extensions/cornerstone/src/index.tsx
+++ b/extensions/cornerstone/src/index.tsx
@@ -21,6 +21,7 @@ import CornerstoneCacheService from './services/CornerstoneCacheService';
 import CornerstoneViewportService from './services/ViewportService/CornerstoneViewportService';
 import ColorbarService from './services/ColorbarService';
 import * as CornerstoneExtensionTypes from './types';
+import * as utils from './utils';
 
 import { toolNames } from './initCornerstoneTools';
 import { getEnabledElement, reset as enabledElementReset, setEnabledElement } from './state';
@@ -227,5 +228,6 @@ export {
   getEnabledElement,
   ImageOverlayViewerTool,
   getSOPInstanceAttributes,
+  utils,
 };
 export default cornerstoneExtension;

--- a/extensions/cornerstone/src/index.tsx
+++ b/extensions/cornerstone/src/index.tsx
@@ -6,7 +6,6 @@ import {
   imageLoadPoolManager,
   imageRetrievalPoolManager,
 } from '@cornerstonejs/core';
-import * as csStreamingImageVolumeLoader from '@cornerstonejs/streaming-image-volume-loader';
 import { Enums as cs3DToolsEnums } from '@cornerstonejs/tools';
 import { Types } from '@ohif/core';
 
@@ -39,9 +38,8 @@ import ActiveViewportWindowLevel from './components/ActiveViewportWindowLevel';
 import getSOPInstanceAttributes from './utils/measurementServiceMappings/utils/getSOPInstanceAttributes';
 import { findNearbyToolData } from './utils/findNearbyToolData';
 import { createFrameViewSynchronizer } from './synchronizers/frameViewSynchronizer';
+import volumeLoaderUtil from './utils/volumeLoaderUtil';
 
-const { helpers: volumeLoaderHelpers } = csStreamingImageVolumeLoader;
-const { getDynamicVolumeInfo } = volumeLoaderHelpers ?? {};
 const { imageRetrieveMetadataProvider } = cornerstone.utilities;
 
 const Component = React.lazy(() => {
@@ -212,9 +210,7 @@ const cornerstoneExtension: Types.Extensions.Extension = {
       },
       {
         name: 'volumeLoader',
-        exports: {
-          getDynamicVolumeInfo,
-        },
+        exports: volumeLoaderUtil,
       },
     ];
   },

--- a/extensions/cornerstone/src/utils/index.ts
+++ b/extensions/cornerstone/src/utils/index.ts
@@ -1,0 +1,1 @@
+export { default as volumeLoaderUtil } from './volumeLoaderUtil';

--- a/extensions/cornerstone/src/utils/volumeLoaderUtil.ts
+++ b/extensions/cornerstone/src/utils/volumeLoaderUtil.ts
@@ -1,0 +1,37 @@
+import * as csStreamingImageVolumeLoader from '@cornerstonejs/streaming-image-volume-loader';
+
+const { helpers: volumeLoaderHelpers } = csStreamingImageVolumeLoader;
+const { getDynamicVolumeInfo } = volumeLoaderHelpers ?? {};
+
+let is4DEnabled = false;
+
+const volumeLoaderUtil = {
+  /**
+   * Check if 4D mode is enabled
+   */
+  is4DModeEnabled: (): boolean => is4DEnabled,
+  /**
+   * Enable 4D mode to allow splitting series into timepoints
+   */
+  enable4DMode: (): void => {
+    is4DEnabled = true;
+  },
+  /**
+   * Disable 4D mode
+   */
+  disable4DMode: (): void => {
+    is4DEnabled = false;
+  },
+  /**
+   * Check if a list of imageIds can be split into timepoints in order to load
+   * it as a 4D series. If it is not possible the a single timepoint is returned
+   * flagged as non-4D series.
+   */
+  getDynamicVolumeInfo: imageIds => {
+    return is4DEnabled
+      ? getDynamicVolumeInfo.call(null, imageIds)
+      : { isDynamicVolume: false, timePoints: imageIds, splittingTag: null };
+  },
+};
+
+export default volumeLoaderUtil;

--- a/modes/preclinical-4d/src/index.tsx
+++ b/modes/preclinical-4d/src/index.tsx
@@ -1,9 +1,12 @@
 import { id } from './id';
 import { hotkeys } from '@ohif/core';
+import * as cornerstoneExtension from '@ohif/extension-cornerstone';
 import initWorkflowSteps from './initWorkflowSteps';
 import initToolGroups from './initToolGroups';
 import toolbarButtons from './toolbarButtons';
 import segmentationButtons from './segmentationButtons';
+
+const { volumeLoaderUtil } = cornerstoneExtension.utils;
 
 const extensionDependencies = {
   '@ohif/extension-default': '3.7.0-beta.76',
@@ -47,10 +50,6 @@ function modeFactory({ modeConfiguration }) {
         customizationService,
         viewportGridService,
       } = servicesManager.services;
-
-      const { exports: volumeLoaderUtil } = extensionManager.getModuleEntry(
-        '@ohif/extension-cornerstone.utilityModule.volumeLoader'
-      );
 
       // Enable 4D mode to allow splitting series into timepoints
       volumeLoaderUtil.enable4DMode();
@@ -105,10 +104,6 @@ function modeFactory({ modeConfiguration }) {
         segmentationService,
         cornerstoneViewportService,
       } = servicesManager.services;
-
-      const { exports: volumeLoaderUtil } = extensionManager.getModuleEntry(
-        '@ohif/extension-cornerstone.utilityModule.volumeLoader'
-      );
 
       // Turn 4D mode off to move back to its initial state.
       volumeLoaderUtil.disable4DMode();

--- a/modes/preclinical-4d/src/index.tsx
+++ b/modes/preclinical-4d/src/index.tsx
@@ -48,6 +48,13 @@ function modeFactory({ modeConfiguration }) {
         viewportGridService,
       } = servicesManager.services;
 
+      const { exports: volumeLoaderUtil } = extensionManager.getModuleEntry(
+        '@ohif/extension-cornerstone.utilityModule.volumeLoader'
+      );
+
+      // Enable 4D mode to allow splitting series into timepoints
+      volumeLoaderUtil.enable4DMode();
+
       const utilityModule = extensionManager.getModuleEntry(
         '@ohif/extension-cornerstone.utilityModule.tools'
       );
@@ -91,13 +98,20 @@ function modeFactory({ modeConfiguration }) {
       // it may change the protocol/stage based on workflow stage settings
       initWorkflowSteps({ servicesManager });
     },
-    onModeExit: ({ servicesManager }: withAppTypes) => {
+    onModeExit: ({ servicesManager, extensionManager }: withAppTypes) => {
       const {
         toolGroupService,
         syncGroupService,
         segmentationService,
         cornerstoneViewportService,
       } = servicesManager.services;
+
+      const { exports: volumeLoaderUtil } = extensionManager.getModuleEntry(
+        '@ohif/extension-cornerstone.utilityModule.volumeLoader'
+      );
+
+      // Turn 4D mode off to move back to its initial state.
+      volumeLoaderUtil.disable4DMode();
 
       toolGroupService.destroy();
       syncGroupService.destroy();


### PR DESCRIPTION
### Context

4D series was not loading in basic mode because the image ids were being split into time points even though all images should be loaded in a stack viewport ("normal mode").

### Changes & Results

4D mode is disabled until preclinical 4D mode is started when it set 4D mode to `true`. Once 

### Testing

Load the study shared [here](https://github.com/OHIF/Viewers/issues/4232) and make sure it loads in basic mode.