### PR TITLE
[DONT MERGE] Trying new cornerstone3d 2.0 with the recent release

### DIFF
--- a/.webpack/webpack.base.js
+++ b/.webpack/webpack.base.js
@@ -144,8 +144,6 @@ module.exports = (env, argv, { SRC_DIR, ENTRY }) => {
         '@state': path.resolve(__dirname, '../platform/app/src/state'),
         'dicom-microscopy-viewer':
           'dicom-microscopy-viewer/dist/dynamic-import/dicomMicroscopyViewer.min.js',
-        '@cornerstonejs/dicom-image-loader':
-          '@cornerstonejs/dicom-image-loader/dist/dynamic-import/cornerstoneDICOMImageLoader.min.js',
       },
       // Which directories to search when resolving modules
       modules: [

--- a/extensions/cornerstone-dicom-rt/src/utils/promptHydrateRT.ts
+++ b/extensions/cornerstone-dicom-rt/src/utils/promptHydrateRT.ts
@@ -10,7 +10,6 @@ function promptHydrateRT({
   servicesManager,
   rtDisplaySet,
   viewportId,
-  toolGroupId = 'default',
   preHydrateCallbacks,
   hydrateRTDisplaySet,
 }: withAppTypes) {
@@ -27,7 +26,6 @@ function promptHydrateRT({
       const isHydrated = await hydrateRTDisplaySet({
         rtDisplaySet,
         viewportId,
-        toolGroupId,
         servicesManager,
       });
 

--- a/extensions/cornerstone-dicom-rt/src/viewports/OHIFCornerstoneRTViewport.tsx
+++ b/extensions/cornerstone-dicom-rt/src/viewports/OHIFCornerstoneRTViewport.tsx
@@ -143,7 +143,7 @@ function OHIFCornerstoneRTViewport(props: withAppTypes) {
         newSelectedSegmentIndex = numberOfSegments - 1;
       }
 
-      segmentationService.jumpToSegmentCenter(segmentationId, newSelectedSegmentIndex, toolGroupId);
+      segmentationService.jumpToSegmentCenter(segmentationId, newSelectedSegmentIndex, viewportId);
       setSelectedSegment(newSelectedSegmentIndex);
     },
     [selectedSegment]
@@ -243,7 +243,7 @@ function OHIFCornerstoneRTViewport(props: withAppTypes) {
 
     return () => {
       // remove the segmentation representations if seg displayset changed
-      segmentationService.removeSegmentationRepresentationFromToolGroup(toolGroupId);
+      segmentationService.removeSegmentationRepresentationFromViewport(viewportId);
 
       toolGroupService.destroyToolGroup(toolGroupId);
     };
@@ -254,7 +254,7 @@ function OHIFCornerstoneRTViewport(props: withAppTypes) {
 
     return () => {
       // remove the segmentation representations if seg displayset changed
-      segmentationService.removeSegmentationRepresentationFromToolGroup(toolGroupId);
+      segmentationService.removeSegmentationRepresentationFromViewport(viewportId);
       referencedDisplaySetRef.current = null;
     };
   }, [rtDisplaySet]);

--- a/extensions/cornerstone-dicom-seg/src/commandsModule.ts
+++ b/extensions/cornerstone-dicom-seg/src/commandsModule.ts
@@ -102,16 +102,14 @@ const commandsModule = ({
             { label: `Segmentation ${currentSegmentations.length + 1}` }
           );
 
-          const toolGroupId = viewport.viewportOptions.toolGroupId;
-
-          await segmentationService.addSegmentationRepresentationToToolGroup(
-            toolGroupId,
+          await segmentationService.addSegmentationRepresentationToViewport(
+            viewportId,
             segmentationId
           );
 
           // Add only one segment for now
           segmentationService.addSegment(segmentationId, {
-            toolGroupId,
+            viewportId,
             segmentIndex: 1,
             properties: {
               label: 'Segment 1',
@@ -160,9 +158,8 @@ const commandsModule = ({
 
           segmentationService.addOrUpdateSegmentation(segmentation);
 
-          const toolGroupId = viewport.viewportOptions.toolGroupId;
-          await segmentationService.addSegmentationRepresentationToToolGroup(
-            toolGroupId,
+          await segmentationService.addSegmentationRepresentationToViewport(
+            viewportId,
             segmentationId
           );
 
@@ -172,7 +169,7 @@ const commandsModule = ({
             }
             segmentationService.addSegment(segmentationId, {
               segmentIndex: segment.segmentIndex,
-              toolGroupId,
+              viewportId,
               properties: {
                 color: segment.color,
                 label: segment.label,

--- a/extensions/cornerstone-dicom-seg/src/panels/PanelSegmentation.tsx
+++ b/extensions/cornerstone-dicom-seg/src/panels/PanelSegmentation.tsx
@@ -117,10 +117,10 @@ export default function PanelSegmentation({
     };
   }, []);
 
-  const getToolGroupIds = segmentationId => {
-    const toolGroupIds = segmentationService.getToolGroupIdsWithSegmentation(segmentationId);
+  const getViewportIds = segmentationId => {
+    const viewportIds = segmentationService.getViewportIdsWithSegmentation(segmentationId);
 
-    return toolGroupIds;
+    return viewportIds;
   };
 
   const onSegmentationAdd = async () => {
@@ -130,7 +130,7 @@ export default function PanelSegmentation({
   };
 
   const onSegmentationClick = (segmentationId: string) => {
-    segmentationService.setActiveSegmentationForToolGroup(segmentationId);
+    segmentationService.setActiveSegmentationForViewport(segmentationId);
   };
 
   const onSegmentationDelete = (segmentationId: string) => {
@@ -144,12 +144,11 @@ export default function PanelSegmentation({
   const onSegmentClick = (segmentationId, segmentIndex) => {
     segmentationService.setActiveSegment(segmentationId, segmentIndex);
 
-    const toolGroupIds = getToolGroupIds(segmentationId);
+    const viewportIds = getViewportIds(segmentationId);
 
-    toolGroupIds.forEach(toolGroupId => {
-      // const toolGroupId =
-      segmentationService.setActiveSegmentationForToolGroup(segmentationId, toolGroupId);
-      segmentationService.jumpToSegmentCenter(segmentationId, segmentIndex, toolGroupId);
+    viewportIds.forEach(viewportId => {
+      segmentationService.setActiveSegmentationForViewport(segmentationId, viewportId);
+      segmentationService.jumpToSegmentCenter(segmentationId, segmentIndex, viewportId);
     });
   };
 
@@ -224,16 +223,11 @@ export default function PanelSegmentation({
     const segmentation = segmentationService.getSegmentation(segmentationId);
     const segmentInfo = segmentation.segments[segmentIndex];
     const isVisible = !segmentInfo.isVisible;
-    const toolGroupIds = getToolGroupIds(segmentationId);
+    const viewportIds = getViewportIds(segmentationId);
 
     // Todo: right now we apply the visibility to all tool groups
-    toolGroupIds.forEach(toolGroupId => {
-      segmentationService.setSegmentVisibility(
-        segmentationId,
-        segmentIndex,
-        isVisible,
-        toolGroupId
-      );
+    viewportIds.forEach(viewportId => {
+      segmentationService.setSegmentVisibility(segmentationId, segmentIndex, isVisible, viewportId);
     });
   };
 
@@ -247,15 +241,15 @@ export default function PanelSegmentation({
     const isVisible = segmentation.isVisible;
     const segments = segmentation.segments;
 
-    const toolGroupIds = getToolGroupIds(segmentationId);
+    const viewportIds = getViewportIds(segmentationId);
 
-    toolGroupIds.forEach(toolGroupId => {
+    viewportIds.forEach(viewportId => {
       segments.forEach((segment, segmentIndex) => {
         segmentationService.setSegmentVisibility(
           segmentationId,
           segmentIndex,
           isVisible,
-          toolGroupId
+          viewportId
         );
       });
     });
@@ -352,8 +346,12 @@ export default function PanelSegmentation({
       setRenderFill={value =>
         _setSegmentationConfiguration(selectedSegmentationId, 'renderFill', value)
       }
-      setRenderInactiveSegmentations={value =>
-        _setSegmentationConfiguration(selectedSegmentationId, 'renderInactiveSegmentations', value)
+      setrenderInactiveRepresentations={value =>
+        _setSegmentationConfiguration(
+          selectedSegmentationId,
+          'renderInactiveRepresentations',
+          value
+        )
       }
       setOutlineWidthActive={value =>
         _setSegmentationConfiguration(selectedSegmentationId, 'outlineWidthActive', value)

--- a/extensions/cornerstone-dicom-seg/src/panels/segmentationConfigReducer.tsx
+++ b/extensions/cornerstone-dicom-seg/src/panels/segmentationConfigReducer.tsx
@@ -6,7 +6,7 @@ const initialState = {
   outlineWidth: 3,
   fillOpacity: 0.9,
   fillOpacityInactive: 0.8,
-  renderInactiveSegmentations: true,
+  renderInactiveRepresentations: true,
 };
 
 const reducer = (state, action) => {
@@ -24,7 +24,7 @@ const reducer = (state, action) => {
     case 'SET_FILL_OPACITY_INACTIVE':
       return { ...state, fillOpacityInactive: action.payload.value };
     case 'RENDER_INACTIVE_SEGMENTATIONS':
-      return { ...state, renderInactiveSegmentations: action.payload.value };
+      return { ...state, renderInactiveRepresentations: action.payload.value };
     default:
       return state;
   }

--- a/extensions/cornerstone-dicom-seg/src/viewports/OHIFCornerstoneSEGViewport.tsx
+++ b/extensions/cornerstone-dicom-seg/src/viewports/OHIFCornerstoneSEGViewport.tsx
@@ -139,7 +139,7 @@ function OHIFCornerstoneSEGViewport(props: withAppTypes) {
         newSelectedSegmentIndex = numberOfSegments - 1;
       }
 
-      segmentationService.jumpToSegmentCenter(segmentationId, newSelectedSegmentIndex, toolGroupId);
+      segmentationService.jumpToSegmentCenter(segmentationId, newSelectedSegmentIndex, viewportId);
       setSelectedSegment(newSelectedSegmentIndex);
     },
     [selectedSegment]
@@ -229,7 +229,7 @@ function OHIFCornerstoneSEGViewport(props: withAppTypes) {
 
     return () => {
       // remove the segmentation representations if seg displayset changed
-      segmentationService.removeSegmentationRepresentationFromToolGroup(toolGroupId);
+      segmentationService.removeSegmentationRepresentationFromViewport(viewportId);
 
       // Only destroy the viewport specific implementation
       toolGroupService.destroyToolGroup(toolGroupId);
@@ -241,7 +241,7 @@ function OHIFCornerstoneSEGViewport(props: withAppTypes) {
 
     return () => {
       // remove the segmentation representations if seg displayset changed
-      segmentationService.removeSegmentationRepresentationFromToolGroup(toolGroupId);
+      segmentationService.removeSegmentationRepresentationFromViewport(viewportId);
       referencedDisplaySetRef.current = null;
     };
   }, [segDisplaySet]);

--- a/extensions/cornerstone-dynamic-volume/src/actions/updateSegmentationsChartDisplaySet.ts
+++ b/extensions/cornerstone-dynamic-volume/src/actions/updateSegmentationsChartDisplaySet.ts
@@ -157,20 +157,14 @@ function _getSegmentationData(segmentation, volumesTimePointsCache, displaySetSe
 
   // since we only use one segmentation representation per segmentationId
   // it is fine to pick the first one
-  const segmentationRepresentations = csTools.segmentation.state.getSegmentationIdRepresentations(
-    segmentation.id
-  );
+  const segmentationRepresentations =
+    csTools.segmentation.state.getSegmentationRepresentationsForSegmentation(segmentation.id);
 
   const segmentationRepresentationUID =
     segmentationRepresentations[0].segmentationRepresentationUID;
 
-  const toolGroupId = csTools.segmentation.state.getToolGroupIdFromSegmentationRepresentationUID(
-    segmentationRepresentationUID
-  );
-
   // Todo: this is useless we should be able to grab color with just segRepUID and segmentIndex
-  const color = csTools.segmentation.config.color.getColorForSegmentIndex(
-    toolGroupId,
+  const color = csTools.segmentation.config.color.getSegmentIndexColor(
     segmentationRepresentationUID,
     1 // segmentIndex
   );

--- a/extensions/cornerstone-dynamic-volume/src/commandsModule.ts
+++ b/extensions/cornerstone-dynamic-volume/src/commandsModule.ts
@@ -345,24 +345,18 @@ const commandsModule = ({ commandsManager, servicesManager }: withAppTypes) => {
         { label }
       );
 
-      // Add Segmentation to all toolGroupIds in the viewer
-      const toolGroupIds = Array.from(
-        viewports.values(),
-        viewport => viewport.viewportOptions.toolGroupId
-      );
-
       const representationType = LABELMAP;
-
-      for (const toolGroupId of toolGroupIds) {
+      for (const viewport of viewports.values()) {
+        const viewportId = viewport.viewportId;
         const hydrateSegmentation = true;
-        await segmentationService.addSegmentationRepresentationToToolGroup(
-          toolGroupId,
+        await segmentationService.addSegmentationRepresentationToViewport(
+          viewportId,
           segmentationId,
           hydrateSegmentation,
           representationType
         );
 
-        segmentationService.setActiveSegmentationForToolGroup(segmentationId, toolGroupId);
+        segmentationService.setActiveSegmentationForViewport(segmentationId, viewportId);
       }
 
       return segmentationId;

--- a/extensions/cornerstone/src/commandsModule.ts
+++ b/extensions/cornerstone/src/commandsModule.ts
@@ -435,9 +435,10 @@ function commandsModule({
         viewport.setCamera({ viewUp: rotatedViewUp as CoreTypes.Point3 });
         viewport.render();
       } else if (viewport.getRotation !== undefined) {
-        const currentRotation = viewport.getRotation();
+        const presentation = viewport.getViewPresentation();
+        const { rotation: currentRotation } = presentation;
         const newRotation = (currentRotation + rotation) % 360;
-        viewport.setProperties({ rotation: newRotation });
+        viewport.setViewPresentation({ rotation: newRotation });
         viewport.render();
       }
     },

--- a/extensions/cornerstone/src/components/CinePlayer/CinePlayer.tsx
+++ b/extensions/cornerstone/src/components/CinePlayer/CinePlayer.tsx
@@ -101,7 +101,7 @@ function WrappedCinePlayer({
       return;
     }
 
-    eventTarget.addEventListener(Enums.Events.STACK_VIEWPORT_NEW_STACK, newDisplaySetHandler);
+    enabledVPElement.addEventListener(Enums.Events.STACK_VIEWPORT_NEW_STACK, newDisplaySetHandler);
     // this doesn't makes sense that we are listening to this event on viewport element
     enabledVPElement.addEventListener(
       Enums.Events.VOLUME_VIEWPORT_NEW_VOLUME,
@@ -111,7 +111,10 @@ function WrappedCinePlayer({
     return () => {
       cineService.setCine({ id: viewportId, isPlaying: false });
 
-      eventTarget.removeEventListener(Enums.Events.STACK_VIEWPORT_NEW_STACK, newDisplaySetHandler);
+      enabledVPElement.removeEventListener(
+        Enums.Events.STACK_VIEWPORT_NEW_STACK,
+        newDisplaySetHandler
+      );
       enabledVPElement.removeEventListener(
         Enums.Events.VOLUME_VIEWPORT_NEW_VOLUME,
         newDisplaySetHandler

--- a/extensions/cornerstone/src/getCustomizationModule.ts
+++ b/extensions/cornerstone/src/getCustomizationModule.ts
@@ -110,7 +110,7 @@ function getCustomizationModule() {
                 type: 'value',
               },
               {
-                value: 'areaUnit',
+                value: 'areaUnits',
                 for: ['area'],
                 type: 'unit',
               },
@@ -130,7 +130,7 @@ function getCustomizationModule() {
               },
               {
                 displayName: 'Unit',
-                value: 'areaUnit',
+                value: 'areaUnits',
                 type: 'value',
               },
             ],
@@ -153,12 +153,12 @@ function getCustomizationModule() {
                 type: 'value',
               },
               {
-                value: 'modalityUnit',
+                value: 'pixelValueUnits',
                 for: ['mean', 'max' /** 'stdDev **/],
                 type: 'unit',
               },
               {
-                value: 'areaUnit',
+                value: 'areaUnits',
                 for: ['area'],
                 type: 'unit',
               },

--- a/extensions/cornerstone/src/init.tsx
+++ b/extensions/cornerstone/src/init.tsx
@@ -182,6 +182,7 @@ export default async function init({
     interaction: appConfig?.maxNumRequests?.interaction || 100,
     thumbnail: appConfig?.maxNumRequests?.thumbnail || 75,
     prefetch: appConfig?.maxNumRequests?.prefetch || 10,
+    compute: appConfig?.maxNumRequests?.compute || 10,
   };
 
   initWADOImageLoader(userAuthenticationService, appConfig, extensionManager);
@@ -243,10 +244,6 @@ export default async function init({
     handler(detail.error);
   };
 
-  eventTarget.addEventListener(EVENTS.STACK_VIEWPORT_NEW_STACK, evt => {
-    const { element } = evt.detail;
-    cornerstoneTools.utilities.stackContextPrefetch.enable(element);
-  });
   eventTarget.addEventListener(EVENTS.IMAGE_LOAD_FAILED, imageLoadFailedHandler);
   eventTarget.addEventListener(EVENTS.IMAGE_LOAD_ERROR, imageLoadFailedHandler);
 
@@ -259,26 +256,11 @@ export default async function init({
       commandsManager.runCommand('resetCrosshairs', { viewportId });
     });
 
-    // eventTarget.addEventListener(EVENTS.STACK_VIEWPORT_NEW_STACK, toolbarEventListener);
-
     initViewTiming({ element });
-  }
-
-  function elementDisabledHandler(evt) {
-    const { element } = evt.detail;
-
-    // element.removeEventListener(EVENTS.CAMERA_RESET, resetCrosshairs);
-
-    // TODO - consider removing the callback when all elements are gone
-    // eventTarget.removeEventListener(
-    //   EVENTS.STACK_VIEWPORT_NEW_STACK,
-    //   newStackCallback
-    // );
   }
 
   eventTarget.addEventListener(EVENTS.ELEMENT_ENABLED, elementEnabledHandler.bind(null));
 
-  eventTarget.addEventListener(EVENTS.ELEMENT_DISABLED, elementDisabledHandler.bind(null));
   colormaps.forEach(registerColormap);
 
   // Event listener

--- a/extensions/cornerstone/src/initCornerstoneTools.js
+++ b/extensions/cornerstone/src/initCornerstoneTools.js
@@ -19,7 +19,6 @@ import {
   CobbAngleTool,
   MagnifyTool,
   CrosshairsTool,
-  SegmentationDisplayTool,
   RectangleScissorsTool,
   SphereScissorsTool,
   CircleScissorsTool,
@@ -67,7 +66,6 @@ export default function initCornerstoneTools(configuration = {}) {
   addTool(CobbAngleTool);
   addTool(MagnifyTool);
   addTool(CrosshairsTool);
-  addTool(SegmentationDisplayTool);
   addTool(RectangleScissorsTool);
   addTool(SphereScissorsTool);
   addTool(CircleScissorsTool);
@@ -120,7 +118,6 @@ const toolNames = {
   CobbAngle: CobbAngleTool.toolName,
   Magnify: MagnifyTool.toolName,
   Crosshairs: CrosshairsTool.toolName,
-  SegmentationDisplay: SegmentationDisplayTool.toolName,
   Brush: BrushTool.toolName,
   PaintFill: PaintFillTool.toolName,
   ReferenceLines: ReferenceLinesTool.toolName,

--- a/extensions/cornerstone/src/services/SegmentationService/SegmentationService.ts
+++ b/extensions/cornerstone/src/services/SegmentationService/SegmentationService.ts
@@ -4,9 +4,10 @@ import {
   Enums as csEnums,
   geometryLoader,
   eventTarget,
-  getEnabledElementByIds,
   utilities as csUtils,
   volumeLoader,
+  Types as csTypes,
+  getEnabledElementByViewportId,
 } from '@cornerstonejs/core';
 import {
   Enums as csToolsEnums,
@@ -96,9 +97,10 @@ class SegmentationService extends PubSubService {
   /**
    * Adds a new segment to the specified segmentation.
    * @param segmentationId - The ID of the segmentation to add the segment to.
+   * @param viewportId: The ID of the viewport to add the segment to, it is used to get the representation, if it is not
+   * provided, the first available representation for the segmentationId will be used.
    * @param config - An object containing the configuration options for the new segment.
    *   - segmentIndex: (optional) The index of the segment to add. If not provided, the next available index will be used.
-   *   - toolGroupId: (optional) The ID of the tool group to associate the new segment with. If not provided, the first available tool group will be used.
    *   - properties: (optional) An object containing the properties of the new segment.
    *     - label: (optional) The label of the new segment. If not provided, a default label will be used.
    *     - color: (optional) The color of the new segment in RGB format. If not provided, a default color will be used.
@@ -111,7 +113,7 @@ class SegmentationService extends PubSubService {
     segmentationId: string,
     config: {
       segmentIndex?: number;
-      toolGroupId?: string;
+      viewportId?: string;
       properties?: {
         label?: string;
         color?: ohifTypes.RGB;
@@ -126,12 +128,8 @@ class SegmentationService extends PubSubService {
       throw new Error('Segment index 0 is reserved for "no label"');
     }
 
-    const toolGroupId = config.toolGroupId ?? this._getApplicableToolGroupId();
-
-    const { segmentationRepresentationUID, segmentation } = this._getSegmentationInfo(
-      segmentationId,
-      toolGroupId
-    );
+    const { segmentationRepresentationUID, segmentation } =
+      this._getSegmentationInfo(segmentationId);
 
     let segmentIndex = config.segmentIndex;
     if (!segmentIndex) {
@@ -143,8 +141,7 @@ class SegmentationService extends PubSubService {
       throw new Error(`Segment ${segmentIndex} already exists`);
     }
 
-    const rgbaColor = cstSegmentation.config.color.getColorForSegmentIndex(
-      toolGroupId,
+    const rgbaColor = cstSegmentation.config.color.getSegmentIndexColor(
       segmentationRepresentationUID,
       segmentIndex
     );
@@ -168,11 +165,23 @@ class SegmentationService extends PubSubService {
       const { color: newColor, opacity, isLocked, visibility, active } = config.properties;
 
       if (newColor !== undefined) {
-        this._setSegmentColor(segmentationId, segmentIndex, newColor, toolGroupId, suppressEvents);
+        this._setSegmentColor(
+          segmentationId,
+          segmentIndex,
+          newColor,
+          config.viewportId,
+          suppressEvents
+        );
       }
 
       if (opacity !== undefined) {
-        this._setSegmentOpacity(segmentationId, segmentIndex, opacity, toolGroupId, suppressEvents);
+        this._setSegmentOpacity(
+          segmentationId,
+          segmentIndex,
+          opacity,
+          config.viewportId,
+          suppressEvents
+        );
       }
 
       if (visibility !== undefined) {
@@ -180,7 +189,7 @@ class SegmentationService extends PubSubService {
           segmentationId,
           segmentIndex,
           visibility,
-          toolGroupId,
+          config.viewportId,
           suppressEvents
         );
       }
@@ -275,16 +284,10 @@ class SegmentationService extends PubSubService {
     segmentationId: string,
     segmentIndex: number,
     isVisible: boolean,
-    toolGroupId?: string,
+    viewportId?: string,
     suppressEvents = false
   ): void {
-    this._setSegmentVisibility(
-      segmentationId,
-      segmentIndex,
-      isVisible,
-      toolGroupId,
-      suppressEvents
-    );
+    this._setSegmentVisibility(segmentationId, segmentIndex, isVisible, viewportId, suppressEvents);
   }
 
   public setSegmentLocked(segmentationId: string, segmentIndex: number, isLocked: boolean): void {
@@ -308,16 +311,16 @@ class SegmentationService extends PubSubService {
     segmentationId: string,
     segmentIndex: number,
     color: ohifTypes.RGB,
-    toolGroupId?: string
+    viewportId?: string
   ): void {
-    this._setSegmentColor(segmentationId, segmentIndex, color, toolGroupId);
+    this._setSegmentColor(segmentationId, segmentIndex, color, viewportId);
   }
 
   public setSegmentRGBA = (
     segmentationId: string,
     segmentIndex: number,
-    rgbaColor: cstTypes.Color,
-    toolGroupId?: string
+    rgbaColor: csTypes.Color,
+    viewportId?: string
   ): void => {
     const segmentation = this.getSegmentation(segmentationId);
 
@@ -326,19 +329,13 @@ class SegmentationService extends PubSubService {
     }
 
     const suppressEvents = true;
-    this._setSegmentOpacity(
-      segmentationId,
-      segmentIndex,
-      rgbaColor[3],
-      toolGroupId,
-      suppressEvents
-    );
+    this._setSegmentOpacity(segmentationId, segmentIndex, rgbaColor[3], viewportId, suppressEvents);
 
     this._setSegmentColor(
       segmentationId,
       segmentIndex,
       [rgbaColor[0], rgbaColor[1], rgbaColor[2]],
-      toolGroupId,
+      viewportId,
       suppressEvents
     );
 
@@ -351,16 +348,14 @@ class SegmentationService extends PubSubService {
     segmentationId: string,
     segmentIndex: number,
     opacity: number,
-    toolGroupId?: string
+    viewportId?: string
   ): void {
-    this._setSegmentOpacity(segmentationId, segmentIndex, opacity, toolGroupId);
+    this._setSegmentOpacity(segmentationId, segmentIndex, opacity, viewportId);
   }
 
-  public setActiveSegmentationForToolGroup(segmentationId: string, toolGroupId?: string): void {
-    toolGroupId = toolGroupId ?? this._getApplicableToolGroupId();
-
+  public setActiveSegmentationForViewport(segmentationId: string, viewportId?: string): void {
     const suppressEvents = false;
-    this._setActiveSegmentationForToolGroup(segmentationId, toolGroupId, suppressEvents);
+    this._setActiveSegmentationForViewport(segmentationId, viewportId, null, suppressEvents);
   }
 
   public setActiveSegment(segmentationId: string, segmentIndex: number): void {
@@ -505,6 +500,8 @@ class SegmentationService extends PubSubService {
       displaySetInstanceUID: segDisplaySet.displaySetInstanceUID,
       type: representationType,
       label: segDisplaySet.SeriesDescription,
+      colorLUTIndex: 1,
+      FrameOfReferenceUID: segDisplaySet.FrameOfReferenceUID,
       representationData: {
         [LABELMAP]: {
           volumeId: segmentationId,
@@ -545,7 +542,6 @@ class SegmentationService extends PubSubService {
       volumeId: segmentationId,
       targetBuffer: {
         type: 'Uint8Array',
-        sharedArrayBuffer: window.SharedArrayBuffer,
       },
     });
     const derivedVolumeScalarData = derivedVolume.getScalarData();
@@ -649,7 +645,7 @@ class SegmentationService extends PubSubService {
       type: representationType,
       label: rtDisplaySet.SeriesDescription,
       representationData: {
-        [CONTOUR]: {
+        CONTOUR: {
           geometryIds,
         },
       },
@@ -690,7 +686,7 @@ class SegmentationService extends PubSubService {
         });
 
         const contourSet = geometry.data;
-        const centroid = contourSet.getCentroid();
+        const centroid = (contourSet as csTypes.IContourSet).getCentroid();
 
         segmentsCachedStats[segmentIndex] = {
           center: { world: centroid },
@@ -801,6 +797,7 @@ class SegmentationService extends PubSubService {
         x: centroid.x / count,
         y: centroid.y / count,
         z: centroid.z / count,
+        world: null,
       };
       normalizedCentroid.world = imageData.indexToWorld([
         normalizedCentroid.x,
@@ -832,7 +829,7 @@ class SegmentationService extends PubSubService {
 
       // If world coordinates are not provided, calculate them
       if (!world || world.length === 0) {
-        world = imageData.indexToWorld(centroid.image);
+        world = imageData.indexToWorld(centroid.image) as number[];
       }
 
       segmentation.cachedStats.segmentCenter[segmentIndex] = {
@@ -849,14 +846,13 @@ class SegmentationService extends PubSubService {
   public jumpToSegmentCenter(
     segmentationId: string,
     segmentIndex: number,
-    toolGroupId?: string,
+    viewportId: string,
     highlightAlpha = 0.9,
     highlightSegment = true,
     animationLength = 750,
     highlightHideOthers = false,
     highlightFunctionType = 'ease-in-out' // todo: make animation functions configurable from outside
   ): void {
-    const { toolGroupService } = this.servicesManager.services;
     const center = this._getSegmentCenter(segmentationId, segmentIndex);
 
     if (!center?.world) {
@@ -865,33 +861,18 @@ class SegmentationService extends PubSubService {
 
     const { world } = center;
 
-    // todo: generalize
-    toolGroupId = toolGroupId || this._getToolGroupIdsWithSegmentation(segmentationId);
+    // need to find which viewports are displaying the segmentation
+    const viewportIds = this.getViewportIdsWithSegmentation(segmentationId);
 
-    const toolGroups = [];
-
-    if (Array.isArray(toolGroupId)) {
-      toolGroupId.forEach(toolGroup => {
-        toolGroups.push(toolGroupService.getToolGroup(toolGroup));
-      });
-    } else {
-      toolGroups.push(toolGroupService.getToolGroup(toolGroupId));
-    }
-
-    toolGroups.forEach(toolGroup => {
-      const viewportsInfo = toolGroup.getViewportsInfo();
-
-      // @ts-ignore
-      for (const { viewportId, renderingEngineId } of viewportsInfo) {
-        const { viewport } = getEnabledElementByIds(viewportId, renderingEngineId);
-        cstUtils.viewport.jumpToWorld(viewport, world);
-      }
+    viewportIds.forEach(viewportId => {
+      const { viewport } = getEnabledElementByViewportId(viewportId);
+      cstUtils.viewport.jumpToWorld(viewport as csTypes.IVolumeViewport, world);
 
       if (highlightSegment) {
         this.highlightSegment(
           segmentationId,
           segmentIndex,
-          toolGroup.id,
+          viewportId,
           highlightAlpha,
           animationLength,
           highlightHideOthers,
@@ -904,7 +885,7 @@ class SegmentationService extends PubSubService {
   public highlightSegment(
     segmentationId: string,
     segmentIndex: number,
-    toolGroupId?: string,
+    viewportId?: string,
     alpha = 0.9,
     animationLength = 750,
     hideOthers = true,
@@ -915,11 +896,10 @@ class SegmentationService extends PubSubService {
     }
 
     const segmentation = this.getSegmentation(segmentationId);
-    toolGroupId = toolGroupId ?? this._getApplicableToolGroupId();
 
     const segmentationRepresentation = this._getSegmentationRepresentation(
       segmentationId,
-      toolGroupId
+      viewportId
     );
 
     const { type } = segmentationRepresentation;
@@ -935,7 +915,7 @@ class SegmentationService extends PubSubService {
       adjustedAlpha,
       hideOthers,
       segments,
-      toolGroupId,
+      viewportId,
       animationLength,
       segmentationRepresentation
     );
@@ -944,8 +924,8 @@ class SegmentationService extends PubSubService {
   public createSegmentationForDisplaySet = async (
     displaySetInstanceUID: string,
     options?: {
-      segmentationId: string;
-      FrameOfReferenceUID: string;
+      segmentationId?: string;
+      FrameOfReferenceUID?: string;
       label: string;
     }
   ): Promise<string> => {
@@ -966,7 +946,6 @@ class SegmentationService extends PubSubService {
       volumeId: segmentationId,
       targetBuffer: {
         type: 'Uint8Array',
-        sharedArrayBuffer: window.SharedArrayBuffer,
       },
     });
 
@@ -980,8 +959,8 @@ class SegmentationService extends PubSubService {
       // We should set it as active by default, as it created for display
       isActive: true,
       type: representationType,
-      FrameOfReferenceUID:
-        options?.FrameOfReferenceUID || displaySet.instances?.[0]?.FrameOfReferenceUID,
+      FrameOfReferenceUID: (options?.FrameOfReferenceUID ||
+        displaySet.instances?.[0]?.FrameOfReferenceUID) as string,
       representationData: {
         LABELMAP: {
           volumeId: segmentationId,
@@ -1006,16 +985,14 @@ class SegmentationService extends PubSubService {
     this._toggleSegmentationVisibility(segmentationId, false);
   };
 
-  public addSegmentationRepresentationToToolGroup = async (
-    toolGroupId: string,
+  public addSegmentationRepresentationToViewport = async (
+    viewportId: string,
     segmentationId: string,
     hydrateSegmentation = false,
     representationType = csToolsEnums.SegmentationRepresentations.Labelmap,
     suppressEvents = false
   ): Promise<void> => {
     const segmentation = this.getSegmentation(segmentationId);
-
-    toolGroupId = toolGroupId || this._getApplicableToolGroupId();
 
     if (!segmentation) {
       throw new Error(`Segmentation with segmentationId ${segmentationId} not found.`);
@@ -1028,7 +1005,7 @@ class SegmentationService extends PubSubService {
 
     // Based on the segmentationId, set the colorLUTIndex.
     const segmentationRepresentationUIDs = await cstSegmentation.addSegmentationRepresentations(
-      toolGroupId,
+      viewportId,
       [
         {
           segmentationId,
@@ -1038,9 +1015,9 @@ class SegmentationService extends PubSubService {
     );
 
     // set the latest segmentation representation as active one
-    this._setActiveSegmentationForToolGroup(
+    this._setActiveSegmentationForViewport(
       segmentationId,
-      toolGroupId,
+      viewportId,
       segmentationRepresentationUIDs[0]
     );
 
@@ -1055,11 +1032,11 @@ class SegmentationService extends PubSubService {
       const suppressEvents = true;
 
       if (color !== undefined) {
-        this._setSegmentColor(segmentationId, segmentIndex, color, toolGroupId, suppressEvents);
+        this._setSegmentColor(segmentationId, segmentIndex, color, viewportId, suppressEvents);
       }
 
       if (opacity !== undefined) {
-        this._setSegmentOpacity(segmentationId, segmentIndex, opacity, toolGroupId, suppressEvents);
+        this._setSegmentOpacity(segmentationId, segmentIndex, opacity, viewportId, suppressEvents);
       }
 
       if (visibility !== undefined) {
@@ -1067,7 +1044,7 @@ class SegmentationService extends PubSubService {
           segmentationId,
           segmentIndex,
           visibility,
-          toolGroupId,
+          viewportId,
           suppressEvents
         );
       }
@@ -1088,7 +1065,7 @@ class SegmentationService extends PubSubService {
     segmentationId: string,
     segmentIndex: number,
     rgbaColor,
-    toolGroupId?: string
+    viewportId?: string
   ) => {
     const segmentation = this.getSegmentation(segmentationId);
 
@@ -1100,14 +1077,14 @@ class SegmentationService extends PubSubService {
       segmentationId,
       segmentIndex,
       rgbaColor[3],
-      toolGroupId, // toolGroupId
+      viewportId, // viewportId
       true
     );
     this._setSegmentColor(
       segmentationId,
       segmentIndex,
       [rgbaColor[0], rgbaColor[1], rgbaColor[2]],
-      toolGroupId, // toolGroupId
+      viewportId, // viewportId
       true
     );
 
@@ -1116,9 +1093,9 @@ class SegmentationService extends PubSubService {
     });
   };
 
-  public getToolGroupIdsWithSegmentation = (segmentationId: string): string[] => {
-    const toolGroupIds = cstSegmentation.state.getToolGroupIdsWithSegmentation(segmentationId);
-    return toolGroupIds;
+  public getViewportIdsWithSegmentation = (segmentationId: string): string[] => {
+    const viewportIds = cstSegmentation.state.getViewportIdsWithSegmentation(segmentationId);
+    return viewportIds;
   };
 
   public hydrateSegmentation = (segmentationId: string, suppressEvents = false): void => {
@@ -1129,7 +1106,7 @@ class SegmentationService extends PubSubService {
     }
     segmentation.hydrated = true;
 
-    // Not all segmentations have dipslaysets, some of them are derived in the client
+    // Not all segmentations have dipslaySets, some of them are derived in the client
     this._setDisplaySetIsHydrated(segmentationId, true);
 
     if (!suppressEvents) {
@@ -1160,9 +1137,9 @@ class SegmentationService extends PubSubService {
     alpha: number,
     hideOthers: boolean,
     segments: Segment[],
-    toolGroupId: string,
+    viewportId: string,
     animationLength: number,
-    segmentationRepresentation: cstTypes.ToolGroupSpecificRepresentation
+    segmentationRepresentation: cstTypes.SegmentationRepresentation
   ) {
     const newSegmentSpecificConfig = {
       [segmentIndex]: {
@@ -1184,7 +1161,7 @@ class SegmentationService extends PubSubService {
       }
     }
 
-    const { fillAlpha } = this.getConfiguration(toolGroupId);
+    const { fillAlpha } = this.getConfiguration(viewportId);
 
     let startTime: number = null;
     const animation = (timestamp: number) => {
@@ -1195,8 +1172,8 @@ class SegmentationService extends PubSubService {
       const elapsed = timestamp - startTime;
       const progress = Math.min(elapsed / animationLength, 1);
 
-      cstSegmentation.config.setSegmentSpecificConfig(
-        toolGroupId,
+      cstSegmentation.config.setSegmentIndexConfig(
+        viewportId,
         segmentationRepresentation.segmentationRepresentationUID,
         {
           [segmentIndex]: {
@@ -1210,8 +1187,8 @@ class SegmentationService extends PubSubService {
       if (progress < 1) {
         requestAnimationFrame(animation);
       } else {
-        cstSegmentation.config.setSegmentSpecificConfig(
-          toolGroupId,
+        cstSegmentation.config.setSegmentIndexConfig(
+          viewportId,
           segmentationRepresentation.segmentationRepresentationUID,
           {}
         );
@@ -1226,17 +1203,17 @@ class SegmentationService extends PubSubService {
     alpha: number,
     hideOthers: boolean,
     segments: Segment[],
-    toolGroupId: string,
+    viewportId: string,
     animationLength: number,
-    segmentationRepresentation: cstTypes.ToolGroupSpecificRepresentation
+    segmentationRepresentation: cstTypes.SegmentationRepresentation
   ) {
     const startTime = performance.now();
 
     const animate = (currentTime: number) => {
       const progress = (currentTime - startTime) / animationLength;
       if (progress >= 1) {
-        cstSegmentation.config.setSegmentSpecificConfig(
-          toolGroupId,
+        cstSegmentation.config.setSegmentIndexConfig(
+          viewportId,
           segmentationRepresentation.segmentationRepresentationUID,
           {}
         );
@@ -1244,8 +1221,8 @@ class SegmentationService extends PubSubService {
       }
 
       const reversedProgress = reverseEaseInOutBell(progress, 0.1);
-      cstSegmentation.config.setSegmentSpecificConfig(
-        toolGroupId,
+      cstSegmentation.config.setSegmentIndexConfig(
+        viewportId,
         segmentationRepresentation.segmentationRepresentationUID,
         {
           [segmentIndex]: {
@@ -1262,13 +1239,13 @@ class SegmentationService extends PubSubService {
     requestAnimationFrame(animate);
   }
 
-  public removeSegmentationRepresentationFromToolGroup(
-    toolGroupId: string,
+  public removeSegmentationRepresentationFromViewport(
+    viewportId: string,
     segmentationRepresentationUIDsIds?: string[]
   ): void {
     const uids = segmentationRepresentationUIDsIds || [];
     if (!uids.length) {
-      const representations = cstSegmentation.state.getSegmentationRepresentations(toolGroupId);
+      const representations = cstSegmentation.state.getSegmentationRepresentations(viewportId);
 
       if (!representations || !representations.length) {
         return;
@@ -1277,7 +1254,7 @@ class SegmentationService extends PubSubService {
       uids.push(...representations.map(rep => rep.segmentationRepresentationUID));
     }
 
-    cstSegmentation.removeSegmentationsFromToolGroup(toolGroupId, uids);
+    cstSegmentation.removeSegmentationRepresentations(viewportId, uids);
   }
 
   /**
@@ -1295,7 +1272,7 @@ class SegmentationService extends PubSubService {
     }
 
     const { colorLUTIndex } = segmentation;
-    const { updatedToolGroupIds } = this._removeSegmentationFromCornerstone(segmentationId);
+    const { updatedViewportIds } = this._removeSegmentationFromCornerstone(segmentationId);
 
     // Delete associated colormap
     // Todo: bring this back
@@ -1315,8 +1292,8 @@ class SegmentationService extends PubSubService {
       if (remainingHydratedSegmentations.length) {
         const { id } = remainingHydratedSegmentations[0];
 
-        updatedToolGroupIds.forEach(toolGroupId => {
-          this._setActiveSegmentationForToolGroup(id, toolGroupId, false);
+        updatedViewportIds.forEach(viewportId => {
+          this._setActiveSegmentationForViewport(id, viewportId, null);
         });
       }
     }
@@ -1328,26 +1305,23 @@ class SegmentationService extends PubSubService {
     });
   }
 
-  public getConfiguration = (toolGroupId?: string): SegmentationConfig => {
-    toolGroupId = toolGroupId ?? this._getApplicableToolGroupId();
+  public getSegmentationRepresentationsForViewport(
+    viewportId: string
+  ): cstTypes.SegmentationRepresentation[] {
+    return cstSegmentation.state.getSegmentationRepresentations(viewportId);
+  }
 
+  public getConfiguration = (viewportId?: string): SegmentationConfig => {
     const brushSize = 1;
-    // const brushSize = cstUtils.segmentation.getBrushSizeForToolGroup(
-    //   toolGroupId
-    // );
 
     const brushThresholdGate = 1;
-    // const brushThresholdGate = cstUtils.segmentation.getBrushThresholdForToolGroup(
-    //   toolGroupId
-    // );
 
-    const segmentationRepresentations =
-      this.getSegmentationRepresentationsForToolGroup(toolGroupId);
+    const segmentationRepresentations = this.getSegmentationRepresentationsForViewport(viewportId);
 
     const typeToUse = segmentationRepresentations?.[0]?.type || LABELMAP;
 
     const config = cstSegmentation.config.getGlobalConfig();
-    const { renderInactiveSegmentations } = config;
+    const { renderInactiveRepresentations } = config;
 
     const representation = config.representations[typeToUse];
 
@@ -1368,7 +1342,7 @@ class SegmentationService extends PubSubService {
       fillAlphaInactive,
       outlineWidthActive,
       renderFill,
-      renderInactiveSegmentations,
+      renderInactiveRepresentations,
       renderOutline,
       outlineOpacity,
       outlineOpacityInactive,
@@ -1382,7 +1356,7 @@ class SegmentationService extends PubSubService {
       outlineWidthActive,
       outlineOpacity,
       renderFill,
-      renderInactiveSegmentations,
+      renderInactiveRepresentations,
       renderOutline,
     } = configuration;
 
@@ -1403,34 +1377,11 @@ class SegmentationService extends PubSubService {
       Math.max(0.75, v / 100)
     );
 
-    if (renderInactiveSegmentations !== undefined) {
+    if (renderInactiveRepresentations !== undefined) {
       const config = cstSegmentation.config.getGlobalConfig();
-      config.renderInactiveSegmentations = renderInactiveSegmentations;
+      config.renderInactiveRepresentations = renderInactiveRepresentations;
       cstSegmentation.config.setGlobalConfig(config);
     }
-
-    // if (brushSize !== undefined) {
-    //   const { toolGroupService } = this.servicesManager.services;
-
-    //   const toolGroupIds = toolGroupService.getToolGroupIds();
-
-    //   toolGroupIds.forEach(toolGroupId => {
-    //     cstUtils.segmentation.setBrushSizeForToolGroup(toolGroupId, brushSize);
-    //   });
-    // }
-
-    // if (brushThresholdGate !== undefined) {
-    //   const { toolGroupService } = this.servicesManager.services;
-
-    //   const toolGroupIds = toolGroupService.getFirstToolGroupIds();
-
-    //   toolGroupIds.forEach(toolGroupId => {
-    //     cstUtils.segmentation.setBrushThresholdForToolGroup(
-    //       toolGroupId,
-    //       brushThresholdGate
-    //     );
-    //   });
-    // }
 
     this._broadcastEvent(this.EVENTS.SEGMENTATION_CONFIGURATION_CHANGED, this.getConfiguration());
   };
@@ -1439,39 +1390,8 @@ class SegmentationService extends PubSubService {
     return cache.getVolume(segmentationId);
   };
 
-  public getSegmentationRepresentationsForToolGroup = toolGroupId => {
-    return cstSegmentation.state.getSegmentationRepresentations(toolGroupId);
-  };
-
   public setSegmentLabel(segmentationId: string, segmentIndex: number, label: string) {
     this._setSegmentLabel(segmentationId, segmentIndex, label);
-  }
-
-  private _setSegmentLabel(
-    segmentationId: string,
-    segmentIndex: number,
-    label: string,
-    suppressEvents = false
-  ) {
-    const segmentation = this.getSegmentation(segmentationId);
-
-    if (segmentation === undefined) {
-      throw new Error(`no segmentation for segmentationId: ${segmentationId}`);
-    }
-
-    const segmentInfo = segmentation.segments[segmentIndex];
-
-    if (segmentInfo === undefined) {
-      throw new Error(`Segment ${segmentIndex} not yet added to segmentation: ${segmentationId}`);
-    }
-
-    segmentInfo.label = label;
-
-    if (suppressEvents === false) {
-      this._broadcastEvent(this.EVENTS.SEGMENTATION_UPDATED, {
-        segmentation,
-      });
-    }
   }
 
   public shouldRenderSegmentation(viewportDisplaySetInstanceUIDs, segmentationFrameOfReferenceUID) {
@@ -1517,27 +1437,38 @@ class SegmentationService extends PubSubService {
     };
   }
 
-  private _setActiveSegmentationForToolGroup(
+  private _setActiveSegmentationForViewport(
     segmentationId: string,
-    toolGroupId: string,
+    viewportId: string,
+    segmentationRepresentationUID?: string,
     suppressEvents = false
   ) {
-    const segmentations = this._getSegmentations();
+    let representationUIDToUse = segmentationRepresentationUID;
     const targetSegmentation = this.getSegmentation(segmentationId);
 
-    if (targetSegmentation === undefined) {
-      throw new Error(`no segmentation for segmentationId: ${segmentationId}`);
+    if (!segmentationRepresentationUID) {
+      const segmentations = this._getSegmentations();
+
+      if (targetSegmentation === undefined) {
+        throw new Error(`no segmentation for segmentationId: ${segmentationId}`);
+      }
+
+      segmentations.forEach(segmentation => {
+        segmentation.isActive = segmentation.id === segmentationId;
+      });
+
+      const representation = this._getSegmentationRepresentation(segmentationId, viewportId);
+
+      if (!representation) {
+        throw new Error('Must add representation to toolgroup before setting segments');
+      }
+
+      representationUIDToUse = representation.segmentationRepresentationUID;
     }
 
-    segmentations.forEach(segmentation => {
-      segmentation.isActive = segmentation.id === segmentationId;
-    });
-
-    const representation = this._getSegmentationRepresentation(segmentationId, toolGroupId);
-
     cstSegmentation.activeSegmentation.setActiveSegmentationRepresentation(
-      toolGroupId,
-      representation.segmentationRepresentationUID
+      viewportId,
+      representationUIDToUse
     );
 
     if (suppressEvents === false) {
@@ -1605,7 +1536,7 @@ class SegmentationService extends PubSubService {
     segmentationId: string,
     segmentIndex: number,
     color: ohifTypes.RGB,
-    toolGroupId?: string,
+    viewportId?: string,
     suppressEvents = false
   ) => {
     const segmentation = this.getSegmentation(segmentationId);
@@ -1620,11 +1551,9 @@ class SegmentationService extends PubSubService {
       throw new Error(`Segment ${segmentIndex} not yet added to segmentation: ${segmentationId}`);
     }
 
-    toolGroupId = toolGroupId ?? this._getApplicableToolGroupId();
-
     const segmentationRepresentation = this._getSegmentationRepresentation(
       segmentationId,
-      toolGroupId
+      viewportId
     );
 
     if (!segmentationRepresentation) {
@@ -1632,18 +1561,15 @@ class SegmentationService extends PubSubService {
     }
     const { segmentationRepresentationUID } = segmentationRepresentation;
 
-    const rgbaColor = cstSegmentation.config.color.getColorForSegmentIndex(
-      toolGroupId,
+    const rgbaColor = cstSegmentation.config.color.getSegmentIndexColor(
       segmentationRepresentationUID,
       segmentIndex
     );
 
-    cstSegmentation.config.color.setColorForSegmentIndex(
-      toolGroupId,
-      segmentationRepresentationUID,
-      segmentIndex,
-      [...color, rgbaColor[3]]
-    );
+    cstSegmentation.config.color.setSegmentIndexColor(segmentationRepresentationUID, segmentIndex, [
+      ...color,
+      rgbaColor[3],
+    ]);
 
     segmentInfo.color = color;
 
@@ -1711,14 +1637,12 @@ class SegmentationService extends PubSubService {
     segmentationId: string,
     segmentIndex: number,
     isVisible: boolean,
-    toolGroupId?: string,
+    viewportId?: string,
     suppressEvents = false
   ) {
-    toolGroupId = toolGroupId ?? this._getApplicableToolGroupId();
-
     const { segmentationRepresentationUID, segmentation } = this._getSegmentationInfo(
       segmentationId,
-      toolGroupId
+      viewportId
     );
 
     if (segmentation === undefined) {
@@ -1733,8 +1657,8 @@ class SegmentationService extends PubSubService {
 
     segmentInfo.isVisible = isVisible;
 
-    cstSegmentation.config.visibility.setSegmentVisibility(
-      toolGroupId,
+    cstSegmentation.config.visibility.setSegmentIndexVisibility(
+      viewportId,
       segmentationRepresentationUID,
       segmentIndex,
       isVisible
@@ -1758,7 +1682,7 @@ class SegmentationService extends PubSubService {
     segmentationId: string,
     segmentIndex: number,
     opacity: number,
-    toolGroupId?: string,
+    viewportId?: string,
     suppressEvents = false
   ) => {
     const segmentation = this.getSegmentation(segmentationId);
@@ -1773,11 +1697,9 @@ class SegmentationService extends PubSubService {
       throw new Error(`Segment ${segmentIndex} not yet added to segmentation: ${segmentationId}`);
     }
 
-    toolGroupId = toolGroupId ?? this._getApplicableToolGroupId();
-
     const segmentationRepresentation = this._getSegmentationRepresentation(
       segmentationId,
-      toolGroupId
+      viewportId
     );
 
     if (!segmentationRepresentation) {
@@ -1785,18 +1707,17 @@ class SegmentationService extends PubSubService {
     }
     const { segmentationRepresentationUID } = segmentationRepresentation;
 
-    const rgbaColor = cstSegmentation.config.color.getColorForSegmentIndex(
-      toolGroupId,
+    const rgbaColor = cstSegmentation.config.color.getSegmentIndexColor(
       segmentationRepresentationUID,
       segmentIndex
     );
 
-    cstSegmentation.config.color.setColorForSegmentIndex(
-      toolGroupId,
-      segmentationRepresentationUID,
-      segmentIndex,
-      [rgbaColor[0], rgbaColor[1], rgbaColor[2], opacity]
-    );
+    cstSegmentation.config.color.setSegmentIndexColor(segmentationRepresentationUID, segmentIndex, [
+      rgbaColor[0],
+      rgbaColor[1],
+      rgbaColor[2],
+      opacity,
+    ]);
 
     segmentInfo.opacity = opacity;
 
@@ -1834,19 +1755,29 @@ class SegmentationService extends PubSubService {
     }
   }
 
-  private _getSegmentationRepresentation(segmentationId, toolGroupId) {
-    const segmentationRepresentations =
-      this.getSegmentationRepresentationsForToolGroup(toolGroupId);
+  /**
+   * Retrieves the segmentation representation for a given segmentation ID and viewport ID.
+   * If the viewport ID is not provided, it retrieves the first representation for the segmentation ID.
+   *
+   * @param segmentationId - The ID of the segmentation.
+   * @param viewportId - The ID of the viewport. Optional.
+   * @returns segmentation representation, or undefined if not found.
+   */
+  private _getSegmentationRepresentation(segmentationId, viewportId) {
+    if (!viewportId) {
+      const reps =
+        cstSegmentation.state.getSegmentationRepresentationsForSegmentation(segmentationId);
 
-    if (!segmentationRepresentations?.length) {
-      return;
+      if (reps.length === 0) {
+        return;
+      }
+
+      return reps[0];
     }
 
-    // Todo: this finds the first segmentation representation that matches the segmentationId
-    // If there are two labelmap representations from the same segmentation, this will not work
-    const representation = segmentationRepresentations.find(
-      representation => representation.segmentationId === segmentationId
-    );
+    const representation = cstSegmentation.state
+      .getSegmentationRepresentations(viewportId)
+      ?.find(representation => representation.segmentationId === segmentationId);
 
     return representation;
   }
@@ -1949,7 +1880,14 @@ class SegmentationService extends PubSubService {
     }
   };
 
-  private _getSegmentationInfo(segmentationId: string, toolGroupId: string) {
+  /**
+   * Retrieves the segmentation information for a given segmentation ID and viewport ID.
+   * @param segmentationId - The ID of the segmentation.
+   * @param viewportId - The ID of the viewport (optional).
+   * @returns An object containing the segmentation representation UID and the segmentation itself.
+   * @throws An error if no segmentation is found for the given segmentation ID, or if the representation is not added to the viewport.
+   */
+  private _getSegmentationInfo(segmentationId: string, viewportId?: string) {
     const segmentation = this.getSegmentation(segmentationId);
 
     if (segmentation === undefined) {
@@ -1957,7 +1895,7 @@ class SegmentationService extends PubSubService {
     }
     const segmentationRepresentation = this._getSegmentationRepresentation(
       segmentationId,
-      toolGroupId
+      viewportId
     );
 
     if (!segmentationRepresentation) {
@@ -1974,29 +1912,29 @@ class SegmentationService extends PubSubService {
     const removeFromCache = true;
     const segmentationState = cstSegmentation.state;
     const sourceSegState = segmentationState.getSegmentation(segmentationId);
-    const updatedToolGroupIds: Set<string> = new Set();
+    const updatedViewportIds: Set<string> = new Set();
 
     if (!sourceSegState) {
       return;
     }
 
-    const toolGroupIds = segmentationState.getToolGroupIdsWithSegmentation(segmentationId);
+    const viewportIds = segmentationState.getViewportIdsWithSegmentation(segmentationId);
 
-    toolGroupIds.forEach(toolGroupId => {
+    viewportIds.forEach(viewportId => {
       const segmentationRepresentations =
-        segmentationState.getSegmentationRepresentations(toolGroupId);
+        segmentationState.getSegmentationRepresentations(viewportId);
 
       const UIDsToRemove = [];
       segmentationRepresentations.forEach(representation => {
         if (representation.segmentationId === segmentationId) {
           UIDsToRemove.push(representation.segmentationRepresentationUID);
-          updatedToolGroupIds.add(toolGroupId);
+          updatedViewportIds.add(viewportId);
         }
       });
 
       // remove segmentation representations
-      cstSegmentation.removeSegmentationsFromToolGroup(
-        toolGroupId,
+      cstSegmentation.removeSegmentationRepresentations(
+        viewportId,
         UIDsToRemove,
         true // immediate
       );
@@ -2009,7 +1947,7 @@ class SegmentationService extends PubSubService {
       cache.removeVolumeLoadObject(segmentationId);
     }
 
-    return { updatedToolGroupIds: Array.from(updatedToolGroupIds) };
+    return { updatedViewportIds: [...updatedViewportIds] };
   }
 
   private _updateCornerstoneSegmentations({ segmentationId, notYetUpdatedAtSource }) {
@@ -2033,11 +1971,11 @@ class SegmentationService extends PubSubService {
 
   private _updateCornerstoneSegmentationVisibility = segmentationId => {
     const segmentationState = cstSegmentation.state;
-    const toolGroupIds = segmentationState.getToolGroupIdsWithSegmentation(segmentationId);
+    const viewportIds = segmentationState.getViewportIdsWithSegmentation(segmentationId);
 
-    toolGroupIds.forEach(toolGroupId => {
+    viewportIds.forEach(viewportId => {
       const segmentationRepresentations =
-        cstSegmentation.state.getSegmentationRepresentations(toolGroupId);
+        cstSegmentation.state.getSegmentationRepresentations(viewportId);
 
       if (segmentationRepresentations.length === 0) {
         return;
@@ -2049,19 +1987,21 @@ class SegmentationService extends PubSubService {
         representation => representation.segmentationId === segmentationId
       );
 
-      const { segmentsHidden } = representation;
-
+      const segmentsHidden = cstSegmentation.config.visibility.getHiddenSegmentIndices(
+        viewportId,
+        representation.segmentationRepresentationUID
+      );
       const currentVisibility = segmentsHidden.size === 0 ? true : false;
       const newVisibility = !currentVisibility;
 
-      cstSegmentation.config.visibility.setSegmentationVisibility(
-        toolGroupId,
+      cstSegmentation.config.visibility.setSegmentationRepresentationVisibility(
+        viewportId,
         representation.segmentationRepresentationUID,
         newVisibility
       );
 
       // update segments visibility
-      const { segmentation } = this._getSegmentationInfo(segmentationId, toolGroupId);
+      const { segmentation } = this._getSegmentationInfo(segmentationId, viewportId);
 
       const segments = segmentation.segments.filter(Boolean);
 
@@ -2071,45 +2011,12 @@ class SegmentationService extends PubSubService {
     });
   };
 
-  private _getToolGroupIdsWithSegmentation(segmentationId: string) {
+  private _getViewportIdsWithSegmentation(segmentationId: string) {
     const segmentationState = cstSegmentation.state;
-    const toolGroupIds = segmentationState.getToolGroupIdsWithSegmentation(segmentationId);
+    const viewportIds = segmentationState.getViewportIdsWithSegmentation(segmentationId);
 
-    return toolGroupIds;
+    return viewportIds;
   }
-
-  private _getFrameOfReferenceUIDForSeg(displaySet) {
-    const frameOfReferenceUID = displaySet.instance?.FrameOfReferenceUID;
-
-    if (frameOfReferenceUID) {
-      return frameOfReferenceUID;
-    }
-
-    // if not found we should try the ReferencedFrameOfReferenceSequence
-    const referencedFrameOfReferenceSequence =
-      displaySet.instance?.ReferencedFrameOfReferenceSequence;
-
-    if (referencedFrameOfReferenceSequence) {
-      return referencedFrameOfReferenceSequence.FrameOfReferenceUID;
-    }
-  }
-
-  private _getApplicableToolGroupId = () => {
-    const { toolGroupService, viewportGridService, cornerstoneViewportService } =
-      this.servicesManager.services;
-
-    const viewportInfo = cornerstoneViewportService.getViewportInfo(
-      viewportGridService.getActiveViewportId()
-    );
-
-    if (!viewportInfo) {
-      const toolGroupIds = toolGroupService.getToolGroupIds();
-
-      return toolGroupIds[0];
-    }
-
-    return viewportInfo.getToolGroupId();
-  };
 
   /**
    * Converts object of objects to array.

--- a/extensions/cornerstone/src/services/SegmentationService/SegmentationServiceTypes.ts
+++ b/extensions/cornerstone/src/services/SegmentationService/SegmentationServiceTypes.ts
@@ -2,7 +2,7 @@ import { Enums as csToolsEnums, Types as cstTypes } from '@cornerstonejs/tools';
 import { Types } from '@cornerstonejs/core';
 
 type SegmentationConfig = cstTypes.LabelmapTypes.LabelmapConfig & {
-  renderInactiveSegmentations: boolean;
+  renderInactiveRepresentations: boolean;
   brushSize: number;
   brushThresholdGate: number;
 };

--- a/extensions/cornerstone/src/utils/measurementServiceMappings/CircleROI.ts
+++ b/extensions/cornerstone/src/utils/measurementServiceMappings/CircleROI.ts
@@ -103,7 +103,7 @@ function getMappedAnnotations(annotation, DisplaySetService) {
     );
 
     const { SeriesNumber } = displaySet;
-    const { mean, stdDev, max, area, Modality, areaUnit, modalityUnit } = targetStats;
+    const { mean, stdDev, max, area, Modality, areaUnits, pixelValueUnits } = targetStats;
 
     annotations.push({
       SeriesInstanceUID,
@@ -111,12 +111,12 @@ function getMappedAnnotations(annotation, DisplaySetService) {
       SeriesNumber,
       frameNumber,
       Modality,
-      unit: modalityUnit,
+      unit: pixelValueUnits,
       mean,
       stdDev,
       max,
       area,
-      areaUnit,
+      areaUnits,
     });
   });
 
@@ -137,14 +137,14 @@ function _getReport(mappedAnnotations, points, FrameOfReferenceUID, customizatio
   values.push('Cornerstone:CircleROI');
 
   mappedAnnotations.forEach(annotation => {
-    const { mean, stdDev, max, area, unit, areaUnit } = annotation;
+    const { mean, stdDev, max, area, unit, areaUnits } = annotation;
 
     if (!mean || !unit || !max || !area) {
       return;
     }
 
     columns.push(`max (${unit})`, `mean (${unit})`, `std (${unit})`, 'Area', 'Unit');
-    values.push(max, mean, stdDev, area, areaUnit);
+    values.push(max, mean, stdDev, area, areaUnits);
   });
 
   if (FrameOfReferenceUID) {
@@ -174,7 +174,7 @@ function getDisplayText(mappedAnnotations, displaySet, customizationService) {
   const displayText = [];
 
   // Area is the same for all series
-  const { area, SOPInstanceUID, frameNumber, areaUnit } = mappedAnnotations[0];
+  const { area, SOPInstanceUID, frameNumber, areaUnits } = mappedAnnotations[0];
 
   const instance = displaySet.images.find(image => image.SOPInstanceUID === SOPInstanceUID);
 
@@ -188,7 +188,7 @@ function getDisplayText(mappedAnnotations, displaySet, customizationService) {
 
   // Area sometimes becomes undefined if `preventHandleOutsideImage` is off.
   const roundedArea = utils.roundNumber(area || 0, 2);
-  displayText.push(`${roundedArea} ${getDisplayUnit(areaUnit)}`);
+  displayText.push(`${roundedArea} ${getDisplayUnit(areaUnits)}`);
 
   // Todo: we need a better UI for displaying all these information
   mappedAnnotations.forEach(mappedAnnotation => {

--- a/extensions/cornerstone/src/utils/measurementServiceMappings/EllipticalROI.ts
+++ b/extensions/cornerstone/src/utils/measurementServiceMappings/EllipticalROI.ts
@@ -103,7 +103,7 @@ function getMappedAnnotations(annotation, displaySetService) {
     );
 
     const { SeriesNumber } = displaySet;
-    const { mean, stdDev, max, area, Modality, areaUnit, modalityUnit } = targetStats;
+    const { mean, stdDev, max, area, Modality, areaUnits, pixelValueUnits } = targetStats;
 
     annotations.push({
       SeriesInstanceUID,
@@ -111,8 +111,8 @@ function getMappedAnnotations(annotation, displaySetService) {
       SeriesNumber,
       frameNumber,
       Modality,
-      unit: modalityUnit,
-      areaUnit,
+      unit: pixelValueUnits,
+      areaUnits,
       mean,
       stdDev,
       max,
@@ -137,14 +137,14 @@ function _getReport(mappedAnnotations, points, FrameOfReferenceUID, customizatio
   values.push('Cornerstone:EllipticalROI');
 
   mappedAnnotations.forEach(annotation => {
-    const { mean, stdDev, max, area, unit, areaUnit } = annotation;
+    const { mean, stdDev, max, area, unit, areaUnits } = annotation;
 
     if (!mean || !unit || !max || !area) {
       return;
     }
 
     columns.push(`max (${unit})`, `mean (${unit})`, `std (${unit})`, 'Area', 'Unit');
-    values.push(max, mean, stdDev, area, areaUnit);
+    values.push(max, mean, stdDev, area, areaUnits);
   });
 
   if (FrameOfReferenceUID) {
@@ -174,7 +174,7 @@ function getDisplayText(mappedAnnotations, displaySet, customizationService) {
   const displayText = [];
 
   // Area is the same for all series
-  const { area, SOPInstanceUID, frameNumber, areaUnit } = mappedAnnotations[0];
+  const { area, SOPInstanceUID, frameNumber, areaUnits } = mappedAnnotations[0];
 
   const instance = displaySet.images.find(image => image.SOPInstanceUID === SOPInstanceUID);
 
@@ -187,7 +187,7 @@ function getDisplayText(mappedAnnotations, displaySet, customizationService) {
   const frameText = displaySet.isMultiFrame ? ` F: ${frameNumber}` : '';
 
   const roundedArea = utils.roundNumber(area, 2);
-  displayText.push(`${roundedArea} ${getDisplayUnit(areaUnit)}`);
+  displayText.push(`${roundedArea} ${getDisplayUnit(areaUnits)}`);
 
   // Todo: we need a better UI for displaying all these information
   mappedAnnotations.forEach(mappedAnnotation => {

--- a/extensions/cornerstone/src/utils/measurementServiceMappings/LivewireContour.ts
+++ b/extensions/cornerstone/src/utils/measurementServiceMappings/LivewireContour.ts
@@ -126,7 +126,7 @@ function getDisplayText(annotation, displaySet, customizationService) {
     return [];
   }
 
-  const { area, areaUnit } = data.cachedStats[`imageId:${metadata.referencedImageId}`];
+  const { area, areaUnits } = data.cachedStats[`imageId:${metadata.referencedImageId}`];
 
   const { SOPInstanceUID, frameNumber } = getSOPInstanceAttributes(metadata.referencedImageId);
 
@@ -152,7 +152,7 @@ function getDisplayText(annotation, displaySet, customizationService) {
      * Area sometimes becomes undefined if `preventHandleOutsideImage` is off
      */
     const roundedArea = utils.roundNumber(area || 0, 2);
-    displayText.push(`${roundedArea} ${getDisplayUnit(areaUnit)}`);
+    displayText.push(`${roundedArea} ${getDisplayUnit(areaUnits)}`);
   }
 
   return displayText;

--- a/extensions/cornerstone/src/utils/removeViewportSegmentationRepresentations.ts
+++ b/extensions/cornerstone/src/utils/removeViewportSegmentationRepresentations.ts
@@ -1,7 +1,7 @@
 import { segmentation } from '@cornerstonejs/tools';
 
-function removeToolGroupSegmentationRepresentations(toolGroupId) {
-  const representations = segmentation.state.getSegmentationRepresentations(toolGroupId);
+function removeViewportSegmentationRepresentations(viewportId) {
+  const representations = segmentation.state.getSegmentationRepresentations(viewportId);
 
   if (!representations || !representations.length) {
     return;
@@ -9,10 +9,9 @@ function removeToolGroupSegmentationRepresentations(toolGroupId) {
 
   representations.forEach(representation => {
     segmentation.state.removeSegmentationRepresentation(
-      toolGroupId,
       representation.segmentationRepresentationUID
     );
   });
 }
 
-export default removeToolGroupSegmentationRepresentations;
+export default removeViewportSegmentationRepresentations;

--- a/extensions/default/src/init.ts
+++ b/extensions/default/src/init.ts
@@ -74,6 +74,8 @@ export default function init({
 
           commandsManager.run(commands, { viewportId });
         });
+      } else {
+        console.warn(`Event ${event} is not supported`);
       }
     });
   };

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "stylus": "^0.59.0",
     "stylus-loader": "^7.1.3",
     "terser-webpack-plugin": "^5.1.4",
-    "typescript": "4.6.4",
+    "typescript": "5.5.4",
     "unused-webpack-plugin": "2.4.0",
     "webpack": "^5.90.3",
     "webpack-cli": "^4.7.2",

--- a/platform/app/.webpack/webpack.pwa.js
+++ b/platform/app/.webpack/webpack.pwa.js
@@ -108,11 +108,6 @@ module.exports = (env, argv) => {
               ignore: ['**/*.min.js.map'],
             },
           },
-          // Copy dicom-image-loader build files
-          {
-            from: '../../../node_modules/@cornerstonejs/dicom-image-loader/dist/dynamic-import',
-            to: DIST_DIR,
-          },
         ],
       }),
       // Generate "index.html" w/ correct includes/imports

--- a/platform/core/src/services/MeasurementService/MeasurementService.ts
+++ b/platform/core/src/services/MeasurementService/MeasurementService.ts
@@ -482,6 +482,21 @@ class MeasurementService extends PubSubService {
       }
       const { toMeasurementSchema } = sourceMapping;
 
+      /**
+       * Compatibility issue for the unit, areaUnit and modalityUnit which have changed to
+       * lengthUnits, areaUnits and pixelValueUnits respectively.
+       * Todo: probably this should be inside the cornerstone as utils
+       */
+      if (sourceAnnotationDetail.unit) {
+        sourceAnnotationDetail.lengthUnits = sourceAnnotationDetail.unit;
+      }
+      if (sourceAnnotationDetail.areaUnit) {
+        sourceAnnotationDetail.areaUnits = sourceAnnotationDetail.areaUnit;
+      }
+      if (sourceAnnotationDetail.modalityUnit) {
+        sourceAnnotationDetail.pixelValueUnits = sourceAnnotationDetail.modalityUnit;
+      }
+
       /* Convert measurement */
       measurement = toMeasurementSchema(sourceAnnotationDetail);
       measurement.source = source;

--- a/platform/core/src/types/AppTypes.ts
+++ b/platform/core/src/types/AppTypes.ts
@@ -86,6 +86,7 @@ declare global {
         interaction?: number;
         prefetch?: number;
         thumbnail?: number;
+        compute?: number;
       };
       disableEditing?: boolean;
       maxNumberOfWebWorkers?: number;

--- a/platform/ui/src/components/SegmentationGroupTable/SegmentationConfig.tsx
+++ b/platform/ui/src/components/SegmentationGroupTable/SegmentationConfig.tsx
@@ -82,7 +82,7 @@ const ActiveSegmentationConfig = ({
 
 const InactiveSegmentationConfig = ({
   config,
-  setRenderInactiveSegmentations,
+  setrenderInactiveRepresentations,
   setFillAlphaInactive,
 }) => {
   const { t } = useTranslation('SegmentationTable');
@@ -90,10 +90,10 @@ const InactiveSegmentationConfig = ({
     <div className="px-3">
       <CheckBox
         label={t('Display inactive segmentations')}
-        checked={config.renderInactiveSegmentations}
+        checked={config.renderInactiveRepresentations}
         labelClassName="text-[12px]"
         className="mb-[9px]"
-        onChange={setRenderInactiveSegmentations}
+        onChange={setrenderInactiveRepresentations}
       />
 
       <div className="flex items-center space-x-2 pl-4">
@@ -121,7 +121,7 @@ const SegmentationConfig = ({
   setOutlineWidthActive,
   setOutlineOpacityActive,
   setRenderFill,
-  setRenderInactiveSegmentations,
+  setrenderInactiveRepresentations,
   setRenderOutline,
 }) => {
   const { t } = useTranslation('SegmentationTable');
@@ -156,7 +156,7 @@ const SegmentationConfig = ({
         {!isMinimized && (
           <InactiveSegmentationConfig
             config={initialConfig}
-            setRenderInactiveSegmentations={setRenderInactiveSegmentations}
+            setrenderInactiveRepresentations={setrenderInactiveRepresentations}
             setFillAlphaInactive={setFillAlphaInactive}
           />
         )}

--- a/platform/ui/src/components/SegmentationGroupTable/SegmentationGroupTable.tsx
+++ b/platform/ui/src/components/SegmentationGroupTable/SegmentationGroupTable.tsx
@@ -40,7 +40,7 @@ const SegmentationGroupTable = ({
   setOutlineWidthActive,
   setOutlineOpacityActive,
   setRenderFill,
-  setRenderInactiveSegmentations,
+  setrenderInactiveRepresentations,
   setRenderOutline,
   addSegmentationClassName,
 }) => {
@@ -94,7 +94,7 @@ const SegmentationGroupTable = ({
             setOutlineWidthActive={setOutlineWidthActive}
             setOutlineOpacityActive={setOutlineOpacityActive}
             setRenderFill={setRenderFill}
-            setRenderInactiveSegmentations={setRenderInactiveSegmentations}
+            setrenderInactiveRepresentations={setrenderInactiveRepresentations}
             setRenderOutline={setRenderOutline}
             segmentationConfig={segmentationConfig}
           />
@@ -212,7 +212,7 @@ SegmentationGroupTable.propTypes = {
   setOutlineWidthActive: PropTypes.func.isRequired,
   setOutlineOpacityActive: PropTypes.func.isRequired,
   setRenderFill: PropTypes.func.isRequired,
-  setRenderInactiveSegmentations: PropTypes.func.isRequired,
+  setrenderInactiveRepresentations: PropTypes.func.isRequired,
   setRenderOutline: PropTypes.func.isRequired,
 };
 
@@ -242,7 +242,7 @@ SegmentationGroupTable.defaultProps = {
   setOutlineWidthActive: () => {},
   setOutlineOpacityActive: () => {},
   setRenderFill: () => {},
-  setRenderInactiveSegmentations: () => {},
+  setrenderInactiveRepresentations: () => {},
   setRenderOutline: () => {},
 };
 export default SegmentationGroupTable;

--- a/platform/ui/src/components/SegmentationGroupTable/SegmentationGroupTableExpanded.tsx
+++ b/platform/ui/src/components/SegmentationGroupTable/SegmentationGroupTableExpanded.tsx
@@ -38,7 +38,7 @@ const SegmentationGroupTableExpanded = ({
   setOutlineWidthActive,
   setOutlineOpacityActive,
   setRenderFill,
-  setRenderInactiveSegmentations,
+  setrenderInactiveRepresentations,
   setRenderOutline,
 }) => {
   const [isConfigOpen, setIsConfigOpen] = useState(false);
@@ -86,7 +86,7 @@ const SegmentationGroupTableExpanded = ({
             setOutlineWidthActive={setOutlineWidthActive}
             setOutlineOpacityActive={setOutlineOpacityActive}
             setRenderFill={setRenderFill}
-            setRenderInactiveSegmentations={setRenderInactiveSegmentations}
+            setrenderInactiveRepresentations={setrenderInactiveRepresentations}
             setRenderOutline={setRenderOutline}
             segmentationConfig={segmentationConfig}
           />
@@ -175,7 +175,7 @@ SegmentationGroupTableExpanded.propTypes = {
   setOutlineWidthActive: PropTypes.func.isRequired,
   setOutlineOpacityActive: PropTypes.func.isRequired,
   setRenderFill: PropTypes.func.isRequired,
-  setRenderInactiveSegmentations: PropTypes.func.isRequired,
+  setrenderInactiveRepresentations: PropTypes.func.isRequired,
   setRenderOutline: PropTypes.func.isRequired,
 };
 
@@ -205,7 +205,7 @@ SegmentationGroupTableExpanded.defaultProps = {
   setOutlineWidthActive: () => {},
   setOutlineOpacityActive: () => {},
   setRenderFill: () => {},
-  setRenderInactiveSegmentations: () => {},
+  setrenderInactiveRepresentations: () => {},
   setRenderOutline: () => {},
 };
 export default SegmentationGroupTableExpanded;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "sourceMap": true,
     "declaration": true,
     "moduleResolution": "node",
+    "target": "ES2022",
     "outDir": "./dist",
     "paths": {
       "@ohif/core": ["platform/core/src"],
@@ -19,6 +20,11 @@
       "@ohif/app": ["platform/app/src"]
     }
   },
-  "include": ["platform/**/src/**/*", "platform/**/public/**/*", "extensions/**/src/**/*", "modes/**/src/**/*"],
+  "include": [
+    "platform/**/src/**/*",
+    "platform/**/public/**/*",
+    "extensions/**/src/**/*",
+    "modes/**/src/**/*"
+  ],
   "exclude": ["node_modules", "dist"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2086,7 +2086,7 @@
     "@docusaurus/theme-search-algolia" "2.4.3"
     "@docusaurus/types" "2.4.3"
 
-"@docusaurus/react-loadable@5.5.2", "react-loadable@npm:@docusaurus/react-loadable@5.5.2":
+"@docusaurus/react-loadable@5.5.2":
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/@docusaurus/react-loadable/-/react-loadable-5.5.2.tgz#81aae0db81ecafbdaee3651f12804580868fa6ce"
   integrity sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==
@@ -17743,6 +17743,14 @@ react-loadable-ssr-addon-v5-slorber@^1.0.1:
   dependencies:
     "@babel/runtime" "^7.10.3"
 
+"react-loadable@npm:@docusaurus/react-loadable@5.5.2":
+  version "5.5.2"
+  resolved "https://registry.yarnpkg.com/@docusaurus/react-loadable/-/react-loadable-5.5.2.tgz#81aae0db81ecafbdaee3651f12804580868fa6ce"
+  integrity sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==
+  dependencies:
+    "@types/react" "*"
+    prop-types "^15.6.2"
+
 react-modal@3.11.2:
   version "3.11.2"
   resolved "https://registry.yarnpkg.com/react-modal/-/react-modal-3.11.2.tgz#bad911976d4add31aa30dba8a41d11e21c4ac8a4"
@@ -19533,7 +19541,7 @@ string-natural-compare@^3.0.1:
   resolved "https://registry.yarnpkg.com/string-natural-compare/-/string-natural-compare-3.0.1.tgz#7a42d58474454963759e8e8b7ae63d71c1e7fdf4"
   integrity sha512-n3sPwynL1nwKi3WJ6AIsClwBMa0zTi54fn2oLU6ndfTSIO05xaznjSf15PcBZU6FNWbmN5Q6cxT4V5hGvB4taw==
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -19550,6 +19558,15 @@ string-width@^1.0.1:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 string-width@^2.1.0, string-width@^2.1.1:
   version "2.1.1"
@@ -19646,7 +19663,7 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -19673,6 +19690,13 @@ strip-ansi@^5.1.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.0, strip-ansi@^7.0.1:
   version "7.1.0"
@@ -20453,10 +20477,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typescript@4.6.4:
-  version "4.6.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.4.tgz#caa78bbc3a59e6a5c510d35703f6a09877ce45e9"
-  integrity sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==
+typescript@5.5.4:
+  version "5.5.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.5.4.tgz#d9852d6c82bad2d2eda4fd74a5762a8f5909e9ba"
+  integrity sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==
 
 "typescript@>=3 < 6":
   version "5.4.5"
@@ -21717,7 +21741,7 @@ worker-loader@3.0.8, worker-loader@^3.0.8:
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -21738,6 +21762,15 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
Trying to migrate ohif to new upcoming cornerstone3D 2.0 with the migration guides from here https://github.com/cornerstonejs/cornerstone3D/pull/1400

Todo:
- [ ] Implement a UI element to add segmentations to viewports, as we no longer add them automatically.
- [ ] Determine how a brush should behave on a viewport without segmentation, considering it activates at the toolGroup level.
- [ ] Add a `segmentationGroup` property to the hanging protocol. This allows hanging protocols to determine which viewports should be rendered together. This feature is particularly useful in scenarios like MPR (Multiplanar Reconstruction) and TMTV (Total Metabolic Tumor Volume), where a segmentation needs to be displayed across multiple viewports.