### PR TITLE
remove border-border class

### DIFF
--- a/platform/ui-next/src/tailwind.css
+++ b/platform/ui-next/src/tailwind.css
@@ -188,9 +188,6 @@
 */
 
 @layer base {
-  * {
-    @apply border-border;
-  }
   body {
     @apply bg-background text-foreground text-base;
   }


### PR DESCRIPTION

### Context
border-border custom class was breaking the build of ohif :  The `border-border` class does not exist. If `border-border` is a custom class, make sure it is defined within a `@layer` directive
It has been introduced here : https://github.com/OHIF/Viewers/commit/6231629b386d680845fb127e48a39348412d75d5
Didn't find any place this custom class is used

### Changes & Results

Build shoudl work

### Testing

### Checklist

#### PR

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] OS: <!--[e.g. Windows 10, macOS 10.15.4]-->
- [] Node version: <!--[e.g. 18.16.1]-->
- [] Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
