### PR TITLE
Feat/multi route modes

### DIFF
--- a/modes/basic-dev-mode/src/index.ts
+++ b/modes/basic-dev-mode/src/index.ts
@@ -127,6 +127,9 @@ function modeFactory({ modeConfiguration }) {
       };
     },
     routes: [
+      // This example has multiple routes & multiple layouts
+      // Navigating to /dev/no-panels with this mode registered will render a layout without panels
+      // navigating to just /dev/ will render the 0th route's layout
       {
         path: 'viewer-cs3d',
         /*init: ({ servicesManager, extensionManager }) => {
@@ -151,6 +154,27 @@ function modeFactory({ modeConfiguration }) {
                 {
                   namespace: dicompdf.viewport,
                   displaySetsToDisplay: [dicompdf.sopClassHandler],
+                },
+              ],
+            },
+          };
+        },
+      },
+      {
+        path: 'no-panels',
+        layoutTemplate: ({ location, servicesManager }) => {
+          return {
+            id: ohif.layout,
+            props: {
+              // TODO: Should be optional, or required to pass empty array for slots?
+              leftPanels: [ohif.thumbnailList],
+              rightPanels: [ohif.measurements],
+              rightPanelClosed: true,
+              leftPanelClosed: true,
+              viewports: [
+                {
+                  namespace: cs3d.viewport,
+                  displaySetsToDisplay: [ohif.sopClassHandler],
                 },
               ],
             },

--- a/platform/app/src/routes/Mode/Mode.tsx
+++ b/platform/app/src/routes/Mode/Mode.tsx
@@ -16,6 +16,7 @@ const { getSplitParam } = utils;
 
 export default function ModeRoute({
   mode,
+  modeRoutePath,
   dataSourceName,
   extensionManager,
   servicesManager,
@@ -84,7 +85,13 @@ export default function ModeRoute({
   const dataSource = extensionManager.getActiveDataSource()[0];
 
   // Only handling one route per mode for now
-  const route = mode.routes[0];
+  let route = mode.routes[0];
+  if (modeRoutePath) {
+    route = mode.routes.find(route => route.path === modeRoutePath);
+    if (!route) {
+      throw new Error(`Route not found for path: ${modeRoutePath}`);
+    }
+  }
 
   useEffect(() => {
     const loadExtensions = async () => {
@@ -398,6 +405,7 @@ function createCombinedContextProvider(extensionManager, servicesManager, comman
 
 ModeRoute.propTypes = {
   mode: PropTypes.object.isRequired,
+  modeRoutePath: PropTypes.string,
   dataSourceName: PropTypes.string,
   extensionManager: PropTypes.object,
   servicesManager: PropTypes.object,

--- a/platform/app/src/routes/buildModeRoutes.tsx
+++ b/platform/app/src/routes/buildModeRoutes.tsx
@@ -4,7 +4,8 @@ import ModeRoute from '@routes/Mode';
 /*
   Routes uniquely define an entry point to:
   - A mode
-  - Linked to a data source
+  - A mode route
+  - A data source
   - With a specified data set.
 
   The full route template is:
@@ -20,6 +21,14 @@ import ModeRoute from '@routes/Mode';
   A default source can be specified at the app level configuration, and then that source is used if :sourceType is omitted:
 
   /:modeId/:modeRoute/?queryParameters=example
+
+  Additionally, not specifying a modeRoute will default to the first route defined in the mode:
+
+  /:modeId/?queryParameters=example
+
+  You can still specify a sourceType in this case - the first mode route will be used with the specified sourceType:
+
+  /:modeId/:sourceType/?queryParameters=example
  */
 export default function buildModeRoutes({
   modes,
@@ -38,12 +47,16 @@ export default function buildModeRoutes({
       dataSourceNames.push(sourceName);
     }
   });
-
+  const allPaths = new Set<string>();
   modes.forEach(mode => {
-    // todo: for each route. add route to path.
     dataSourceNames.forEach(dataSourceName => {
-      const path = `/${mode.routeName}/${dataSourceName}`;
-
+      const datasourcePath = `/${mode.routeName}/${dataSourceName}`;
+      if (allPaths.has(datasourcePath)) {
+        console.warn(
+          `Duplicate path '${datasourcePath}' in buildModeRoutes, mode ${mode.routeName}, dataSource ${dataSourceName}`
+        );
+      }
+      allPaths.add(datasourcePath);
       // TODO move up.
       const children = () => (
         <ModeRoute
@@ -57,15 +70,43 @@ export default function buildModeRoutes({
       );
 
       routes.push({
-        path,
+        path: datasourcePath,
         children,
         private: true,
+      });
+
+      mode.routes.forEach(route => {
+        const path = `/${mode.routeName}/${route.path}/${dataSourceName}`;
+        if (allPaths.has(path)) {
+          console.warn(
+            `Duplicate path '${path}' in buildModeRoutes, mode ${mode.routeName}, route ${route.path}, dataSource ${dataSourceName}`
+          );
+        }
+        allPaths.add(path);
+        // TODO move up.
+        const children = () => (
+          <ModeRoute
+            mode={mode}
+            modeRoutePath={route.path}
+            dataSourceName={dataSourceName}
+            extensionManager={extensionManager}
+            servicesManager={servicesManager}
+            commandsManager={commandsManager}
+            hotkeysManager={hotkeysManager}
+          />
+        );
+
+        routes.push({
+          path,
+          children,
+          private: true,
+        });
       });
     });
 
     // Add active DataSource route.
     // This is the DataSource route for the active data source defined in ExtensionManager.getActiveDataSource
-    const path = `/${mode.routeName}`;
+    const modePath = `/${mode.routeName}`;
 
     // TODO move up.
     const children = () => (
@@ -78,10 +119,42 @@ export default function buildModeRoutes({
       />
     );
 
+    if (allPaths.has(modePath)) {
+      console.warn(`Duplicate path '${modePath}' in buildModeRoutes, mode ${mode.routeName}`);
+    }
+    allPaths.add(modePath);
+
     routes.push({
-      path,
+      path: modePath,
       children,
       private: true,
+    });
+
+    mode.routes.forEach(route => {
+      const path = `/${mode.routeName}/${route.path}`;
+      if (allPaths.has(path)) {
+        console.warn(
+          `Duplicate path '${path}' in buildModeRoutes, mode ${mode.routeName}, route ${route.path}`
+        );
+      }
+      allPaths.add(path);
+
+      const children = () => (
+        <ModeRoute
+          mode={mode}
+          modeRoutePath={route.path}
+          extensionManager={extensionManager}
+          servicesManager={servicesManager}
+          commandsManager={commandsManager}
+          hotkeysManager={hotkeysManager}
+        />
+      );
+
+      routes.push({
+        path,
+        children,
+        private: true,
+      });
     });
   });
 


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

The documentation mentions support for multi-route/multi-layout modes being planned in the future.
Given that we'd like to start using this functionality, we'd be happy to contribute it.

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

#### Updated ModeRoute (`platform/app/src/routes/Mode/Mode.tsx`) to accept an optional `modeRoutePath` prop
- If not passed, the route falls back to previous behaviour (rendering the first `route` of a given mode)
- if passed, ModeRoute tries to render a `route` object with the matching `path` parameter from `mode.routes`
- If a matching route is not present for some reason, the component throws an error 

#### Updated buildModeRoutes logic (`platform/app/src/routes/buildModeRoutes.tsx`)
In addition to generating & registering `/{mode.routeName}` and `/{mode.routeName}/{dataSourceID}` paths, we generate & register for each route in a mode
- a `/{mode.routeName}/{mode.route[n].path}` route
- for each Data Source, a `/{mode.routeName}/{mode.route[n].path}/{dataSourceID}` path

Given that we still register the `/{mode.routeName}` and `/{mode.routeName}/{dataSourceID}` paths, the router retains previous functionality.

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->
- Check out this PR
- Install the bundled `basic-dev-mode` or temporarily add the following to the longitudinal mode's (`modes/longitudinal/src/index.ts`) routes:

```javascript
{
  path: 'panelless',
  /*init: ({ servicesManager, extensionManager }) => {
    //defaultViewerRouteInit
  },*/
  layoutTemplate: () => {
    return {
      id: 'some-other-id',
      props: {
        leftPanels: [],
        rightPanels: [],
        rightPanelClosed: true,
        leftPanelClosed: true,
        viewports: [
          {
            namespace: tracked.viewport,
            displaySetsToDisplay: [ohif.sopClassHandler],
          },
        ],
      },
    };
  },
},
```
- `yarn dev`
- Open one of the default demo cases, eg. http://localhost:3000/viewer?StudyInstanceUIDs=2.16.840.1.114362.1.11972228.22789312658.616067305.306.2

> ⚠️  The following steps are written assuming you chose to modify the longitudinal mode. Please modify URL-s as appropriate in case you installed the basic dev mode instead.
- Confirm the default mode route still works on the bare `/viewer?...` URL
- Confirm the default dataset-specific route (`/viewer/dicomweb?....`) still works
- Confirm the explicit longitudinal route (`/viewer/longitudinal?....`) works
- Confirm the newly added route (`viewer/panelless?...`) works and renders without any side panels
- Confirm the newly added route works with the explicit datasource suffix (`viewer/panelless/dicomweb?...`)

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- feat(ModeRoute): add support for rendering an explicit route
- feat(buildModeRoutes): generate an explicit route mapping for each route in a mode

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [ ] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] OS: MacOS 14.0
- [x] Node version: v18.14.2
- [x] Browser: Chrome 126.0.6478.185
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
