### PR TITLE
fix: customization types

### DIFF
--- a/platform/core/src/services/CustomizationService/types.ts
+++ b/platform/core/src/services/CustomizationService/types.ts
@@ -9,6 +9,7 @@ export interface BaseCustomization extends Obj {
   description?: string;
   label?: string;
   commands?: Command[];
+  content?: (...props: any) => React.JSX.Element;
 }
 
 export interface LabelCustomization extends BaseCustomization {
@@ -23,11 +24,16 @@ export interface CommandCustomization extends BaseCustomization {
   commands: Command[];
 }
 
+export interface ComponentCustomization extends BaseCustomization {
+  content: (...props: any) => React.JSX.Element;
+}
+
 export type Customization =
   | BaseCustomization
   | LabelCustomization
   | CommandCustomization
-  | CodeCustomization;
+  | CodeCustomization
+  | ComponentCustomization;
 
 export default Customization;
 

--- a/platform/ui/src/components/MeasurementTable/MeasurementTable.tsx
+++ b/platform/ui/src/components/MeasurementTable/MeasurementTable.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useTranslation } from 'react-i18next';
+import { Types } from '@ohif/core';
 
 import MeasurementItem from './MeasurementItem';
 
@@ -17,9 +18,11 @@ const MeasurementTable = ({
   const amount = data.length;
 
   const itemCustomization = customizationService.getCustomization('MeasurementItem', {
+    id: 'MeasurementItem',
     content: MeasurementItem,
     contentProps: {},
-  });
+  }) as Types.Customization;
+
   const CustomMeasurementItem = itemCustomization.content;
 
   const onMeasurementDeleteHandler = ({ uid }) => {


### PR DESCRIPTION
### Context

Customization types do not match what already exists in custom components. Just fixing it so it comprises everything.

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] OS: <!--[e.g. Windows 10, macOS 10.15.4]-->
- [] Node version: <!--[e.g. 18.16.1]-->
- [] Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
