### PR TITLE
fix(hps): turn off HP when switching to a common layout or a custom MxN grid.

### DIFF
--- a/extensions/cornerstone/src/hps/fourUp.ts
+++ b/extensions/cornerstone/src/hps/fourUp.ts
@@ -8,6 +8,15 @@ export const fourUp = {
   modifiedDate: '2023-03-15T10:29:44.894Z',
   availableTo: {},
   editableBy: {},
+  callbacks: {
+    onLayoutChange: [
+      {
+        commandName: 'toggleHangingProtocol',
+        commandOptions: { protocolId: 'fourUp' },
+        context: 'DEFAULT',
+      },
+    ],
+  },
   protocolMatchingRules: [],
   imageLoadStrategy: 'interleaveCenter',
   displaySetSelectors: {

--- a/extensions/cornerstone/src/hps/main3D.ts
+++ b/extensions/cornerstone/src/hps/main3D.ts
@@ -8,6 +8,15 @@ export const main3D = {
   modifiedDate: '2023-03-15T10:29:44.894Z',
   availableTo: {},
   editableBy: {},
+  callbacks: {
+    onLayoutChange: [
+      {
+        commandName: 'toggleHangingProtocol',
+        commandOptions: { protocolId: 'main3D' },
+        context: 'DEFAULT',
+      },
+    ],
+  },
   protocolMatchingRules: [],
   imageLoadStrategy: 'interleaveCenter',
   displaySetSelectors: {

--- a/extensions/cornerstone/src/hps/mpr.ts
+++ b/extensions/cornerstone/src/hps/mpr.ts
@@ -10,11 +10,19 @@ export const mpr: Types.HangingProtocol.Protocol = {
   modifiedDate: '2023-08-15',
   availableTo: {},
   editableBy: {},
+  callbacks: {
+    onLayoutChange: [
+      {
+        commandName: 'toggleHangingProtocol',
+        commandOptions: { protocolId: 'mpr' },
+        context: 'DEFAULT',
+      },
+    ],
+  },
   // Unknown number of priors referenced - so just match any study
   numberOfPriorsReferenced: 0,
   protocolMatchingRules: [],
   imageLoadStrategy: 'nth',
-  callbacks: {},
   displaySetSelectors: {
     activeDisplaySet: {
       seriesMatchingRules: [

--- a/extensions/cornerstone/src/hps/mprAnd3DVolumeViewport.ts
+++ b/extensions/cornerstone/src/hps/mprAnd3DVolumeViewport.ts
@@ -6,6 +6,15 @@ export const mprAnd3DVolumeViewport = {
   modifiedDate: '2023-03-15T10:29:44.894Z',
   availableTo: {},
   editableBy: {},
+  callbacks: {
+    onLayoutChange: [
+      {
+        commandName: 'toggleHangingProtocol',
+        commandOptions: { protocolId: 'mprAnd3DVolumeViewport' },
+        context: 'DEFAULT',
+      },
+    ],
+  },
   protocolMatchingRules: [],
   imageLoadStrategy: 'interleaveCenter',
   displaySetSelectors: {

--- a/extensions/cornerstone/src/hps/only3D.ts
+++ b/extensions/cornerstone/src/hps/only3D.ts
@@ -8,6 +8,24 @@ export const only3D = {
   modifiedDate: '2023-03-15T10:29:44.894Z',
   availableTo: {},
   editableBy: {},
+  callbacks: {
+    onLayoutChange: [
+      {
+        commandName: 'toggleHangingProtocol',
+        commandOptions: { protocolId: 'only3D' },
+        context: 'DEFAULT',
+      },
+    ],
+  },
+  callbacks: {
+    onLayoutChange: [
+      {
+        commandName: 'toggleHangingProtocol',
+        commandOptions: { protocolId: 'only3D' },
+        context: 'DEFAULT',
+      },
+    ],
+  },
   protocolMatchingRules: [],
   imageLoadStrategy: 'interleaveCenter',
   displaySetSelectors: {

--- a/extensions/cornerstone/src/hps/primary3D.ts
+++ b/extensions/cornerstone/src/hps/primary3D.ts
@@ -8,6 +8,15 @@ export const primary3D = {
   modifiedDate: '2023-03-15T10:29:44.894Z',
   availableTo: {},
   editableBy: {},
+  callbacks: {
+    onLayoutChange: [
+      {
+        commandName: 'toggleHangingProtocol',
+        commandOptions: { protocolId: 'primary3D' },
+        context: 'DEFAULT',
+      },
+    ],
+  },
   protocolMatchingRules: [],
   imageLoadStrategy: 'interleaveCenter',
   displaySetSelectors: {

--- a/extensions/cornerstone/src/hps/primaryAxial.ts
+++ b/extensions/cornerstone/src/hps/primaryAxial.ts
@@ -8,6 +8,15 @@ export const primaryAxial = {
   modifiedDate: '2023-03-15T10:29:44.894Z',
   availableTo: {},
   editableBy: {},
+  callbacks: {
+    onLayoutChange: [
+      {
+        commandName: 'toggleHangingProtocol',
+        commandOptions: { protocolId: 'primaryAxial' },
+        context: 'DEFAULT',
+      },
+    ],
+  },
   protocolMatchingRules: [],
   imageLoadStrategy: 'interleaveCenter',
   displaySetSelectors: {


### PR DESCRIPTION
This change lets users get out of the advanced HPs when they select a common layout or a custom grid.