### PR TITLE
Auto flipping of disoriented Mammography images on stack viewport

### DIFF
--- a/extensions/cornerstone/jest.config.js
+++ b/extensions/cornerstone/jest.config.js
@@ -4,6 +4,11 @@ const pkg = require('./package');
 module.exports = {
   ...base,
   displayName: pkg.name,
+  moduleNameMapper: {
+    ...base.moduleNameMapper,
+    '^@ohif/(.*)$': '<rootDir>/../../platform/$1/src',
+    '^@cornerstonejs/tools(.*)$': '<rootDir>/../../node_modules/@cornerstonejs/tools',
+  },
   // rootDir: "../.."
   // testMatch: [
   //   //`<rootDir>/platform/${pack.name}/**/*.spec.js`

--- a/extensions/cornerstone/src/commandsModule.ts
+++ b/extensions/cornerstone/src/commandsModule.ts
@@ -5,6 +5,7 @@ import {
   utilities as csUtils,
   Types as CoreTypes,
   BaseVolumeViewport,
+  metaData,
 } from '@cornerstonejs/core';
 import {
   ToolGroupManager,
@@ -21,6 +22,7 @@ import toggleImageSliceSync from './utils/imageSliceSync/toggleImageSliceSync';
 import { getFirstAnnotationSelected } from './utils/measurementServiceMappings/utils/selection';
 import getActiveViewportEnabledElement from './utils/getActiveViewportEnabledElement';
 import toggleVOISliceSync from './utils/toggleVOISliceSync';
+import { getImageFlips } from './utils/getImageFlips';
 
 const toggleSyncFunctions = {
   imageSlice: toggleImageSliceSync,
@@ -497,6 +499,16 @@ function commandsModule({
 
       viewport.resetProperties?.();
       viewport.resetCamera();
+
+      const { criteria: isOrientationCorrectionNeeded } = customizationService.get(
+        'orientationCorrectionCriterion'
+      );
+      const instance = metaData.get('instance', viewport.getCurrentImageId());
+
+      if ((isOrientationCorrectionNeeded as (input) => boolean)?.(instance)) {
+        const { hFlip, vFlip } = getImageFlips(instance);
+        (hFlip || vFlip) && viewport.setCamera({ flipHorizontal: hFlip, flipVertical: vFlip });
+      }
 
       viewport.render();
     },

--- a/extensions/cornerstone/src/getCustomizationModule.ts
+++ b/extensions/cornerstone/src/getCustomizationModule.ts
@@ -5,6 +5,7 @@ import defaultWindowLevelPresets from './components/WindowLevelActionMenu/defaul
 import { colormaps } from './utils/colormaps';
 import { CONSTANTS } from '@cornerstonejs/core';
 import { CornerstoneOverlay } from './Viewport/Overlays/CustomizableViewportOverlay';
+import isOrientationCorrectionNeeded from './utils/isOrientationCorrectionNeeded';
 
 const DefaultColormap = 'Grayscale';
 const { VIEWPORT_PRESETS } = CONSTANTS;
@@ -211,6 +212,8 @@ function getCustomizationModule() {
             ],
           },
         },
+        // TODO: Move this customization to MG specific mode when introduced in OHIF.
+        { id: 'orientationCorrectionCriterion', criteria: isOrientationCorrectionNeeded },
       ],
     },
   ];

--- a/extensions/cornerstone/src/utils/getImageFlips.test.js
+++ b/extensions/cornerstone/src/utils/getImageFlips.test.js
@@ -1,0 +1,159 @@
+import { getImageFlips } from './getImageFlips';
+
+const orientationDirectionVectorMap = {
+  L: [1, 0, 0], // Left
+  R: [-1, 0, 0], // Right
+  P: [0, 1, 0], // Posterior/ Back
+  A: [0, -1, 0], // Anterior/ Front
+  H: [0, 0, 1], // Head/ Superior
+  F: [0, 0, -1], // Feet/ Inferior
+};
+
+const getDirectionsFromPatientOrientation = patientOrientation => {
+  if (typeof patientOrientation === 'string') {
+    patientOrientation = patientOrientation.split('\\');
+  }
+
+  return {
+    rowDirection: patientOrientation[0],
+    columnDirection: patientOrientation[1][0],
+  };
+};
+
+const getOrientationStringLPS = vector => {
+  const sampleVectorDirectionMap = {
+    '1,0,0': 'L',
+    '-1,0,0': 'R',
+    '0,1,0': 'P',
+    '0,-1,0': 'A',
+    '0,0,1': 'H',
+    '0,0,-1': 'F',
+  };
+
+  return sampleVectorDirectionMap[vector.toString()];
+};
+
+jest.mock('@cornerstonejs/tools ', () => ({
+  utilities: { orientation: { getOrientationStringLPS } },
+}));
+jest.mock('@ohif/core', () => ({
+  defaults: { orientationDirectionVectorMap },
+  utils: { getDirectionsFromPatientOrientation },
+}));
+
+describe('getImageFlips', () => {
+  test('should return empty object if none of the parameters are provided', () => {
+    const flipsNeeded = getImageFlips({});
+    expect(flipsNeeded).toEqual({});
+  });
+
+  test('should return empty object if ImageOrientationPatient and PatientOrientation is not provided', () => {
+    const ImageLaterality = 'L';
+    const flipsNeeded = getImageFlips({
+      ImageLaterality,
+    });
+    expect(flipsNeeded).toEqual({});
+  });
+
+  test('should return empty object if ImageLaterality is not privided', () => {
+    const ImageOrientationPatient = [0, 1, 0, 0, 0, 1],
+      PatientOrientation = ['P', 'H'];
+    const flipsNeeded = getImageFlips({
+      ImageOrientationPatient,
+      PatientOrientation,
+    });
+    expect(flipsNeeded).toEqual({});
+  });
+
+  test('should return { hFlip: false, vFlip: false } if ImageOrientationPatient is [0, 1, 0, 0, 0, -1] and ImageLaterality is R', () => {
+    const ImageOrientationPatient = [0, 1, 0, 0, 0, -1],
+      PatientOrientation = ['P', 'F'],
+      ImageLaterality = 'R';
+    const flipsNeeded = getImageFlips({
+      ImageOrientationPatient,
+      PatientOrientation,
+      ImageLaterality,
+    });
+    expect(flipsNeeded).toEqual({ hFlip: false, vFlip: false });
+  });
+
+  test('should return { hFlip: false, vFlip: true } if ImageOrientationPatient is [0, -1, 0, 0, 0, 1] and ImageLaterality is L', () => {
+    const ImageOrientationPatient = [0, -1, 0, 0, 0, 1],
+      ImageLaterality = 'L';
+    const flipsNeeded = getImageFlips({
+      ImageOrientationPatient,
+      ImageLaterality,
+    });
+    expect(flipsNeeded).toEqual({ hFlip: false, vFlip: true });
+  });
+
+  test('should return { hFlip: true, vFlip: true } if ImageOrientationPatient is [0, -1, 0, -1, 0, 0] and ImageLaterality is R', () => {
+    const ImageOrientationPatient = [0, -1, 0, -1, 0, 0],
+      ImageLaterality = 'R';
+    const flipsNeeded = getImageFlips({
+      ImageOrientationPatient,
+      ImageLaterality,
+    });
+    expect(flipsNeeded).toEqual({ hFlip: true, vFlip: true });
+  });
+
+  test("should return { hFlip: true, vFlip: true } if ImageOrientationPatient is not present, PatientOrientation is ['P', 'H'] and ImageLaterality is L", () => {
+    const PatientOrientation = ['P', 'H'],
+      ImageLaterality = 'L';
+    const flipsNeeded = getImageFlips({
+      PatientOrientation,
+      ImageLaterality,
+    });
+    expect(flipsNeeded).toEqual({ hFlip: true, vFlip: true });
+  });
+
+  test("should return { hFlip: true, vFlip: false } if ImageOrientationPatient is not present, PatientOrientation is ['A', 'F'] and ImageLaterality is R", () => {
+    const PatientOrientation = ['A', 'F'],
+      ImageLaterality = 'R';
+    const flipsNeeded = getImageFlips({
+      PatientOrientation,
+      ImageLaterality,
+    });
+    expect(flipsNeeded).toEqual({ hFlip: true, vFlip: false });
+  });
+
+  test("should return { hFlip: true, vFlip: false } if ImageOrientationPatient is not present, PatientOrientation is ['A', 'FL'] and ImageLaterality is R", () => {
+    const PatientOrientation = ['A', 'FL'],
+      ImageLaterality = 'R';
+    const flipsNeeded = getImageFlips({
+      PatientOrientation,
+      ImageLaterality,
+    });
+    expect(flipsNeeded).toEqual({ hFlip: true, vFlip: false });
+  });
+
+  test("should return { hFlip: true, vFlip: false } if ImageOrientationPatient ans ImageLaterality is not present, PatientOrientation is ['P', 'FL'] and FrameLaterality is L", () => {
+    const PatientOrientation = ['P', 'FL'],
+      FrameLaterality = 'L';
+    const flipsNeeded = getImageFlips({
+      PatientOrientation,
+      FrameLaterality,
+    });
+    expect(flipsNeeded).toEqual({ hFlip: true, vFlip: false });
+  });
+
+  test("should return empty object if ImageOrientationPatient is not present, PatientOrientation is ['H', 'R'] and ImageLaterality is R since the orientation is rotated, not flipped", () => {
+    const PatientOrientation = ['H', 'R'],
+      ImageLaterality = 'R';
+    const flipsNeeded = getImageFlips({
+      PatientOrientation,
+      ImageLaterality,
+    });
+    expect(flipsNeeded).toEqual({});
+  });
+
+  test("should return empty object if ImageOrientationPatient is not present, PatientOrientation is ['F', 'L'] and ImageLaterality is L since the orientation is rotated, not flipped", () => {
+    const PatientOrientation = ['F', 'L'],
+      ImageLaterality = 'L';
+    const flipsNeeded = getImageFlips({
+      PatientOrientation,
+      ImageLaterality,
+    });
+    expect(flipsNeeded).toEqual({});
+  });
+});

--- a/extensions/cornerstone/src/utils/getImageFlips.ts
+++ b/extensions/cornerstone/src/utils/getImageFlips.ts
@@ -1,0 +1,123 @@
+import { defaults, utils } from '@ohif/core';
+import { utilities } from '@cornerstonejs/tools';
+import { vec3 } from 'gl-matrix';
+
+const { orientationDirectionVectorMap } = defaults;
+const { getOrientationStringLPS } = utilities.orientation;
+
+type IOP = [number, number, number, number, number, number];
+type PO = [string, string] | string;
+type IL = string;
+type FL = string;
+type Instance = {
+  ImageOrientationPatient?: IOP;
+  PatientOrientation?: PO;
+  ImageLaterality?: IL;
+  FrameLaterality?: FL;
+};
+
+/**
+ * A function to get required flipping to correct the image according to Orientation and Laterality.
+ * This function does not handle rotated images.
+ * @param instance Metadata instance of the image.
+ * @returns vertical and horizontal flipping needed to correct the image if possible.
+ */
+export function getImageFlips(instance: Instance): { vFlip?: boolean; hFlip?: boolean } {
+  const { ImageOrientationPatient, PatientOrientation, ImageLaterality, FrameLaterality } =
+    instance;
+
+  if (!(ImageOrientationPatient || PatientOrientation) || !(ImageLaterality || FrameLaterality)) {
+    console.warn(
+      'Skipping image orientation correction due to missing ImageOrientationPatient/ PatientOrientation or/and ImageLaterality/ FrameLaterality'
+    );
+    return {};
+  }
+
+  let rowDirectionCurrent, columnDirectionCurrent, rowCosines, columnCosines;
+  if (ImageOrientationPatient) {
+    rowCosines = ImageOrientationPatient.slice(0, 3);
+    columnCosines = ImageOrientationPatient.slice(3, 6);
+    rowDirectionCurrent = getOrientationStringLPS(rowCosines);
+    columnDirectionCurrent = getOrientationStringLPS(columnCosines)[0];
+  } else {
+    ({ rowDirection: rowDirectionCurrent, columnDirection: columnDirectionCurrent } =
+      utils.getDirectionsFromPatientOrientation(PatientOrientation));
+
+    rowCosines = orientationDirectionVectorMap[rowDirectionCurrent];
+    columnCosines = orientationDirectionVectorMap[columnDirectionCurrent];
+  }
+
+  const scanAxisNormal = vec3.create();
+  vec3.cross(scanAxisNormal, rowCosines, columnCosines);
+
+  const scanAxisDirection = getOrientationStringLPS(scanAxisNormal as [number, number, number]);
+
+  if (isImageRotated(rowDirectionCurrent, columnDirectionCurrent)) {
+    // TODO: Correcting images with rotation is not implemented.
+    console.warn('Correcting images by rotating is not implemented');
+    return {};
+  }
+
+  let rowDirectionTarget, columnDirectionTarget;
+  switch (scanAxisDirection[0]) {
+    // Sagittal
+    case 'L':
+    case 'R':
+      if ((ImageLaterality || FrameLaterality) === 'L') {
+        rowDirectionTarget = 'A';
+      } else {
+        rowDirectionTarget = 'P';
+      }
+      columnDirectionTarget = 'F';
+      break;
+    // Coronal
+    case 'A':
+    case 'P':
+      if ((ImageLaterality || FrameLaterality) === 'L') {
+        rowDirectionTarget = 'R';
+      } else {
+        rowDirectionTarget = 'L';
+      }
+      columnDirectionTarget = 'F';
+      break;
+    // Axial
+    case 'H':
+    case 'F':
+      if ((ImageLaterality || FrameLaterality) === 'L') {
+        rowDirectionTarget = 'A';
+        columnDirectionTarget = 'R';
+      } else {
+        rowDirectionTarget = 'P';
+        columnDirectionTarget = 'L';
+      }
+      break;
+  }
+
+  let hFlip = false,
+    vFlip = false;
+  if (rowDirectionCurrent !== rowDirectionTarget) {
+    hFlip = true;
+  }
+  if (columnDirectionCurrent !== columnDirectionTarget) {
+    vFlip = true;
+  }
+
+  return { hFlip, vFlip };
+}
+
+function isImageRotated(rowDirection: string, columnDirection: string): boolean {
+  const possibleValues: { [key: string]: [string, string] } = {
+    xDirection: ['L', 'R'],
+    yDirection: ['P', 'A'],
+    zDirection: ['H', 'F'],
+  };
+
+  if (
+    possibleValues.yDirection.includes(columnDirection) ||
+    possibleValues.zDirection.includes(rowDirection)
+  ) {
+    return true;
+  }
+
+  return false;
+}

--- a/extensions/cornerstone/src/utils/isOrientationCorrectionNeeded.ts
+++ b/extensions/cornerstone/src/utils/isOrientationCorrectionNeeded.ts
@@ -1,0 +1,10 @@
+const DEFAULT_AUTO_FLIP_MODALITIES: string[] = ['MG'];
+
+export default function isOrientationCorrectionNeeded(instance) {
+  const { Modality } = instance;
+
+  // Check Modality
+  const isModalityIncluded = DEFAULT_AUTO_FLIP_MODALITIES.includes(Modality);
+
+  return isModalityIncluded;
+}

--- a/platform/core/src/classes/MetadataProvider.ts
+++ b/platform/core/src/classes/MetadataProvider.ts
@@ -6,6 +6,7 @@ import DicomMetadataStore from '../services/DicomMetadataStore';
 import fetchPaletteColorLookupTableData from '../utils/metadataProvider/fetchPaletteColorLookupTableData';
 import toNumber from '../utils/toNumber';
 import combineFrameInstance from '../utils/combineFrameInstance';
+import { orientationDirectionVectorMap } from '../defaults';
 
 class MetadataProvider {
   constructor() {
@@ -533,7 +534,7 @@ export default metadataProvider;
 
 const WADO_IMAGE_LOADER = {
   imagePlaneModule: instance => {
-    const { ImageOrientationPatient } = instance;
+    const { ImageOrientationPatient, PatientOrientation } = instance;
 
     // Fallback for DX images.
     // TODO: We should use the rest of the results of this function
@@ -554,6 +555,13 @@ const WADO_IMAGE_LOADER = {
     if (ImageOrientationPatient) {
       rowCosines = ImageOrientationPatient.slice(0, 3);
       columnCosines = ImageOrientationPatient.slice(3, 6);
+    } else if (PatientOrientation) {
+      let patientOrientation = PatientOrientation;
+      if (typeof patientOrientation === 'string') {
+        patientOrientation = patientOrientation.split('\\');
+      }
+      rowCosines = orientationDirectionVectorMap[patientOrientation[0]];
+      columnCosines = orientationDirectionVectorMap[patientOrientation[1][0]];
     }
 
     return {

--- a/platform/core/src/defaults/index.js
+++ b/platform/core/src/defaults/index.js
@@ -1,4 +1,5 @@
 import hotkeyBindings from './hotkeyBindings';
 import windowLevelPresets from './windowLevelPresets';
-export { hotkeyBindings, windowLevelPresets };
-export default { hotkeyBindings, windowLevelPresets };
+import orientationDirectionVectorMap from './orientationDirectionVectors';
+export { hotkeyBindings, windowLevelPresets, orientationDirectionVectorMap };
+export default { hotkeyBindings, windowLevelPresets, orientationDirectionVectorMap };

--- a/platform/core/src/defaults/orientationDirectionVectors.ts
+++ b/platform/core/src/defaults/orientationDirectionVectors.ts
@@ -1,0 +1,12 @@
+import { Types } from '@cornerstonejs/core';
+
+const orientationDirectionVectorMap: { [key: string]: Types.Point3 } = {
+  L: [1, 0, 0], // Left
+  R: [-1, 0, 0], // Right
+  P: [0, 1, 0], // Posterior/ Back
+  A: [0, -1, 0], // Anterior/ Front
+  H: [0, 0, 1], // Head/ Superior
+  F: [0, 0, -1], // Feet/ Inferior
+};
+
+export default orientationDirectionVectorMap;

--- a/platform/core/src/types/OrientationDirections.ts
+++ b/platform/core/src/types/OrientationDirections.ts
@@ -1,0 +1,1 @@
+export type OrientationDirections = { rowDirection: string; columnDirection: string };

--- a/platform/core/src/types/index.ts
+++ b/platform/core/src/types/index.ts
@@ -19,6 +19,7 @@ export type * from './StudyMetadata';
 export type * from './PanelModule';
 export type * from './IPubSub';
 export type * from './Color';
+export type * from './OrientationDirections';
 
 /**
  * Export the types used within the various services and managers, but

--- a/platform/core/src/utils/getDirectionsFromPatientOrientation.ts
+++ b/platform/core/src/utils/getDirectionsFromPatientOrientation.ts
@@ -1,0 +1,16 @@
+import { OrientationDirections } from '../types';
+
+export default function getDirectionsFromPatientOrientation(
+  patientOrientation: string | [string, string]
+): OrientationDirections {
+  if (typeof patientOrientation === 'string') {
+    patientOrientation = patientOrientation.split('\\') as [string, string];
+  }
+
+  // TODO: We are only considering first direction in column orientation.
+  // ex: in ['P', 'HL'], we are only taking 'H' instead of 'HL' as column orientation.
+  return {
+    rowDirection: patientOrientation[0],
+    columnDirection: patientOrientation[1][0],
+  };
+}

--- a/platform/core/src/utils/index.test.js
+++ b/platform/core/src/utils/index.test.js
@@ -44,6 +44,7 @@ describe('Top level exports', () => {
       'subscribeToNextViewportGridChange',
       'uuidv4',
       'addAccessors',
+      'getDirectionsFromPatientOrientation',
     ].sort();
 
     const exports = Object.keys(utils.default).sort();

--- a/platform/core/src/utils/index.ts
+++ b/platform/core/src/utils/index.ts
@@ -40,6 +40,7 @@ import { subscribeToNextViewportGridChange } from './subscribeToNextViewportGrid
 import { splitComma, getSplitParam } from './splitComma';
 import { createStudyBrowserTabs } from './createStudyBrowserTabs';
 import { sopClassDictionary } from './sopClassDictionary';
+import getDirectionsFromPatientOrientation from './getDirectionsFromPatientOrientation';
 
 // Commented out unused functionality.
 // Need to implement new mechanism for derived displaySets using the displaySetManager.
@@ -86,6 +87,7 @@ const utils = {
   getSplitParam,
   generateAcceptHeader,
   createStudyBrowserTabs,
+  getDirectionsFromPatientOrientation,
 };
 
 export {
@@ -119,6 +121,7 @@ export {
   getSplitParam,
   generateAcceptHeader,
   createStudyBrowserTabs,
+  getDirectionsFromPatientOrientation,
 };
 
 export default utils;


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context
The feature is designed to flip the images in the stack viewport, which are initially stored in a flipped orientation. The images are flipped upon loading and when the viewport is reset. It relies on ImageOrientationPatient or PatientOrientation, and ImageLaterality or FrameLaterality to identify the necessary flipping. Primarily, this feature is aimed at MG images that are stored in an incorrect orientation. It is capable of correcting images through vertical and/or horizontal flips, but it does not handle images requiring rotation for correction.
<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results
The activation of the feature is handled through CustomizationService. A function that accepts the metadata instance and returns whether auto-flipping is needed or not is provided in the CustomizationService.
#### A sample customization
```
function getCustomizationModule() {
	return [
		{
			name: 'default',
			value: [
				{ id: 'orientationCorrectionCriterion', criteria: isOrientationCorrectionNeeded }
			]
		}
	]
}
```
#### A demo recording of the feature
https://github.com/user-attachments/assets/58aabeff-4529-4d12-8ad5-0c3276eacead
<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] OS: Windows 11 Pro
- [x] Node version: 18.17.0
- [x] Browser: Chrome 127.0.6533.120 (Official Build) (64-bit)

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
