### PR TITLE
fix(MergeDataSource):  remove duplicated instances and fix to issue #4349

### DIFF
--- a/extensions/default/src/MergeDataSource/types.ts
+++ b/extensions/default/src/MergeDataSource/types.ts
@@ -17,6 +17,7 @@ export type CallForAllDataSourcesAsyncOptions = {
 };
 
 export type CallForAllDataSourcesOptions = {
+  mergeMap: object;
   path: string;
   args: unknown[];
   dataSourceNames: string[];

--- a/platform/app/src/routes/Mode/defaultRouteInit.ts
+++ b/platform/app/src/routes/Mode/defaultRouteInit.ts
@@ -116,7 +116,7 @@ export async function defaultRouteInit(
     const remainingPromises = [];
 
     function startRemainingPromises(remainingPromises) {
-      remainingPromises.forEach(p => p.forEach(p => p.start()));
+      remainingPromises.forEach(p => p.forEach(p => p));
     }
 
     promises.forEach(promise => {
@@ -127,7 +127,7 @@ export async function defaultRouteInit(
 
       if (displaySetFromUrl) {
         const requiredSeriesPromises = retrieveSeriesMetadataPromise.map(promise =>
-          promise.start()
+          promise
         );
         allPromises.push(Promise.allSettled(requiredSeriesPromises));
       } else {
@@ -135,7 +135,7 @@ export async function defaultRouteInit(
           hangingProtocolId,
           retrieveSeriesMetadataPromise
         );
-        const requiredSeriesPromises = requiredSeries.map(promise => promise.start());
+        const requiredSeriesPromises = requiredSeries.map(promise => promise);
         allPromises.push(Promise.allSettled(requiredSeriesPromises));
         remainingPromises.push(remaining);
       }


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

Problems: 
1. When having [merged two dicomweb Data Sources](https://docs.ohif.org/platform/extensions/modules/data-source/#merge-data-source) it gets the error "[promise.start() is not a function](https://github.com/OHIF/Viewers/issues/4349)", since neither remainingPromises nor requiredSeriesPromises are Promises.
![Capture d’écran du 2024-09-02 16-17-22](https://github.com/user-attachments/assets/a96e4d0e-bac3-434a-a20b-b848951bf723)

2. Also, when having a study in both servers, the instances are being called twice, resulting in duplicated viewports.
![Capture d’écran du 2024-09-02 16-16-02](https://github.com/user-attachments/assets/ff09453f-884a-4b61-bf6e-a0d1192c0992)


### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

1. Changed `promise.start()` and `p.start()` to `promise` and `p`, respectively.
2. mergeKey added to mergeMap in order to remove duplicated mergedData.

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

1. Merge two dicomweb servers using the  [official documentation](https://docs.ohif.org/platform/extensions/modules/data-source/#merge-data-source) 
2. Upload different instances of the same study on both servers
3. Open OHIF and try to access to that study

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] OS: <!--[e.g. Windows 10, macOS 10.15.4]--> Fedora 40
- [x] Node version: <!--[e.g. 18.16.1]--> v20.12.2
- [x] Browser: Chrome 127.0.6533.119, Firefox 129.0
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
