### PR TITLE
fix(3d-viewport): exception was being thrown and 3d viewpot not getting resized.

### DIFF
--- a/extensions/cornerstone/src/services/ViewportService/CornerstoneViewportService.ts
+++ b/extensions/cornerstone/src/services/ViewportService/CornerstoneViewportService.ts
@@ -242,7 +242,7 @@ class CornerstoneViewportService extends PubSubService implements IViewportServi
     return {
       id: positionPresentationId,
       viewportType: viewportInfo.getViewportType(),
-      viewReference: csViewport.getViewReference(),
+      viewReference: csViewport instanceof VolumeViewport3D ? null : csViewport.getViewReference(),
       position: csViewport.getViewPresentation({ pan: true, zoom: true }),
     };
   }


### PR DESCRIPTION
### Context

The 3D viewport was throwing exceptions when it tries to resize due to calls to a method that is not implemented. Removing the call makes the viewport resize as expected.

This can be removed when the 3D viewport method is added.

Try the bug here: https://viewer-dev.ohif.org/viewer?StudyInstanceUIDs=2.16.840.1.114362.1.11972228.22789312658.616067305.306.2&hangingProtocolId=only3D

resize the browser

