### PR TITLE
fix(tmtv):Change volume unit from mm³ to cm³ in ROI thresholding display

### DIFF
--- a/extensions/tmtv/src/commandsModule.ts
+++ b/extensions/tmtv/src/commandsModule.ts
@@ -381,7 +381,7 @@ const commandsModule = ({ servicesManager, commandsManager, extensionManager }: 
           segmentationValues
             .map((k) => (k - mean) ** 2)
             .reduce((acc, curr) => acc + curr, 0) / voxelCount),
-        volume: voxelCount * spacing[0] * spacing[1] * spacing[2] * 1e-3,
+        volume: voxelCount * spacing[0] * spacing[1] * spacing[2],
       };
 
       return stats;

--- a/extensions/tmtv/src/utils/handleROIThresholding.ts
+++ b/extensions/tmtv/src/utils/handleROIThresholding.ts
@@ -34,7 +34,7 @@ export const handleROIThresholding = async ({
       segment.cachedStats = cachedStats;
       segment.displayText = [
         `SUV Peak: ${suvPeak.suvPeak.toFixed(2)}`,
-        `Volume: ${lesionStats.volume.toFixed(2)} mm3`,
+        `Volume: ${lesionStats.volume.toFixed(2)} cm3`,
       ];
       updatedPerSegmentCachedStats[segmentIndex] = cachedStats;
 

--- a/extensions/tmtv/src/utils/handleROIThresholding.ts
+++ b/extensions/tmtv/src/utils/handleROIThresholding.ts
@@ -34,7 +34,7 @@ export const handleROIThresholding = async ({
       segment.cachedStats = cachedStats;
       segment.displayText = [
         `SUV Peak: ${suvPeak.suvPeak.toFixed(2)}`,
-        `Volume: ${lesionStats.volume.toFixed(2)} cm3`,
+        `Volume: ${lesionStats.volume.toFixed(2)} mm3`,
       ];
       updatedPerSegmentCachedStats[segmentIndex] = cachedStats;
 


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context
In the getLesionStats function of extensions/tmtv/src/commandsModule.ts, the volume is calculated as voxelCount * spacing[0] * spacing[1] * spacing[2] * 1e-3. This 1e-3 means that the final unit should be cubic centimeters rather than millimeters. Additionally, the final TMTV unit is in mL, which corresponds correctly.




