### PR TITLE
fix(Select): select clear button

### DIFF
--- a/platform/ui/src/components/Select/Select.tsx
+++ b/platform/ui/src/components/Select/Select.tsx
@@ -101,6 +101,9 @@ const Select = ({
       }}
       value={value && Array.isArray(value) ? selectedOptions : value}
       onChange={(selectedOptions, { action }) => {
+        if (selectedOptions === null) {
+          return onChange(null, action);
+        }
         const newSelection = !selectedOptions.length
           ? selectedOptions
           : selectedOptions.reduce((acc, curr) => acc.concat([curr.value]), []);


### PR DESCRIPTION
### Context

The ohif/ui select does not work if you try to clear the selection. The onChange function throws an error because it tries to select the length property of null:

![image](https://github.com/user-attachments/assets/6e3b1ffc-4460-40b2-8599-5d29ec6ed66b)


### Changes & Results

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] OS: <!--[e.g. Windows 10, macOS 10.15.4]-->
- [] Node version: <!--[e.g. 18.16.1]-->
- [] Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
