### PR TITLE
fix(auth): oidc-react-issue

### DIFF
--- a/platform/app/src/routes/Mode/Mode.tsx
+++ b/platform/app/src/routes/Mode/Mode.tsx
@@ -95,7 +95,10 @@ export default function ModeRoute({
           await extensionManager.registerExtension(extension);
         }
       }
-      setExtensionDependenciesLoaded(true);
+
+      if (isMounted.current) {
+        setExtensionDependenciesLoaded(true);
+      }
     };
 
     loadExtensions();

--- a/platform/app/src/utils/OpenIdConnectRoutes.tsx
+++ b/platform/app/src/utils/OpenIdConnectRoutes.tsx
@@ -44,7 +44,7 @@ const initUserManager = (oidc, routerBasename) => {
     post_logout_redirect_uri: _makeAbsoluteIfNecessary(post_logout_redirect_uri, baseUri),
   });
 
-  const client = firstOpenIdClient.useAuthorizationCodeFlow ? NextClient: LegacyClient
+  const client = firstOpenIdClient.useAuthorizationCodeFlow ? NextClient : LegacyClient
 
   return client(openIdConnectConfiguration);
 };
@@ -110,8 +110,10 @@ function OpenIdConnectRoutes({ oidc, routerBasename, userAuthenticationService }
     };
   };
 
-  const handleUnauthenticated = async () => {
-    await userManager.signinRedirect();
+  const handleUnauthenticated = () => {
+    // Note: Don't await the redirect. If you make this component async it
+    // causes a react error before redirect as it returns a promise of a component rather than a component.
+    userManager.signinRedirect();
 
     // return null because this is used in a react component
     return null;


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

In the OpenIdConnectRoutes there was a component which was defined as asynchronous, which causes issues in react.

This caused the following error before redirect: https://react.dev/errors/31?invariant=31&args%5B%5D=%5Bobject%20Promise%5D

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

To prevent this issue we instead don't await the redirect promise and just return null. Redirect works as expected, but React doesn't complain about its input

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

Try an OpenIdConnect setup and you will not get a React error prior to redirect after this commit.

