### PR TITLE
fix(cli): publish 4D preclincial mode on NPM so it can be used in the OHIF cli commands

### DIFF
--- a/modes/preclinical-4d/package.json
+++ b/modes/preclinical-4d/package.json
@@ -17,6 +17,9 @@
     "public/**",
     "README.md"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "ohif-mode"
   ],

--- a/platform/app/cypress/support/commands.js
+++ b/platform/app/cypress/support/commands.js
@@ -47,6 +47,7 @@ Cypress.Commands.add('openStudy', PatientName => {
 Cypress.Commands.add(
   'checkStudyRouteInViewer',
   (StudyInstanceUID, otherParams = '', mode = '/basic-test') => {
+    Cypress.on('uncaught:exception', () => false);
     cy.location('pathname').then($url => {
       cy.log($url);
       if ($url === 'blank' || !$url.includes(`${mode}/${StudyInstanceUID}${otherParams}`)) {


### PR DESCRIPTION
### Context

Currently the 4D mode is not on NPM, leading to errors when calling OHIF cli commands cuz some information can't be retrieved

example:

longitudinal

![CleanShot 2024-11-29 at 09 36 47@2x](https://github.com/user-attachments/assets/3064d94a-d563-423c-a9a4-98179b589613)

4d

![CleanShot 2024-11-29 at 09 37 16@2x](https://github.com/user-attachments/assets/def2207e-d7cb-4e26-a38f-6ab0d8474668)
