### PR TITLE
fix(SR): set view reference on hydrated measurements, don't jump to displaySets that are excluded from thumbnail browser

### DIFF
--- a/extensions/cornerstone-dicom-sr/src/utils/hydrateStructuredReport.ts
+++ b/extensions/cornerstone-dicom-sr/src/utils/hydrateStructuredReport.ts
@@ -46,7 +46,13 @@ export default function hydrateStructuredReport(
 ) {
   const annotationManager = CsAnnotation.state.getAnnotationManager();
   const dataSource = extensionManager.getActiveDataSource()[0];
-  const { measurementService, displaySetService, customizationService } = servicesManager.services;
+  const {
+    measurementService,
+    displaySetService,
+    customizationService,
+    viewportGridService,
+    cornerstoneViewportService,
+  } = servicesManager.services;
 
   const codingValues = customizationService.getCustomization('codingValues', {});
 
@@ -191,13 +197,18 @@ export default function hydrateStructuredReport(
         // StudyInstanceUID,
       } = instance;
 
+      const activeViewportId = viewportGridService.getActiveViewportId();
+      const cornerstoneViewport =
+        cornerstoneViewportService.getCornerstoneViewport(activeViewportId);
+      const viewRef = cornerstoneViewport.getViewReference({ referenceImageId: imageId });
+
       const annotation = {
         annotationUID: toolData.annotation.annotationUID,
         data: toolData.annotation.data,
         metadata: {
           toolName: annotationType,
-          referencedImageId: imageId,
           FrameOfReferenceUID,
+          ...viewRef,
         },
       };
 

--- a/extensions/cornerstone/src/initMeasurementService.ts
+++ b/extensions/cornerstone/src/initMeasurementService.ts
@@ -420,9 +420,7 @@ const connectMeasurementServiceToTools = (measurementService, cornerstoneViewpor
         isLocked: false,
         invalidated: false,
         metadata: {
-          toolName: measurement.toolName,
-          FrameOfReferenceUID: measurement.FrameOfReferenceUID,
-          referencedImageId: imageId,
+          ...measurement.metadata,
         },
         data: {
           /**

--- a/extensions/cornerstone/src/utils/measurementServiceMappings/Length.ts
+++ b/extensions/cornerstone/src/utils/measurementServiceMappings/Length.ts
@@ -6,7 +6,7 @@ import { utils } from '@ohif/core';
 import { config } from '@cornerstonejs/tools/annotation';
 
 const Length = {
-  toAnnotation: measurement => {},
+  toAnnotation: measurement => { },
 
   /**
    * Maps cornerstone annotation event data to measurement service format.

--- a/extensions/measurement-tracking/src/panels/PanelStudyBrowserTracking/PanelStudyBrowserTracking.tsx
+++ b/extensions/measurement-tracking/src/panels/PanelStudyBrowserTracking/PanelStudyBrowserTracking.tsx
@@ -282,14 +282,14 @@ export default function PanelStudyBrowserTracking({
         const { displaySetsAdded, options } = data;
         displaySetsAdded.forEach(async dSet => {
           const displaySetInstanceUID = dSet.displaySetInstanceUID;
-
+          const isExcludedFromThumbnailBrowser = dSet.excludeFromThumbnailBrowser;
           const newImageSrcEntry = {};
           const displaySet = displaySetService.getDisplaySetByUID(displaySetInstanceUID);
           if (displaySet?.unsupported) {
             return;
           }
 
-          if (options.madeInClient) {
+          if (options.madeInClient && !isExcludedFromThumbnailBrowser) {
             setJumpToDisplaySet(displaySetInstanceUID);
           }
 


### PR DESCRIPTION
### Context

Adds a view reference on hydrated measurements, since otherwise the viewport can't jump to them since there is not sufficient metadata.

Also ignores displaySets that are not in the thumbnail browser even if they have the made in client flag, it will use the actual SR from the panel, not the OHIF generated reference