### PR TITLE
Fix : Resize was broken if 3d viewport displayed in HP

### DIFF
--- a/extensions/cornerstone/src/services/ViewportService/CornerstoneViewportService.ts
+++ b/extensions/cornerstone/src/services/ViewportService/CornerstoneViewportService.ts
@@ -1062,7 +1062,7 @@ class CornerstoneViewportService extends PubSubService implements IViewportServi
         // During a resize, the slice index should remain unchanged. This is a temporary fix for
         // a larger issue regarding the definition of slice index with slab thickness.
         // We need to revisit this to make it more robust and understandable.
-        delete presentation.viewReference.sliceIndex;
+        delete presentation.viewReference?.sliceIndex;
         this.beforeResizePositionPresentations.set(viewportId, presentation);
       });
 

--- a/platform/ui/src/contextProviders/ViewportGridProvider.tsx
+++ b/platform/ui/src/contextProviders/ViewportGridProvider.tsx
@@ -187,7 +187,7 @@ export function ViewportGridProvider({ children, service }: ViewportGridProvider
             updatedViewport?.viewportOptions
           );
 
-          const displaySetOptions = updatedViewport.displaySetOptions || [];
+          const displaySetOptions = updatedViewport?.displaySetOptions || [];
           if (!displaySetOptions.length) {
             // Copy all the display set options, assuming a full set of displaySet UID's is provided.
             if (state.isHangingProtocolLayout) {


### PR DESCRIPTION
### Context


If we resize the window in a HP containing a 3D viewport we currently have this error : 
`CornerstoneViewportService.ts:1087 Caught resize exception TypeError: Cannot convert undefined or null to object
    at CornerstoneViewportService.ts:1065:29
    at Array.forEach (<anonymous>)
    at un.performResize (CornerstoneViewportService.ts:1059:17)
    at un.resize (CornerstoneViewportService.ts:154:12)
    at Object.callback (init.tsx:215:32)
    at pubSubServiceInterface.ts:88:16
    at Array.forEach (<anonymous>)
    at N.l [as _broadcastEvent] (pubSubServiceInterface.ts:87:31)
    at N.setViewportGridSizeChanged (ViewportGridService.ts:163:10)
    at Object.setViewportGridSizeChanged (ViewportGridProvider.tsx:511:50)`


See also this video showing image being distorted while resizing in a HP having 3D viewport: 
[Screenity video - Nov 30, 2024.webm](https://github.com/user-attachments/assets/762faeba-bbc4-4869-a68b-c8005bc0eeb8)

This was due to _getPositionPresentation returning a null in case of VolumeViewport3D
`viewReference: csViewport instanceof VolumeViewport3D ? null : csViewport.getViewReference(),`

While the resize function do not have a null safe before deleting the slice index here : 
`
        // During a resize, the slice index should remain unchanged. This is a temporary fix for
        // a larger issue regarding the definition of slice index with slab thickness.
        // We need to revisit this to make it more robust and understandable.
        delete presentation.viewReference.sliceIndex;
`


### Changes & Results
Add a null safe operator for view referencd
`
        // During a resize, the slice index should remain unchanged. This is a temporary fix for
        // a larger issue regarding the definition of slice index with slab thickness.
        // We need to revisit this to make it more robust and understandable.
        delete presentation.viewReference?.sliceIndex;
`

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] OS: <!--[e.g. Windows 10, macOS 10.15.4]-->
- [] Node version: <!--[e.g. 18.16.1]-->
- [] Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
