### PR TITLE
fix(WorkflowSteps): fixed how hooks are invoked + added support for 'onExit' hook

### DIFF
--- a/platform/core/src/services/WorkflowStepsService/WorkflowStepsService.ts
+++ b/platform/core/src/services/WorkflowStepsService/WorkflowStepsService.ts
@@ -77,6 +77,7 @@ export type WorkflowStep = {
     };
   };
   onEnter: () => void | CommandCallback[];
+  onExit: () => void | CommandCallback[];
 };
 
 class WorkflowStepsService extends PubSubService {
@@ -172,7 +173,7 @@ class WorkflowStepsService extends PubSubService {
 
     const commandsManager = this._commandsManager;
 
-    if (!Array.isArray) {
+    if (!Array.isArray(callbacks)) {
       callbacks = [callbacks];
     }
 
@@ -201,6 +202,10 @@ class WorkflowStepsService extends PubSubService {
 
     if (!newWorkflowStep) {
       throw new Error(`Invalid workflowStepId (${workflowStepId})`);
+    }
+
+    if (this._activeWorkflowStep) {
+      this._invokeCallbacks(previousWorkflowStep.onExit);
     }
 
     // onEnter needs to be called before updating the Hanging Protocol because


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

- Users can specify an `onEnter` hook which may be a single function/command or an array of functions/commands but due to an issue it was not working for the first case.
- There is no `onExit` hook which may be very useful in some cases.

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

Fixed how `WorkflowStepsService` validates if `callbacks` is an array and added support for `onExit` hook.

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

- Define an `onEnter` hook for a single function/command in `getWorkflowSteps` and launch the viewer. You can do that in 4D mode since it is the only mode currently using `WorkflowStepsService`.
- Define an `onExit` hook for single or multiple functions/commands and verify if they are invoked after moving from step `A` to `B`.

