### PR TITLE
feat(extension): added 'extensionManager' to 'onModeEnter' parameter list

### DIFF
--- a/platform/core/src/extensions/ExtensionManager.ts
+++ b/platform/core/src/extensions/ExtensionManager.ts
@@ -175,6 +175,7 @@ export default class ExtensionManager extends PubSubService {
           servicesManager: _servicesManager,
           commandsManager: _commandsManager,
           hotkeysManager: _hotkeysManager,
+          extensionManager: this,
         });
       }
     });


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

OHIF's managers (`servicesManager`, `commandsManager`, `hotkeysManager` and `extensionManager`) need to be passed down the function call tree which can result in a considerable amount of refactoring when we need some of them in a function called at +4th level (all functions up in the call tree need to be updated until we reach one that receives desired manager as parameter). 

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

Added `extensionManager` along all other managers to `extension.onModeEnter`. In that way it is possible to create a extension context when `onModeEnter` is called and all managers can be stored into it. If a method at any level needs to have access to one or more managers there is no need to change the functions up in the call tree and we can solve the problem adding a single line of code:

```javascript
import context from '../context';
```

