### PR TITLE
fix(defaultRouteInit): fixes 'madeInClient' parameter when 'makeDisplaySets' is called

### DIFF
--- a/platform/app/src/routes/Mode/defaultRouteInit.ts
+++ b/platform/app/src/routes/Mode/defaultRouteInit.ts
@@ -71,7 +71,7 @@ export async function defaultRouteInit(
         });
       }
 
-      displaySetService.makeDisplaySets(seriesMetadata.instances, madeInClient);
+      displaySetService.makeDisplaySets(seriesMetadata.instances, { madeInClient });
     }
   );
 


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

The second `displaySetService.makeDisplaySets(...)` is an object ("options") but `defaultRouteInit` is passing `madeInClient` as a boolean making the new dynamic displaySets created without the `madeInClient` property as expected.

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

Fixed the way `displaySetService.makeDisplaySets` passing `{ madeInClient }` instead of a boolean value.