### PR TITLE
[OHI-1483] fix(tag-browser): fix dicom tag browser not loading in segmentation mode in study panel

### DIFF
--- a/extensions/default/src/Panels/WrappedPanelStudyBrowser.tsx
+++ b/extensions/default/src/Panels/WrappedPanelStudyBrowser.tsx
@@ -30,6 +30,7 @@ function WrappedPanelStudyBrowser({ commandsManager, extensionManager, servicesM
   return (
     <PanelStudyBrowser
       servicesManager={servicesManager}
+      commandsManager={commandsManager}
       dataSource={dataSource}
       getImageSrc={_getImageSrcFromImageId}
       getStudiesForPatientByMRN={_getStudiesForPatientByMRN}


### PR DESCRIPTION
### Context

DICOM Tag Brower was not working in segmentation mode. The issue was that the commandsManager was not passed to the panel. This is now resolved.

Fixes https://github.com/OHIF/Viewers/issues/4595