### PR TITLE
[OHI-833] fix(datasource): attach auth headers for delete requests in the dicomweb datasource

### DIFF
--- a/extensions/default/src/DicomWebDataSource/dcm4cheeReject.js
+++ b/extensions/default/src/DicomWebDataSource/dcm4cheeReject.js
@@ -1,4 +1,4 @@
-export default function (wadoRoot) {
+export default function (wadoRoot, getAuthrorizationHeader) {
   return {
     series: (StudyInstanceUID, SeriesInstanceUID) => {
       return new Promise((resolve, reject) => {
@@ -9,6 +9,12 @@ export default function (wadoRoot) {
 
         const xhr = new XMLHttpRequest();
         xhr.open('POST', url, true);
+
+        const headers = getAuthrorizationHeader();
+
+        for (const key in headers) {
+          xhr.setRequestHeader(key, headers[key]);
+        }
 
         //Send the proper header information along with the request
         // TODO -> Auth when we re-add authorization.

--- a/extensions/default/src/DicomWebDataSource/index.ts
+++ b/extensions/default/src/DicomWebDataSource/index.ts
@@ -598,7 +598,7 @@ function createDicomWebApi(dicomWebConfig: DicomWebConfig, servicesManager) {
   };
 
   if (dicomWebConfig.supportsReject) {
-    implementation.reject = dcm4cheeReject(dicomWebConfig.wadoRoot);
+    implementation.reject = dcm4cheeReject(dicomWebConfig.wadoRoot, getAuthrorizationHeader);
   }
 
   return IWebApiDataSource.create(implementation);


### PR DESCRIPTION
### Context

The headers for the userAuthenticationService were not being attached if `dataSource.reject` is called. This has now been fixed.