### PR TITLE
fix(3D rendering): disabled light sliders when shade is off

### DIFF
--- a/extensions/cornerstone/src/components/WindowLevelActionMenu/VolumeLighting.tsx
+++ b/extensions/cornerstone/src/components/WindowLevelActionMenu/VolumeLighting.tsx
@@ -5,7 +5,7 @@ export function VolumeLighting({
   servicesManager,
   commandsManager,
   viewportId,
-  isShadeToggled,
+  hasShade,
 }: VolumeLightingProps): ReactElement {
   const { cornerstoneViewportService } = servicesManager.services;
   const [ambient, setAmbient] = useState(null);
@@ -39,8 +39,8 @@ export function VolumeLighting({
     setDiffuse(diffuse);
     setSpecular(specular);
   }, [viewportId, cornerstoneViewportService]);
-  const disableOption = isShadeToggled ? '' : 'ohif-disabled !opacity-40';
-  const disableSlider = !isShadeToggled;
+  const disableOption = hasShade ? '' : 'ohif-disabled !opacity-40';
+  const disableSlider = !hasShade;
   return (
     <>
       <div

--- a/extensions/cornerstone/src/components/WindowLevelActionMenu/VolumeLighting.tsx
+++ b/extensions/cornerstone/src/components/WindowLevelActionMenu/VolumeLighting.tsx
@@ -5,6 +5,7 @@ export function VolumeLighting({
   servicesManager,
   commandsManager,
   viewportId,
+  isShadeToggled,
 }: VolumeLightingProps): ReactElement {
   const { cornerstoneViewportService } = servicesManager.services;
   const [ambient, setAmbient] = useState(null);
@@ -38,11 +39,15 @@ export function VolumeLighting({
     setDiffuse(diffuse);
     setSpecular(specular);
   }, [viewportId, cornerstoneViewportService]);
+  const disableOption = isShadeToggled ? '' : 'ohif-disabled !opacity-40';
+  const disableSlider = !isShadeToggled;
   return (
     <>
-      <div className="all-in-one-menu-item flex  w-full flex-row !items-center justify-between gap-[10px]">
+      <div
+        className={`all-in-one-menu-item flex w-full flex-row !items-center justify-between gap-[10px] ${disableOption}`}
+      >
         <label
-          className="block  text-white"
+          className="block text-white"
           htmlFor="ambient"
         >
           Ambient
@@ -56,6 +61,7 @@ export function VolumeLighting({
               onAmbientChange();
             }}
             id="ambient"
+            disabled={disableSlider}
             max={1}
             min={0}
             type="range"
@@ -68,9 +74,11 @@ export function VolumeLighting({
           />
         )}
       </div>
-      <div className="all-in-one-menu-item flex  w-full flex-row !items-center justify-between gap-[10px]">
+      <div
+        className={`all-in-one-menu-item flex w-full flex-row !items-center justify-between gap-[10px] ${disableOption}`}
+      >
         <label
-          className="block  text-white"
+          className="block text-white"
           htmlFor="diffuse"
         >
           Diffuse
@@ -83,6 +91,7 @@ export function VolumeLighting({
               setDiffuse(e.target.value);
               onDiffuseChange();
             }}
+            disabled={disableSlider}
             id="diffuse"
             max={1}
             min={0}
@@ -97,9 +106,11 @@ export function VolumeLighting({
         )}
       </div>
 
-      <div className="all-in-one-menu-item flex  w-full flex-row !items-center justify-between gap-[10px]">
+      <div
+        className={`all-in-one-menu-item flex w-full flex-row !items-center justify-between gap-[10px] ${disableOption}`}
+      >
         <label
-          className="block  text-white"
+          className="block text-white"
           htmlFor="specular"
         >
           Specular
@@ -108,6 +119,7 @@ export function VolumeLighting({
           <input
             className="bg-inputfield-main h-2 w-[120px] cursor-pointer appearance-none rounded-lg"
             value={specular}
+            disabled={disableSlider}
             onChange={e => {
               setSpecular(e.target.value);
               onSpecularChange();

--- a/extensions/cornerstone/src/components/WindowLevelActionMenu/VolumeRenderingOptions.tsx
+++ b/extensions/cornerstone/src/components/WindowLevelActionMenu/VolumeRenderingOptions.tsx
@@ -11,7 +11,7 @@ export function VolumeRenderingOptions({
   volumeRenderingQualityRange,
   servicesManager,
 }: VolumeRenderingOptionsProps): ReactElement {
-  const [isShadeToggled, setShadeToggled] = useState(false);
+  const [hasShade, setShade] = useState(false);
   return (
     <AllInOneMenu.ItemPanel>
       <VolumeRenderingQuality
@@ -35,14 +35,14 @@ export function VolumeRenderingOptions({
           commandsManager={commandsManager}
           servicesManager={servicesManager}
           viewportId={viewportId}
-          onClickShade={setShadeToggled}
+          onClickShade={setShade}
         />
       </div>
       <VolumeLighting
         viewportId={viewportId}
         commandsManager={commandsManager}
         servicesManager={servicesManager}
-        isShadeToggled={isShadeToggled}
+        hasShade={hasShade}
       />
     </AllInOneMenu.ItemPanel>
   );

--- a/extensions/cornerstone/src/components/WindowLevelActionMenu/VolumeRenderingOptions.tsx
+++ b/extensions/cornerstone/src/components/WindowLevelActionMenu/VolumeRenderingOptions.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useState } from 'react';
 import { AllInOneMenu } from '@ohif/ui';
 import { VolumeRenderingOptionsProps } from '../../types/ViewportPresets';
 import { VolumeRenderingQuality } from './VolumeRenderingQuality';
@@ -11,6 +11,7 @@ export function VolumeRenderingOptions({
   volumeRenderingQualityRange,
   servicesManager,
 }: VolumeRenderingOptionsProps): ReactElement {
+  const [isShadeToggled, setShadeToggled] = useState(false);
   return (
     <AllInOneMenu.ItemPanel>
       <VolumeRenderingQuality
@@ -34,12 +35,14 @@ export function VolumeRenderingOptions({
           commandsManager={commandsManager}
           servicesManager={servicesManager}
           viewportId={viewportId}
+          onClickShade={setShadeToggled}
         />
       </div>
       <VolumeLighting
         viewportId={viewportId}
         commandsManager={commandsManager}
         servicesManager={servicesManager}
+        isShadeToggled={isShadeToggled}
       />
     </AllInOneMenu.ItemPanel>
   );

--- a/extensions/cornerstone/src/components/WindowLevelActionMenu/VolumeShade.tsx
+++ b/extensions/cornerstone/src/components/WindowLevelActionMenu/VolumeShade.tsx
@@ -6,6 +6,7 @@ export function VolumeShade({
   commandsManager,
   viewportId,
   servicesManager,
+  onClickShade = bool => {},
 }: VolumeShadeProps): ReactElement {
   const { cornerstoneViewportService } = servicesManager.services;
   const [shade, setShade] = useState(true);
@@ -22,6 +23,7 @@ export function VolumeShade({
     const { actor } = viewport.getActors()[0];
     const shade = actor.getProperty().getShade();
     setShade(shade);
+    onClickShade(shade);
     setKey(key + 1);
   }, [viewportId, cornerstoneViewportService]);
 
@@ -32,6 +34,7 @@ export function VolumeShade({
       checked={shade}
       onChange={() => {
         setShade(!shade);
+        onClickShade(!shade);
         onShadeChange(!shade);
       }}
     />

--- a/extensions/cornerstone/src/types/ViewportPresets.ts
+++ b/extensions/cornerstone/src/types/ViewportPresets.ts
@@ -64,5 +64,5 @@ export type VolumeLightingProps = {
   viewportId: string;
   commandsManager: CommandsManager;
   servicesManager: AppTypes.ServicesManager;
-  isShadeToggled: boolean;
+  hasShade: boolean;
 };

--- a/extensions/cornerstone/src/types/ViewportPresets.ts
+++ b/extensions/cornerstone/src/types/ViewportPresets.ts
@@ -57,10 +57,12 @@ export type VolumeShadeProps = {
   viewportId: string;
   commandsManager: CommandsManager;
   servicesManager: AppTypes.ServicesManager;
+  onClickShade?: (bool: boolean) => void;
 };
 
 export type VolumeLightingProps = {
   viewportId: string;
   commandsManager: CommandsManager;
   servicesManager: AppTypes.ServicesManager;
+  isShadeToggled: boolean;
 };


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

Implemented disabling of light sliders when the shade option is turned off in 3D rendering mode. 
This PR has been incorporated by [FlyWheel.io](https://flywheel.io/).
Close https://github.com/OHIF/Viewers/issues/4629

### Changes & Results

A new state was added to manage the toggled status of the shade in VolumeRenderingOptions. Based on this value, I applied a disabled property to the input sliders and added the corresponding disabled CSS classes to indicate that they were inactive. With this update, the sliders will be disabled when the shade is turned off.


https://github.com/user-attachments/assets/ab0be4b0-1ab5-4e5b-8c0e-0b6f1494f815



### Testing

1. Launch a study in 3D layout.
2. Select the Window Level Action menu.
3. Select Rendering Options.
4. Turn off the Shade toggle switch.
5. Observe the sliders.
6. The sliders are in a disabled state now

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] OS: Windows 10 <!--[e.g. Windows 10, macOS 10.15.4]-->
- [x] Node version: 18.19.0 <!--[e.g. 18.16.1]-->
- [x] Browser: Chrome v131.0.6778.205
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
