### PR TITLE
Feat/customization option for viewport notification

### DIFF
--- a/extensions/cornerstone-dicom-rt/src/utils/promptHydrateRT.ts
+++ b/extensions/cornerstone-dicom-rt/src/utils/promptHydrateRT.ts
@@ -39,7 +39,7 @@ function promptHydrateRT({
 
 function _askHydrate(uiViewportDialogService: AppTypes.UIViewportDialogService, viewportId) {
   return new Promise(function (resolve, reject) {
-    const message = 'Do you want to open this Segmentation?';
+    const content = 'Do you want to open this Segmentation?';
     const actions = [
       {
         id: 'no-hydrate',
@@ -63,7 +63,7 @@ function _askHydrate(uiViewportDialogService: AppTypes.UIViewportDialogService, 
       id: 'promptHydrateRT',
       viewportId,
       type: 'info',
-      message,
+      content,
       actions,
       onSubmit,
       onOutsideClick: () => {

--- a/extensions/cornerstone-dicom-seg/src/utils/promptHydrateSEG.ts
+++ b/extensions/cornerstone-dicom-seg/src/utils/promptHydrateSEG.ts
@@ -41,7 +41,7 @@ function promptHydrateSEG({
 
 function _askHydrate(uiViewportDialogService, viewportId) {
   return new Promise(function (resolve, reject) {
-    const message = 'Do you want to open this Segmentation?';
+    const content = 'Do you want to open this Segmentation?';
     const actions = [
       {
         id: 'no-hydrate',
@@ -64,7 +64,7 @@ function _askHydrate(uiViewportDialogService, viewportId) {
     uiViewportDialogService.show({
       viewportId,
       type: 'info',
-      message,
+      content,
       actions,
       onSubmit,
       onOutsideClick: () => {

--- a/extensions/cornerstone/src/Viewport/OHIFCornerstoneViewport.tsx
+++ b/extensions/cornerstone/src/Viewport/OHIFCornerstoneViewport.tsx
@@ -99,6 +99,7 @@ const OHIFCornerstoneViewport = React.memo(
       segmentationService,
       cornerstoneCacheService,
       viewportActionCornersService,
+      customizationService,
     } = servicesManager.services;
 
     const [viewportDialogState] = useViewportDialog();
@@ -372,7 +373,11 @@ const OHIFCornerstoneViewport = React.memo(
     const { ref: resizeRef } = useResizeDetector({
       onResize,
     });
-
+    const customNotificationComponent =
+      customizationService.get('notificationComponent')?.component;
+    const NotificationComponent = customNotificationComponent
+      ? customNotificationComponent
+      : Notification;
     return (
       <React.Fragment>
         <div className="viewport-wrapper">
@@ -406,9 +411,9 @@ const OHIFCornerstoneViewport = React.memo(
         {/* top offset of 24px to account for ViewportActionCorners. */}
         <div className="absolute top-[24px] w-full">
           {viewportDialogState.viewportId === viewportId && (
-            <Notification
+            <NotificationComponent
               id="viewport-notification"
-              message={viewportDialogState.message}
+              content={viewportDialogState.content}
               type={viewportDialogState.type}
               actions={viewportDialogState.actions}
               onSubmit={viewportDialogState.onSubmit}

--- a/extensions/cornerstone/src/Viewport/OHIFCornerstoneViewport.tsx
+++ b/extensions/cornerstone/src/Viewport/OHIFCornerstoneViewport.tsx
@@ -373,11 +373,12 @@ const OHIFCornerstoneViewport = React.memo(
     const { ref: resizeRef } = useResizeDetector({
       onResize,
     });
-    const customNotificationComponent =
-      customizationService.get('notificationComponent')?.component;
+
+    const customNotificationComponent = customizationService.get('notificationComponent')?.content;
     const NotificationComponent = customNotificationComponent
       ? customNotificationComponent
       : Notification;
+
     return (
       <React.Fragment>
         <div className="viewport-wrapper">

--- a/extensions/measurement-tracking/src/contexts/TrackedMeasurementsContext/promptBeginTracking.js
+++ b/extensions/measurement-tracking/src/contexts/TrackedMeasurementsContext/promptBeginTracking.js
@@ -32,7 +32,7 @@ function promptBeginTracking({ servicesManager, extensionManager }, ctx, evt) {
 
 function _askTrackMeasurements(uiViewportDialogService, viewportId) {
   return new Promise(function (resolve, reject) {
-    const message = i18n.t('MeasurementTable:Track measurements for this series?');
+    const content = i18n.t('MeasurementTable:Track measurements for this series?');
     const actions = [
       {
         id: 'prompt-begin-tracking-cancel',
@@ -62,7 +62,7 @@ function _askTrackMeasurements(uiViewportDialogService, viewportId) {
       viewportId,
       id: 'measurement-tracking-prompt-begin-tracking',
       type: 'info',
-      message,
+      content,
       actions,
       onSubmit,
       onOutsideClick: () => {

--- a/extensions/measurement-tracking/src/contexts/TrackedMeasurementsContext/promptHydrateStructuredReport.js
+++ b/extensions/measurement-tracking/src/contexts/TrackedMeasurementsContext/promptHydrateStructuredReport.js
@@ -47,7 +47,7 @@ function promptHydrateStructuredReport({ servicesManager, extensionManager, appC
 
 function _askTrackMeasurements(uiViewportDialogService, viewportId) {
   return new Promise(function (resolve, reject) {
-    const message = 'Do you want to continue tracking measurements for this study?';
+    const content = 'Do you want to continue tracking measurements for this study?';
     const actions = [
       {
         id: 'no-hydrate',
@@ -70,7 +70,7 @@ function _askTrackMeasurements(uiViewportDialogService, viewportId) {
     uiViewportDialogService.show({
       viewportId,
       type: 'info',
-      message,
+      content,
       actions,
       onSubmit,
       onOutsideClick: () => {

--- a/extensions/measurement-tracking/src/contexts/TrackedMeasurementsContext/promptTrackNewSeries.js
+++ b/extensions/measurement-tracking/src/contexts/TrackedMeasurementsContext/promptTrackNewSeries.js
@@ -36,7 +36,7 @@ function promptTrackNewSeries({ servicesManager, extensionManager }, ctx, evt) {
 
 function _askShouldAddMeasurements(uiViewportDialogService, viewportId) {
   return new Promise(function (resolve, reject) {
-    const message = 'Do you want to add this measurement to the existing report?';
+    const content = 'Do you want to add this measurement to the existing report?';
     const actions = [
       {
         type: ButtonEnums.type.secondary,
@@ -62,7 +62,7 @@ function _askShouldAddMeasurements(uiViewportDialogService, viewportId) {
     uiViewportDialogService.show({
       viewportId,
       type: 'info',
-      message,
+      content,
       actions,
       onSubmit,
       onOutsideClick: () => {
@@ -75,7 +75,7 @@ function _askShouldAddMeasurements(uiViewportDialogService, viewportId) {
 
 function _askSaveDiscardOrCancel(UIViewportDialogService, viewportId) {
   return new Promise(function (resolve, reject) {
-    const message =
+    const content =
       'You have existing tracked measurements. What would you like to do with your existing tracked measurements?';
     const actions = [
       { type: 'cancel', text: 'Cancel', value: RESPONSE.CANCEL },
@@ -98,7 +98,7 @@ function _askSaveDiscardOrCancel(UIViewportDialogService, viewportId) {
     UIViewportDialogService.show({
       viewportId,
       type: 'warning',
-      message,
+      content,
       actions,
       onSubmit,
       onOutsideClick: () => {

--- a/extensions/measurement-tracking/src/contexts/TrackedMeasurementsContext/promptTrackNewStudy.ts
+++ b/extensions/measurement-tracking/src/contexts/TrackedMeasurementsContext/promptTrackNewStudy.ts
@@ -39,7 +39,7 @@ function _askTrackMeasurements(
   viewportId
 ) {
   return new Promise(function (resolve, reject) {
-    const message = i18n.t('MeasurementTable:Track measurements for this series?');
+    const content = i18n.t('MeasurementTable:Track measurements for this series?');
     const actions = [
       { type: 'cancel', text: i18n.t('MeasurementTable:No'), value: RESPONSE.CANCEL },
       {
@@ -61,7 +61,7 @@ function _askTrackMeasurements(
     UIViewportDialogService.show({
       viewportId,
       type: 'info',
-      message,
+      content,
       actions,
       onSubmit,
       onOutsideClick: () => {
@@ -83,7 +83,7 @@ function _askSaveDiscardOrCancel(
   viewportId
 ) {
   return new Promise(function (resolve, reject) {
-    const message =
+    const content =
       'Measurements cannot span across multiple studies. Do you want to save your tracked measurements?';
     const actions = [
       { type: 'cancel', text: 'Cancel', value: RESPONSE.CANCEL },
@@ -106,7 +106,7 @@ function _askSaveDiscardOrCancel(
     UIViewportDialogService.show({
       viewportId,
       type: 'warning',
-      message,
+      content,
       actions,
       onSubmit,
       onOutsideClick: () => {

--- a/platform/core/src/services/UIViewportDialogService/UIViewportDialogService.ts
+++ b/platform/core/src/services/UIViewportDialogService/UIViewportDialogService.ts
@@ -22,12 +22,12 @@ class UIViewportDialogService extends PubSubService {
     };
   }
 
-  public show({ viewportId, id, type, message, actions, onSubmit, onOutsideClick, onKeyPress }) {
+  public show({ viewportId, id, type, content, actions, onSubmit, onOutsideClick, onKeyPress }) {
     return this.serviceImplementation._show({
       viewportId,
       id,
       type,
-      message,
+      content,
       actions,
       onSubmit,
       onOutsideClick,

--- a/platform/ui/src/components/Notification/Notification.tsx
+++ b/platform/ui/src/components/Notification/Notification.tsx
@@ -8,7 +8,7 @@ import { Icons } from '@ohif/ui-next';
 const Notification = ({
   id,
   type = 'info',
-  message,
+  content,
   actions,
   onSubmit,
   onOutsideClick = () => {},
@@ -84,7 +84,7 @@ const Notification = ({
           name={icon}
           className={classnames('h-6 w-6', color)}
         />
-        <span className="ml-2 text-[13px] text-black">{message}</span>
+        <span className="ml-2 text-[13px] text-black">{content}</span>
       </div>
       <div className="mt-2 flex flex-wrap justify-end gap-2">
         {actions?.map((action, index) => {
@@ -109,7 +109,7 @@ const Notification = ({
 
 Notification.propTypes = {
   type: PropTypes.oneOf(['error', 'warning', 'info', 'success']),
-  message: PropTypes.string.isRequired,
+  message: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
   actions: PropTypes.arrayOf(
     PropTypes.shape({
       text: PropTypes.string.isRequired,


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context
<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->
An option has been implemented to allow for the customization of the viewport notification component. This enhancement enables users to tailor viewport notifications, thereby introducing a new component that improves user-friendliness.
![image](https://github.com/user-attachments/assets/8542c3d5-ccf1-4919-b217-29fa1a077b58)

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->
Introduced a provision for displaying customized viewport notifications.
### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] OS: <!--[e.g. Windows 10, macOS 10.15.4]--> Windows 10 with WSL.2
- [x] Node version: <!--[e.g. 18.16.1]-->  v18.20.4
- [x] Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]--> Chrome 120.0.6099.71

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
