### PR TITLE
[OHI-1538] fix(icons): icons missing for volume presets and others

### DIFF
--- a/extensions/cornerstone/src/components/WindowLevelActionMenu/VolumeRenderingPresetsContent.tsx
+++ b/extensions/cornerstone/src/components/WindowLevelActionMenu/VolumeRenderingPresetsContent.tsx
@@ -62,7 +62,7 @@ export function VolumeRenderingPresetsContent({
                 }}
               >
                 <Icons.ByName
-                  name={preset.name}
+                  name={preset.name.replace(/-/g, '')}
                   className={
                     selectedPreset?.name === preset.name
                       ? 'border-primary-light h-[75px] w-[95px] max-w-none rounded border-2'

--- a/extensions/cornerstone/src/components/WindowLevelActionMenu/VolumeRenderingPresetsContent.tsx
+++ b/extensions/cornerstone/src/components/WindowLevelActionMenu/VolumeRenderingPresetsContent.tsx
@@ -62,7 +62,7 @@ export function VolumeRenderingPresetsContent({
                 }}
               >
                 <Icons.ByName
-                  name={preset.name.replace(/-/g, '')}
+                  name={preset.name}
                   className={
                     selectedPreset?.name === preset.name
                       ? 'border-primary-light h-[75px] w-[95px] max-w-none rounded border-2'

--- a/platform/ui-next/src/components/Icons/Icons.tsx
+++ b/platform/ui-next/src/components/Icons/Icons.tsx
@@ -201,157 +201,157 @@ const ImageWrapper = ({ src, ...props }: { src: string } & ImageIconProps) => {
 };
 
 export const Icons = {
-  CTAAA: (props: ImageIconProps) => (
+  'CT-AAA': (props: ImageIconProps) => (
     <ImageWrapper
       src={CTAAA}
       {...props}
     />
   ),
-  CTAAA2: (props: ImageIconProps) => (
+  'CT-AAA2': (props: ImageIconProps) => (
     <ImageWrapper
       src={CTAAA2}
       {...props}
     />
   ),
-  CTAir: (props: ImageIconProps) => (
+  'CT-Air': (props: ImageIconProps) => (
     <ImageWrapper
       src={CTAir}
       {...props}
     />
   ),
-  CTBone: (props: ImageIconProps) => (
+  'CT-Bone': (props: ImageIconProps) => (
     <ImageWrapper
       src={CTBone}
       {...props}
     />
   ),
-  CTBones: (props: ImageIconProps) => (
+  'CT-Bones': (props: ImageIconProps) => (
     <ImageWrapper
       src={CTBones}
       {...props}
     />
   ),
-  CTCardiac: (props: ImageIconProps) => (
+  'CT-Cardiac': (props: ImageIconProps) => (
     <ImageWrapper
       src={CTCardiac}
       {...props}
     />
   ),
-  CTCardiac2: (props: ImageIconProps) => (
+  'CT-Cardiac2': (props: ImageIconProps) => (
     <ImageWrapper
       src={CTCardiac2}
       {...props}
     />
   ),
-  CTCardiac3: (props: ImageIconProps) => (
+  'CT-Cardiac3': (props: ImageIconProps) => (
     <ImageWrapper
       src={CTCardiac3}
       {...props}
     />
   ),
-  CTChestContrastEnhanced: (props: ImageIconProps) => (
+  'CT-Chest-Contrast-Enhanced': (props: ImageIconProps) => (
     <ImageWrapper
       src={CTChestContrastEnhanced}
       {...props}
     />
   ),
-  CTChestVessels: (props: ImageIconProps) => (
+  'CT-Chest-Vessels': (props: ImageIconProps) => (
     <ImageWrapper
       src={CTChestVessels}
       {...props}
     />
   ),
-  CTCoronaryArteries: (props: ImageIconProps) => (
+  'CT-Coronary-Arteries': (props: ImageIconProps) => (
     <ImageWrapper
       src={CTCoronaryArteries}
       {...props}
     />
   ),
-  CTCoronaryArteries2: (props: ImageIconProps) => (
+  'CT-Coronary-Arteries-2': (props: ImageIconProps) => (
     <ImageWrapper
       src={CTCoronaryArteries2}
       {...props}
     />
   ),
-  CTCoronaryArteries3: (props: ImageIconProps) => (
+  'CT-Coronary-Arteries-3': (props: ImageIconProps) => (
     <ImageWrapper
       src={CTCoronaryArteries3}
       {...props}
     />
   ),
-  CTCroppedVolumeBone: (props: ImageIconProps) => (
+  'CT-Cropped-Volume-Bone': (props: ImageIconProps) => (
     <ImageWrapper
       src={CTCroppedVolumeBone}
       {...props}
     />
   ),
-  CTFat: (props: ImageIconProps) => (
+  'CT-Fat': (props: ImageIconProps) => (
     <ImageWrapper
       src={CTFat}
       {...props}
     />
   ),
-  CTLiverVasculature: (props: ImageIconProps) => (
+  'CT-Liver-Vasculature': (props: ImageIconProps) => (
     <ImageWrapper
       src={CTLiverVasculature}
       {...props}
     />
   ),
-  CTLung: (props: ImageIconProps) => (
+  'CT-Lung': (props: ImageIconProps) => (
     <ImageWrapper
       src={CTLung}
       {...props}
     />
   ),
-  CTMIP: (props: ImageIconProps) => (
+  'CT-MIP': (props: ImageIconProps) => (
     <ImageWrapper
       src={CTMIP}
       {...props}
     />
   ),
-  CTMuscle: (props: ImageIconProps) => (
+  'CT-Muscle': (props: ImageIconProps) => (
     <ImageWrapper
       src={CTMuscle}
       {...props}
     />
   ),
-  CTPulmonaryArteries: (props: ImageIconProps) => (
+  'CT-Pulmonary-Arteries': (props: ImageIconProps) => (
     <ImageWrapper
       src={CTPulmonaryArteries}
       {...props}
     />
   ),
-  CTSoftTissue: (props: ImageIconProps) => (
+  'CT-Soft-Tissue': (props: ImageIconProps) => (
     <ImageWrapper
       src={CTSoftTissue}
       {...props}
     />
   ),
-  DTIFABrain: (props: ImageIconProps) => (
+  'DTI-FA-Brain': (props: ImageIconProps) => (
     <ImageWrapper
       src={DTIFABrain}
       {...props}
     />
   ),
-  MRAngio: (props: ImageIconProps) => (
+  'MR-Angio': (props: ImageIconProps) => (
     <ImageWrapper
       src={MRAngio}
       {...props}
     />
   ),
-  MRDefault: (props: ImageIconProps) => (
+  'MR-Default': (props: ImageIconProps) => (
     <ImageWrapper
       src={MRDefault}
       {...props}
     />
   ),
-  MRMIP: (props: ImageIconProps) => (
+  'MR-MIP': (props: ImageIconProps) => (
     <ImageWrapper
       src={MRMIP}
       {...props}
     />
   ),
-  MRT2Brain: (props: ImageIconProps) => (
+  'MR-T2-Brain': (props: ImageIconProps) => (
     <ImageWrapper
       src={MRT2Brain}
       {...props}

--- a/platform/ui-next/src/components/Icons/Icons.tsx
+++ b/platform/ui-next/src/components/Icons/Icons.tsx
@@ -183,6 +183,7 @@ import Magnifier from './Sources/Magnifier';
 import LoadingOHIFMark from './Sources/LoadingOHIFMark';
 import ArrowLeftBold from './Sources/ArrowLeftBold';
 import Pencil from './Sources/Pencil';
+import NotificationWarning from './Sources/NotificationWarning';
 //
 //
 //
@@ -651,6 +652,7 @@ export const Icons = {
   'status-alert': (props: IconProps) => Alert(props),
   info: (props: IconProps) => Info(props),
   'notifications-info': (props: IconProps) => NotificationInfo(props),
+  'notificationwarning-diamond': (props: IconProps) => NotificationWarning(props),
   'content-prev': (props: IconProps) => ContentPrev(props),
   'content-next': (props: IconProps) => ContentNext(props),
   'icon-settings': (props: IconProps) => Settings(props),

--- a/platform/ui-next/src/components/Icons/Sources/NotificationWarning.tsx
+++ b/platform/ui-next/src/components/Icons/Sources/NotificationWarning.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import type { IconProps } from '../types';
+
+export const NotificationInfo = (props: IconProps) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="13"
+    height="13"
+    viewBox="0 0 13 13"
+    {...props}
+  >
+    <g
+      fill="none"
+      fillRule="evenodd"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path
+        fill="#F3DC43"
+        stroke="#F3DC43"
+        d="M1.217 5.076L5.54.751c.391-.39 1.024-.39 1.415 0l4.324 4.325c.391.39.391 1.024 0 1.414l-4.324 4.325c-.39.39-1.024.39-1.415 0L1.217 6.49c-.39-.39-.39-1.023 0-1.414z"
+        transform="translate(0 1)"
+      />
+      <g stroke="#000">
+        <path
+          strokeWidth="1.5"
+          d="M0.5 3L0.5 0"
+          transform="translate(0 1) translate(6 3)"
+        />
+        <path
+          d="M0.5 4.5L0.5 4.5"
+          transform="translate(0 1) translate(6 3)"
+        />
+        <path
+          strokeWidth="1.5"
+          d="M.489 5.25c-.065.002-.127.03-.172.078-.044.048-.068.112-.065.177.005.135.115.243.25.245h.009c.065-.002.127-.03.171-.078.045-.048.068-.112.066-.177-.004-.134-.112-.241-.246-.245"
+          transform="translate(0 1) translate(6 3)"
+        />
+      </g>
+    </g>
+  </svg>
+);
+
+export default NotificationInfo;


### PR DESCRIPTION
### Context

Fixes some icons that were not being display due to small name differences, or just being missing after the migration.

![CleanShot 2025-01-09 at 23 52 04@2x](https://github.com/user-attachments/assets/0017fd10-61dd-47ec-bd13-06749167b44e)

![CleanShot 2025-01-09 at 23 52 34@2x](https://github.com/user-attachments/assets/097fd9db-d7d0-4300-8e4e-707ac541836a)


Closes #4652
Closes OHI-1538