### PR TITLE
[OHI-1547] fix(docker): run compression regardless of APP_CONFIG being present ( in cases such as volume mount)

### DIFF
--- a/.docker/Viewer-v3.x/entrypoint.sh
+++ b/.docker/Viewer-v3.x/entrypoint.sh
@@ -7,19 +7,25 @@ if [ -n "$SSL_PORT" ]
     envsubst '${PORT}' < /usr/src/default.conf.template > /etc/nginx/conf.d/default.conf
 fi
 
-if [ -n "$APP_CONFIG" ] ; then
+
+if [ -n "$APP_CONFIG" ]; then
   echo "$APP_CONFIG" > /usr/share/nginx/html${PUBLIC_URL}app-config.js
-  # Removes the old compressed app-config file, then compresses the replacement
-  # and finally creates a new empty file so that gunzip works correctly.
-  # This code is correct despite the AI warning otherwise about order of create/delete
-  rm /usr/share/nginx/html${PUBLIC_URL}app-config.js.gz
+  echo "Using custom APP_CONFIG environment variable"
+else
+  echo "Not using custom APP_CONFIG"
+fi
+
+if [ -f /usr/share/nginx/html${PUBLIC_URL}app-config.js ]; then
+  echo "Detected app-config.js. Ensuring .gz file is updated..."
+  rm -f /usr/share/nginx/html${PUBLIC_URL}app-config.js.gz
   gzip /usr/share/nginx/html${PUBLIC_URL}app-config.js
   touch /usr/share/nginx/html${PUBLIC_URL}app-config.js
+  echo "Compressed app-config.js to app-config.js.gz"
+else
+  echo "No app-config.js file found. Skipping compression."
 fi
-if [ ! -n "$APP_CONFIG" ]
-  then
-    echo "Not using custom app config"
-fi
+
+
 
 if [ -n "$CLIENT_ID" ] || [ -n "$HEALTHCARE_API_ENDPOINT" ]
   then

--- a/.docker/Viewer-v3.x/entrypoint.sh
+++ b/.docker/Viewer-v3.x/entrypoint.sh
@@ -16,11 +16,15 @@ else
 fi
 
 if [ -f /usr/share/nginx/html${PUBLIC_URL}app-config.js ]; then
-  echo "Detected app-config.js. Ensuring .gz file is updated..."
-  rm -f /usr/share/nginx/html${PUBLIC_URL}app-config.js.gz
-  gzip /usr/share/nginx/html${PUBLIC_URL}app-config.js
-  touch /usr/share/nginx/html${PUBLIC_URL}app-config.js
-  echo "Compressed app-config.js to app-config.js.gz"
+  if [ -s /usr/share/nginx/html${PUBLIC_URL}app-config.js ]; then
+    echo "Detected non-empty app-config.js. Ensuring .gz file is updated..."
+    rm -f /usr/share/nginx/html${PUBLIC_URL}app-config.js.gz
+    gzip /usr/share/nginx/html${PUBLIC_URL}app-config.js
+    touch /usr/share/nginx/html${PUBLIC_URL}app-config.js
+    echo "Compressed app-config.js to app-config.js.gz"
+  else
+    echo "app-config.js is empty. Skipping compression."
+  fi
 else
   echo "No app-config.js file found. Skipping compression."
 fi


### PR DESCRIPTION
### Context

Docker compression step was not being triggered if APP_CONFIG is not present, but it should still do if a user mounts a file using volumes.

Fixes OHIF-1547
Closes #4669 