### PR TITLE
migration docs typo (3.8 -> 3.9, useViewportGridStore())

### DIFF
--- a/platform/docs/docs/migration-guide/3p8-to-3p9/5-StateSyncService.md
+++ b/platform/docs/docs/migration-guide/3p8-to-3p9/5-StateSyncService.md
@@ -142,7 +142,7 @@ stateSyncService.store({
 
 ```js
 import { useViewportGridStore } from '../stores/useViewportGridStore';
-const { viewportGridState, setViewportGridState } = useViewportGridStore().getState();
+const { viewportGridState, setViewportGridState } = useViewportGridStore.getState();
 const gridState = viewportGridState[storeId];
 // ...to update
 setViewportGridState(storeId, newGridState);

--- a/platform/docs/docs/migration-guide/3p8-to-3p9/5-StateSyncService.md
+++ b/platform/docs/docs/migration-guide/3p8-to-3p9/5-StateSyncService.md
@@ -142,7 +142,7 @@ stateSyncService.store({
 
 ```js
 import { useViewportGridStore } from '../stores/useViewportGridStore';
-const { viewportGridState, setViewportGridState } = useViewportGridStore();
+const { viewportGridState, setViewportGridState } = useViewportGridStore().getState();
 const gridState = viewportGridState[storeId];
 // ...to update
 setViewportGridState(storeId, newGridState);


### PR DESCRIPTION
[extensions/default/src/utils/reuseCachedLayouts.ts](https://github.com/OHIF/Viewers/blob/7a13c28eb3560466896bbf1c76fc178e02d96fee/extensions/default/src/utils/reuseCachedLayouts.ts#L31)

[extensions/default/src/commandsModule.ts](https://github.com/OHIF/Viewers/blob/7a13c28eb3560466896bbf1c76fc178e02d96fee/extensions/default/src/commandsModule.ts#L180)

I think .getState() is required for useViewportGridStore()