### PR TITLE
Fix - Make the DICOM SR be able to load 

### DIFF
--- a/platform/core/src/classes/MetadataProvider.ts
+++ b/platform/core/src/classes/MetadataProvider.ts
@@ -462,6 +462,12 @@ class MetadataProvider {
   }
 
   getUIDsFromImageID(imageId) {
+    const frameNumber = this.getFrameInformationFromURL(imageId) || '1';
+    // add &frame=number to imageId if it doesn't already exist.
+    if (!imageId.includes('&frame=')) {
+      imageId = imageId + '&frame=' + frameNumber;
+    }
+
     const cachedUIDs = this.imageUIDsByImageId.get(imageId);
     if (cachedUIDs) {
       return cachedUIDs;
@@ -499,12 +505,7 @@ class MetadataProvider {
       imageURI = imageIdToURI(imageId);
     }
 
-    // remove &frame=number from imageId
-    imageURI = imageURI.split('&frame=')[0];
-
     const uids = this.imageURIToUIDs.get(imageURI);
-    const frameNumber = this.getFrameInformationFromURL(imageId) || '1';
-
     if (uids && frameNumber !== undefined) {
       return { ...uids, frameNumber };
     }


### PR DESCRIPTION
### Context

- The DICOM SR file cannot be loaded in a viewport when loading data locally, as reported in [GitHub Issue #4630](https://github.com/OHIF/Viewers/issues/4630). The error message is shown: 
![Screenshot 2025-01-14 at 11 12 59 pm](https://github.com/user-attachments/assets/075c7b60-af60-4115-bcc5-79e057ed9c58)
- This issue occurs in both the master branch and version 3.9.2 but does not appear in version 3.9.1.
- This bug was introduced in [[PR #4554]](https://github.com/OHIF/Viewers/pull/4554)](https://github.com/OHIF/Viewers/pull/4554 ). In [[1]](https://github.com/OHIF/Viewers/pull/4554/files#diff-98e19434a8e95bc59cdfe90b374fe0d18edfa9b50d3cb84bbcf071941382e5cf ), the change is made to handle multi-frame images. As a result, instead of using the `imageId` as the key of the data mapping, the latest update uses `frameImageId` (imageId&Frame=##). It leads to the `metadataProvider.getUIDsFromImageID` being unable to get the image UID by the image ID without the frame number.

### Changes & Results

- In [[2]](https://github.com/OHIF/Viewers/pull/4685/files#diff-6b143612508a642eb2f3c52a3227be7f8d9cdd7784df1d48922fe46531ca6bf3 ), ensure that the imageId includes the frame number.

What are the effects of this change?
- The local DICOM SR file will now load correctly into the viewport.

### Testing
- run `yarn install`
- run `yarn run dev`
- open `localhost:3000/local`
- select a study with DICOM SR and load the data in the basic viewer
- double click the DICOM SR, the DICOM SR shall be able to be loaded in the viewport.

### Checklist

**PR**
- [x] My Pull Request title is descriptive, accurate and follows the semantic-release format and guidelines. 

**Code**
- [x] My code has been well-documented (function documentation, inline comments, etc.)

**Tested Environment**
- [ ] OS: 
- [ ] Node version:
- [ ] Browser:
