### PR TITLE
Fix for initialImageIndex mismatch issue for loading SR after disabling prompts

### DIFF
--- a/extensions/cornerstone/src/commandsModule.ts
+++ b/extensions/cornerstone/src/commandsModule.ts
@@ -124,7 +124,7 @@ function commandsModule({
         type,
       });
     },
-    updateStoredPositionPresentation: ({ viewportId, displaySetInstanceUID }) => {
+    updateStoredPositionPresentation: ({ viewportId, displaySetInstanceUID, measurement }) => {
       const presentations = cornerstoneViewportService.getPresentations(viewportId);
       const { positionPresentationStore, setPositionPresentation, getPositionPresentationId } =
         usePositionPresentationStore.getState();
@@ -136,10 +136,11 @@ function commandsModule({
       )?.[0];
 
       if (previousReferencedDisplaySetStoreKey) {
-        setPositionPresentation(
-          previousReferencedDisplaySetStoreKey,
-          presentations.positionPresentation
-        );
+        setPositionPresentation(previousReferencedDisplaySetStoreKey, {
+          viewReference: {
+            referencedImageId: measurement.referencedImageId,
+          },
+        });
 
         return;
       }

--- a/extensions/cornerstone/src/commandsModule.ts
+++ b/extensions/cornerstone/src/commandsModule.ts
@@ -124,7 +124,11 @@ function commandsModule({
         type,
       });
     },
-    updateStoredPositionPresentation: ({ viewportId, displaySetInstanceUID, measurement }) => {
+    updateStoredPositionPresentation: ({
+      viewportId,
+      displaySetInstanceUID,
+      referencedImageId,
+    }) => {
       const presentations = cornerstoneViewportService.getPresentations(viewportId);
       const { positionPresentationStore, setPositionPresentation, getPositionPresentationId } =
         usePositionPresentationStore.getState();
@@ -136,11 +140,18 @@ function commandsModule({
       )?.[0];
 
       if (previousReferencedDisplaySetStoreKey) {
-        setPositionPresentation(previousReferencedDisplaySetStoreKey, {
-          viewReference: {
-            referencedImageId: measurement.referencedImageId,
-          },
-        });
+        if (referencedImageId) {
+          setPositionPresentation(previousReferencedDisplaySetStoreKey, {
+            viewReference: {
+              referencedImageId,
+            },
+          });
+        } else {
+          setPositionPresentation(
+            previousReferencedDisplaySetStoreKey,
+            presentations.positionPresentation
+          );
+        }
 
         return;
       }

--- a/extensions/cornerstone/src/components/WindowLevelActionMenu/WindowLevelActionMenu.tsx
+++ b/extensions/cornerstone/src/components/WindowLevelActionMenu/WindowLevelActionMenu.tsx
@@ -51,7 +51,7 @@ export function WindowLevelActionMenu({
   const { colorbarService, cornerstoneViewportService } = servicesManager.services;
   const viewportInfo = cornerstoneViewportService.getViewportInfo(viewportId);
   const viewport = cornerstoneViewportService.getCornerstoneViewport(viewportId);
-  const backgroundColor = viewportInfo.getViewportOptions().background;
+  const backgroundColor = viewportInfo?.getViewportOptions().background;
   const isLight = backgroundColor ? utilities.isEqual(backgroundColor, [1, 1, 1]) : false;
 
   const { t } = useTranslation('WindowLevelActionMenu');

--- a/extensions/measurement-tracking/src/contexts/TrackedMeasurementsContext/TrackedMeasurementsContext.tsx
+++ b/extensions/measurement-tracking/src/contexts/TrackedMeasurementsContext/TrackedMeasurementsContext.tsx
@@ -99,9 +99,18 @@ function TrackedMeasurementsContextProvider(
         displaySetInstanceUID: referencedDisplaySetUID,
       });
 
+      const referencedDisplaySetImageIds =
+        displaySetService.getDisplaySetByUID(referencedDisplaySetUID)?.imageIds;
+      const imageIndex = referencedDisplaySetImageIds.indexOf(trackedMeasurement.referencedImageId);
+
       viewportGridService.setDisplaySetsForViewport({
         viewportId: activeViewportId,
         displaySetInstanceUIDs: [referencedDisplaySetUID],
+        viewportOptions: {
+          initialImageOptions: {
+            index: imageIndex,
+          },
+        },
       });
     },
     showStructuredReportDisplaySetInActiveViewport: (ctx, evt) => {

--- a/extensions/measurement-tracking/src/contexts/TrackedMeasurementsContext/TrackedMeasurementsContext.tsx
+++ b/extensions/measurement-tracking/src/contexts/TrackedMeasurementsContext/TrackedMeasurementsContext.tsx
@@ -97,7 +97,7 @@ function TrackedMeasurementsContextProvider(
       commandsManager.runCommand('updateStoredPositionPresentation', {
         viewportId: activeViewportId,
         displaySetInstanceUID: referencedDisplaySetUID,
-        measurement: trackedMeasurement,
+        referencedImageId: trackedMeasurement.referencedImageId,
       });
 
       viewportGridService.setDisplaySetsForViewport({

--- a/extensions/measurement-tracking/src/contexts/TrackedMeasurementsContext/TrackedMeasurementsContext.tsx
+++ b/extensions/measurement-tracking/src/contexts/TrackedMeasurementsContext/TrackedMeasurementsContext.tsx
@@ -97,20 +97,12 @@ function TrackedMeasurementsContextProvider(
       commandsManager.runCommand('updateStoredPositionPresentation', {
         viewportId: activeViewportId,
         displaySetInstanceUID: referencedDisplaySetUID,
+        measurement: trackedMeasurement,
       });
-
-      const referencedDisplaySetImageIds =
-        displaySetService.getDisplaySetByUID(referencedDisplaySetUID)?.imageIds;
-      const imageIndex = referencedDisplaySetImageIds.indexOf(trackedMeasurement.referencedImageId);
 
       viewportGridService.setDisplaySetsForViewport({
         viewportId: activeViewportId,
         displaySetInstanceUIDs: [referencedDisplaySetUID],
-        viewportOptions: {
-          initialImageOptions: {
-            index: imageIndex,
-          },
-        },
       });
     },
     showStructuredReportDisplaySetInActiveViewport: (ctx, evt) => {


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

- After disabling the prompts, the initial image calculation for the SR issue was fixed.
- This PR has been incorporated by [FlyWheel.io](https://flywheel.io/).
- Close https://github.com/OHIF/Viewers/issues/4731

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

- Added initial image options to the viewport options while setting the displaysets from trackedMeasurementsContext.tsx file in order to get the initailImageIndex to be loaded after loading an SR after disabling the prompts.
- Added a null checking in WindowlevelActionMenu inorder to prevent the error displayd while loading the SR after disabling the prompts.

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

Initial image is correctly loaded now after disabling the prompt and loading the SR.

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] OS: <!--[e.g. Windows 10, macOS 10.15.4]--> Windows 11
- [x] Node version: <!--[e.g. 18.16.1]-->18.19.0
- [x] Browser: Chrome 132.0.6834.110
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
