### PR TITLE
feat: Add support for Custom Modal component in Modal Service

### DIFF
--- a/platform/app/src/state/appConfig.tsx
+++ b/platform/app/src/state/appConfig.tsx
@@ -9,7 +9,7 @@ export const useAppConfig = () => useContext(appConfigContext);
 export function AppConfigProvider({ children, value: initAppConfig }) {
   const [appConfig, setAppConfig] = useState(initAppConfig);
 
-  return <Provider value={[appConfig]}>{children}</Provider>;
+  return <Provider value={[appConfig, setAppConfig]}>{children}</Provider>;
 }
 
 AppConfigProvider.propTypes = {

--- a/platform/core/src/services/UIModalService/index.ts
+++ b/platform/core/src/services/UIModalService/index.ts
@@ -60,8 +60,8 @@ class UIModalService {
       movable,
       containerDimensions,
       contentDimensions,
-      shouldCloseOnOverlayClick = true,
-      shouldCloseImmediately = false,
+      shouldCloseOnOverlayClick,
+      shouldCloseImmediately,
     });
   }
 

--- a/platform/core/src/services/UIModalService/index.ts
+++ b/platform/core/src/services/UIModalService/index.ts
@@ -16,6 +16,7 @@ const name = 'uiModalService';
 const serviceImplementation = {
   _hide: () => console.warn('hide() NOT IMPLEMENTED'),
   _show: () => console.warn('show() NOT IMPLEMENTED'),
+  _component: null,
 };
 
 class UIModalService {
@@ -45,6 +46,8 @@ class UIModalService {
     movable = false,
     containerDimensions = null,
     contentDimensions = null,
+    shouldCloseOnOverlayClick = true,
+    shouldCloseImmediately = false,
   }) {
     return serviceImplementation._show({
       content,
@@ -57,6 +60,8 @@ class UIModalService {
       movable,
       containerDimensions,
       contentDimensions,
+      shouldCloseOnOverlayClick = true,
+      shouldCloseImmediately = false,
     });
   }
 
@@ -70,6 +75,15 @@ class UIModalService {
   }
 
   /**
+   * This provides flexibility in customizing the Modal's default component
+   *
+   * @returns {React.Component}
+   */
+  component() {
+    return serviceImplementation._component;
+  }
+
+  /**
    *
    *
    * @param {*} {
@@ -77,12 +91,19 @@ class UIModalService {
    *   show: showImplementation,
    * }
    */
-  setServiceImplementation({ hide: hideImplementation, show: showImplementation }) {
+  setServiceImplementation({
+    hide: hideImplementation,
+    show: showImplementation,
+    component: componentImplementation,
+  }) {
     if (hideImplementation) {
       serviceImplementation._hide = hideImplementation;
     }
     if (showImplementation) {
       serviceImplementation._show = showImplementation;
+    }
+    if (componentImplementation) {
+      serviceImplementation._component = componentImplementation;
     }
   }
 }

--- a/platform/core/src/services/UIModalService/index.ts
+++ b/platform/core/src/services/UIModalService/index.ts
@@ -16,7 +16,7 @@ const name = 'uiModalService';
 const serviceImplementation = {
   _hide: () => console.warn('hide() NOT IMPLEMENTED'),
   _show: () => console.warn('show() NOT IMPLEMENTED'),
-  _component: null,
+  _customComponent: null,
 };
 
 class UIModalService {
@@ -79,8 +79,8 @@ class UIModalService {
    *
    * @returns {React.Component}
    */
-  component() {
-    return serviceImplementation._component;
+  getCustomComponent() {
+    return serviceImplementation._customComponent;
   }
 
   /**
@@ -94,7 +94,7 @@ class UIModalService {
   setServiceImplementation({
     hide: hideImplementation,
     show: showImplementation,
-    component: componentImplementation,
+    customComponent: customComponentImplementation,
   }) {
     if (hideImplementation) {
       serviceImplementation._hide = hideImplementation;
@@ -102,8 +102,8 @@ class UIModalService {
     if (showImplementation) {
       serviceImplementation._show = showImplementation;
     }
-    if (componentImplementation) {
-      serviceImplementation._component = componentImplementation;
+    if (customComponentImplementation) {
+      serviceImplementation._customComponent = customComponentImplementation;
     }
   }
 }

--- a/platform/docs/docs/platform/services/ui/ui-modal-service.md
+++ b/platform/docs/docs/platform/services/ui/ui-modal-service.md
@@ -29,6 +29,7 @@ is expected to support, [check out it's interface in `@ohif/core`][interface]
 | ---------- | ------------------------------------- |
 | `hide()`   | Hides the open modal                  |
 | `show()`   | Shows the provided content in a modal |
+| `customComponent()` | Overrides the default Modal component |
 
 ## Implementations
 

--- a/platform/docs/docs/platform/services/ui/ui-modal-service.md
+++ b/platform/docs/docs/platform/services/ui/ui-modal-service.md
@@ -36,6 +36,7 @@ is expected to support, [check out it's interface in `@ohif/core`][interface]
 | Implementation                     | Consumer  |
 | ---------------------------------- | --------- |
 | [Modal Provider][modal-provider]\* | Modal.jsx |
+| customComponent | setServiceImplementation({customComponent: Modal}) |
 
 `*` - Denotes maintained by OHIF
 

--- a/platform/docs/docs/platform/services/ui/ui-modal-service.md
+++ b/platform/docs/docs/platform/services/ui/ui-modal-service.md
@@ -15,6 +15,8 @@ be centered, and not draggable. They're commonly used when:
 If you're curious about the DOs and DON'Ts of dialogs and modals, check out this
 article: ["Best Practices for Modals / Overlays / Dialog Windows"][ux-article]
 
+customComponent: The modal service allows users to provide their own Modal UI using the customComponents.
+
 
 <div style={{padding:"56.25% 0 0 0", position:"relative"}}>
     <iframe src="https://player.vimeo.com/video/843233754?badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479"  frameBorder="0" allow="autoplay; fullscreen; picture-in-picture" allowFullScreen style= {{ position:"absolute",top:0,left:0,width:"100%",height:"100%"}} title="measurement-report"></iframe>
@@ -36,7 +38,7 @@ is expected to support, [check out it's interface in `@ohif/core`][interface]
 | Implementation                     | Consumer  |
 | ---------------------------------- | --------- |
 | [Modal Provider][modal-provider]\* | Modal.jsx |
-| customComponent | setServiceImplementation({customComponent: Modal}) |
+| customComponent | user extensions via setServiceImplementation({customComponent: Modal}) |
 
 `*` - Denotes maintained by OHIF
 

--- a/platform/ui/src/contextProviders/ModalProvider.tsx
+++ b/platform/ui/src/contextProviders/ModalProvider.tsx
@@ -39,6 +39,8 @@ const ModalProvider = ({ children, modal: Modal, service = null }) => {
 
   const [options, setOptions] = useState(DEFAULT_OPTIONS);
 
+  const CustomModal = service.component();
+
   /**
    * Show the modal and override its configuration props.
    *
@@ -81,10 +83,12 @@ const ModalProvider = ({ children, modal: Modal, service = null }) => {
     contentDimensions,
   } = options;
 
+  const ModalComp = CustomModal ? CustomModal : Modal;
+
   return (
     <Provider value={{ show, hide }}>
       {ModalContent && (
-        <Modal
+        <ModalComp
           className={classNames(customClassName, ModalContent.className)}
           shouldCloseOnEsc={shouldCloseOnEsc}
           isOpen={isOpen}
@@ -101,7 +105,7 @@ const ModalProvider = ({ children, modal: Modal, service = null }) => {
             show={show}
             hide={hide}
           />
-        </Modal>
+        </ModalComp>
       )}
       {children}
     </Provider>

--- a/platform/ui/src/contextProviders/ModalProvider.tsx
+++ b/platform/ui/src/contextProviders/ModalProvider.tsx
@@ -39,7 +39,7 @@ const ModalProvider = ({ children, modal: Modal, service = null }) => {
 
   const [options, setOptions] = useState(DEFAULT_OPTIONS);
 
-  const CustomModal = service.component();
+  const CustomModal = service.getCustomComponent();
 
   /**
    * Show the modal and override its configuration props.


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

- Added support for a custom Modal component in ModalProvider without modifying App.tsx.
- Exposed setAppConfig in the appConfig provider to allow adding custom configurations without modifying App.

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

- Implemented new logic in UIModalService and ModalProvider to support a custom Modal component without modifying App. If no custom component is provided, the default modal will be rendered. Users can set a custom component through the setServiceImplementation method.
```
 uiModalService.setServiceImplementation({
      component: Modal,
    });
```
- Exposed setAppConfig from the appConfig provider to allow adding custom configurations from the application without modifying App.tsx. 

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

**Modal**

- Create a new Modal component 
-  Set the new component using the setServiceImplementation method.
  ```
uiModalService.setServiceImplementation({
      component: Modal,
    });
```
- Trigger a Modal in the viewer. It will render with the newly provided component as the Modal. 

**Config**

- Set additional configurations from another area using the setAppConfig method from the useAppConfig hook.
- Observe the behavior in viewer: The newly provided configuration will be appended to the existing configuration.

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] OS: <!--[e.g. Windows 10, macOS 10.15.4]-->
- [x] Node version: <!--[e.g. 18.16.1]-->
- [x] Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
