### PR TITLE
[OHI-1445] fix(store-segmentation): storing segmentations was hitting the wrong command resulting in an undefined datasource

### DIFF
--- a/extensions/cornerstone/src/panels/PanelSegmentation.tsx
+++ b/extensions/cornerstone/src/panels/PanelSegmentation.tsx
@@ -61,7 +61,11 @@ export default function PanelSegmentation({
     },
 
     storeSegmentation: async segmentationId => {
-      commandsManager.run('storeSegmentation', { segmentationId });
+      commandsManager.run({
+        commandName: 'storeSegmentation',
+        commandOptions: { segmentationId },
+        context: 'CORNERSTONE',
+      });
     },
 
     onSegmentationDownloadRTSS: segmentationId => {

--- a/extensions/default/src/Components/MoreDropdownMenu.tsx
+++ b/extensions/default/src/Components/MoreDropdownMenu.tsx
@@ -34,15 +34,15 @@ const getMenuItemsDefault = ({
       id: string;
       label: string;
       iconName: string;
-      commands: string;
+      onClick: ({
+        servicesManager,
+        commandsManager,
+        displaySetInstanceUID,
+      }: withAppTypes) => () => void;
     };
   }) => (
     <DropdownMenuItem
-      onClick={() =>
-        commandsManager.runCommand(item.commands, {
-          displaySetInstanceUID,
-        })
-      }
+      onClick={() => item.onClick({ servicesManager, commandsManager, displaySetInstanceUID })}
     >
       <div className="flex items-center gap-2">
         <Icons.ByName name={item.iconName} />

--- a/extensions/default/src/Components/MoreDropdownMenu.tsx
+++ b/extensions/default/src/Components/MoreDropdownMenu.tsx
@@ -16,7 +16,6 @@ const getMenuItemsDefault = ({
   commandsManager,
   items,
   servicesManager,
-  displaySetInstanceUID,
   ...props
 }: withAppTypes) => {
   const { customizationService } = servicesManager.services;
@@ -34,16 +33,10 @@ const getMenuItemsDefault = ({
       id: string;
       label: string;
       iconName: string;
-      onClick: ({
-        servicesManager,
-        commandsManager,
-        displaySetInstanceUID,
-      }: withAppTypes) => () => void;
+      onClick: ({ servicesManager, commandsManager, ...props }: withAppTypes) => () => void;
     };
   }) => (
-    <DropdownMenuItem
-      onClick={() => item.onClick({ servicesManager, commandsManager, displaySetInstanceUID })}
-    >
+    <DropdownMenuItem onClick={() => item.onClick({ ...props })}>
       <div className="flex items-center gap-2">
         <Icons.ByName name={item.iconName} />
         <span>{item.label}</span>

--- a/extensions/default/src/Components/MoreDropdownMenu.tsx
+++ b/extensions/default/src/Components/MoreDropdownMenu.tsx
@@ -12,7 +12,13 @@ import {
  * The default sub-menu appearance and setup is defined here, but this can be
  * replaced by
  */
-const getMenuItemsDefault = ({ commandsManager, items, servicesManager, ...props }) => {
+const getMenuItemsDefault = ({
+  commandsManager,
+  items,
+  servicesManager,
+  displaySetInstanceUID,
+  ...props
+}: withAppTypes) => {
   const { customizationService } = servicesManager.services;
 
   // This allows replacing the default child item for menus, whereas the entire
@@ -20,8 +26,29 @@ const getMenuItemsDefault = ({ commandsManager, items, servicesManager, ...props
   const menuContent = customizationService.getCustomization('ohif.menuContent');
 
   // Default menu item component if none is provided through customization
-  const DefaultMenuItem = ({ item }) => (
-    <DropdownMenuItem onClick={item.onClick}>{item.label || item.title}</DropdownMenuItem>
+
+  const DefaultMenuItem = ({
+    item,
+  }: {
+    item: {
+      id: string;
+      label: string;
+      iconName: string;
+      commands: string;
+    };
+  }) => (
+    <DropdownMenuItem
+      onClick={() =>
+        commandsManager.runCommand(item.commands, {
+          displaySetInstanceUID,
+        })
+      }
+    >
+      <div className="flex items-center gap-2">
+        <Icons.ByName name={item.iconName} />
+        <span>{item.label}</span>
+      </div>
+    </DropdownMenuItem>
   );
 
   const MenuItemComponent = menuContent?.content || DefaultMenuItem;

--- a/extensions/default/src/Components/MoreDropdownMenu.tsx
+++ b/extensions/default/src/Components/MoreDropdownMenu.tsx
@@ -38,7 +38,7 @@ const getMenuItemsDefault = ({
   }) => (
     <DropdownMenuItem onClick={() => item.onClick({ ...props })}>
       <div className="flex items-center gap-2">
-        <Icons.ByName name={item.iconName} />
+        {item.iconName && <Icons.ByName name={item.iconName} />}
         <span>{item.label}</span>
       </div>
     </DropdownMenuItem>

--- a/extensions/default/src/Components/MoreDropdownMenu.tsx
+++ b/extensions/default/src/Components/MoreDropdownMenu.tsx
@@ -33,7 +33,7 @@ const getMenuItemsDefault = ({
       id: string;
       label: string;
       iconName: string;
-      onClick: ({ servicesManager, commandsManager, ...props }: withAppTypes) => () => void;
+      onClick: ({ ...props }: withAppTypes) => () => void;
     };
   }) => (
     <DropdownMenuItem onClick={() => item.onClick({ ...props })}>

--- a/extensions/default/src/customizations/studyBrowserCustomization.ts
+++ b/extensions/default/src/customizations/studyBrowserCustomization.ts
@@ -8,7 +8,7 @@ export default {
       id: 'tagBrowser',
       label: 'Tag Browser',
       iconName: 'DicomTagBrowser',
-      onClick: ({ servicesManager, commandsManager, displaySetInstanceUID }: withAppTypes) => {
+      onClick: ({ commandsManager, displaySetInstanceUID }: withAppTypes) => {
         commandsManager.runCommand('openDICOMTagViewer', {
           displaySetInstanceUID,
         });

--- a/extensions/default/src/customizations/studyBrowserCustomization.ts
+++ b/extensions/default/src/customizations/studyBrowserCustomization.ts
@@ -8,8 +8,6 @@ export default {
       id: 'tagBrowser',
       label: 'Tag Browser',
       iconName: 'DicomTagBrowser',
-      // it makes sense to have displaySetInstanceUID as a paramter always passed here because this is a thumbnail item (linked to a display set)
-      // theres not an easy way to know what thumbnail was clicked if we don't pass this
       onClick: ({ servicesManager, commandsManager, displaySetInstanceUID }: withAppTypes) => {
         commandsManager.runCommand('openDICOMTagViewer', {
           displaySetInstanceUID,

--- a/extensions/default/src/customizations/studyBrowserCustomization.ts
+++ b/extensions/default/src/customizations/studyBrowserCustomization.ts
@@ -8,7 +8,13 @@ export default {
       id: 'tagBrowser',
       label: 'Tag Browser',
       iconName: 'DicomTagBrowser',
-      commands: 'openDICOMTagViewer',
+      // it makes sense to have displaySetInstanceUID as a paramter always passed here because this is a thumbnail item (linked to a display set)
+      // theres not an easy way to know what thumbnail was clicked if we don't pass this
+      onClick: ({ servicesManager, commandsManager, displaySetInstanceUID }: withAppTypes) => {
+        commandsManager.runCommand('openDICOMTagViewer', {
+          displaySetInstanceUID,
+        });
+      },
     },
   ],
   'studyBrowser.sortFunctions': [


### PR DESCRIPTION
### Context

In segmentation mode, exporting a segmentation would incorrectly prioritize the `storeSegmentation` command from the `cornerstone-dicom-seg` extension instead of first invoking the regular `cornerstone` extension command to retrieve the data source before passing it to the second command.

This behavior occurred because `storeSegmentation` exists in both modules, causing it to default to `cornerstone-dicom-seg` first. Other commands did not face this issue since they do not exist in `cornerstone-dicom-seg`, allowing them to fall back to `cornerstone` as expected. 

This has been resolved by explicitly passing the `CORNERSTONE` context name to ensure the correct command execution order.

![CleanShot 2025-01-31 at 10 55 17](https://github.com/user-attachments/assets/0e87bad5-bf11-48bd-bb68-ff6c73cf1e76)


Fixes #4584 
Fixes OHI-1445

