### PR TITLE
fix(context-menu):  Fixing regression introduced by PR #4727

### DIFF
--- a/platform/ui/src/components/ContextMenu/ContextMenu.tsx
+++ b/platform/ui/src/components/ContextMenu/ContextMenu.tsx
@@ -6,17 +6,17 @@ import { Icons } from '@ohif/ui-next';
 const ContextMenu = ({ items, ...props }) => {
   const contextMenuRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
-    if(!contextMenuRef?.current) {
+    if (!contextMenuRef?.current) {
       return;
     }
 
     const contextMenu = contextMenuRef.current;
 
     const boundingClientRect = contextMenu.getBoundingClientRect();
-    if (boundingClientRect.bottom + boundingClientRect.height > window.innerHeight) {
+    if (boundingClientRect.bottom > window.innerHeight) {
       props.defaultPosition.y = props.defaultPosition.y - boundingClientRect.height;
     }
-    if (boundingClientRect.right + boundingClientRect.width > window.innerWidth) {
+    if (boundingClientRect.right > window.innerWidth) {
       props.defaultPosition.x = props.defaultPosition.x - boundingClientRect.width;
     }
   }, [props.defaultPosition]);


### PR DESCRIPTION
Fixing regression introduced by PR https://github.com/OHIF/Viewers/issues/4727

<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

Longer/taller context menus are incorrectly opening from bottom to top and are getting clipped.

In most cases, taller (custom) context menus are opening "bottom-to-top" from the click point even though there is enough space to open them (the desired) "top-to-bottom". Furthermore, the menus are also getting clipped at the top of the browser window. See the screen shot below...

In this screen shot there is plenty of space to open the menu in its traditional sense. Yet, look at how it opens "bottom-to-top" and is clipped at the top.

![image](https://github.com/user-attachments/assets/9d3bc969-d5e1-48e9-b771-d25c9ad12090)




<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

The logic in ContextMenu.tsx was incorrectly adding the height of the menu to the bottom max point to test if the menu were off the screen. This was changed to just test the bottom max point. A similar calculation was altered for the width of the menu.

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

Create a custom context menu with about twelve or more items. Right anywhere. If the menu were to be clipped at the bottom then it will open "bottom-to-top".

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] OS: Windows 11<!--[e.g. Windows 10, macOS 10.15.4]-->
- [x] Node version: 20.9.0 <!--[e.g. 18.16.1]-->
- [x] Browser: Chrome
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
