### PR TITLE
feat(Segments Looping) : Fixed looping through Segments of SEG

### DIFF
--- a/extensions/cornerstone-dicom-rt/src/viewports/OHIFCornerstoneRTViewport.tsx
+++ b/extensions/cornerstone-dicom-rt/src/viewports/OHIFCornerstoneRTViewport.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import { ViewportActionArrows } from '@ohif/ui';
 import { useViewportGrid } from '@ohif/ui-next';
+import { onSegmentChange as handleSegmentChange } from '../../../cornerstone/src/utils/segmentUtils';
 
 import promptHydrateRT from '../utils/promptHydrateRT';
 import _getStatusComponent from './_getStatusComponent';
@@ -141,38 +142,9 @@ function OHIFCornerstoneRTViewport(props: withAppTypes) {
 
   const onSegmentChange = useCallback(
     direction => {
-      const segmentationId = rtDisplaySet.displaySetInstanceUID;
-      const segmentation = segmentationService.getSegmentation(segmentationId);
-
-      const { segments } = segmentation;
-
-      const numberOfSegments = Object.keys(segments).length;
-      //Get activeSegment each time because the user can select any segment from the list and thus the index should be updated
-      const activeSegment = segmentationService.getActiveSegment(viewportId);
-      if (activeSegment) {
-        const activeSegmentIndex = Object.values(segments).findIndex(
-          segment => segment.segmentIndex === activeSegment.segmentIndex
-        );
-        //from the activeSegment get the actual obeject array index to be used
-        selectedSegmentObjectIndex = activeSegmentIndex;
-      }
-      let newSelectedSegmentIndex = selectedSegmentObjectIndex + direction;
-
-      //Handle looping through list of segments
-      if (newSelectedSegmentIndex > numberOfSegments - 1) {
-        newSelectedSegmentIndex = 0;
-      } else if (newSelectedSegmentIndex < 0) {
-        newSelectedSegmentIndex = numberOfSegments - 1;
-      }
-
-      //convert segmentationId from object array index to property value of type Segment
-      //Functions below uses the segmentIndex object attribute so we have to do the conversion
-      const keyIndex = Object.values(segments)[newSelectedSegmentIndex]?.segmentIndex;
-      segmentationService.setActiveSegment(segmentationId, keyIndex);
-      segmentationService.jumpToSegmentCenter(segmentationId, keyIndex, viewportId);
-      selectedSegmentObjectIndex = newSelectedSegmentIndex;
+      handleSegmentChange(direction, rtDisplaySet, viewportId, selectedSegmentObjectIndex);
     },
-    [selectedSegmentObjectIndex, segmentationService]
+    [selectedSegmentObjectIndex]
   );
 
   useEffect(() => {

--- a/extensions/cornerstone-dicom-rt/src/viewports/OHIFCornerstoneRTViewport.tsx
+++ b/extensions/cornerstone-dicom-rt/src/viewports/OHIFCornerstoneRTViewport.tsx
@@ -142,13 +142,13 @@ function OHIFCornerstoneRTViewport(props: withAppTypes) {
 
   const onSegmentChange = useCallback(
     direction => {
-      utils.handleSegmentChange(
+      utils.handleSegmentChange({
         direction,
-        rtDisplaySet,
+        segDisplaySet: rtDisplaySet,
         viewportId,
         selectedSegmentObjectIndex,
-        segmentationService
-      );
+        segmentationService,
+      });
     },
     [selectedSegmentObjectIndex]
   );

--- a/extensions/cornerstone-dicom-rt/src/viewports/OHIFCornerstoneRTViewport.tsx
+++ b/extensions/cornerstone-dicom-rt/src/viewports/OHIFCornerstoneRTViewport.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import { ViewportActionArrows } from '@ohif/ui';
 import { useViewportGrid } from '@ohif/ui-next';
-import { onSegmentChange as handleSegmentChange } from '../../../cornerstone/src/utils/segmentUtils';
+import { utils } from '@ohif/extension-cornerstone';
 
 import promptHydrateRT from '../utils/promptHydrateRT';
 import _getStatusComponent from './_getStatusComponent';
@@ -49,7 +49,7 @@ function OHIFCornerstoneRTViewport(props: withAppTypes) {
   const [viewportGrid, viewportGridService] = useViewportGrid();
 
   // States
-  let selectedSegmentObjectIndex: number = 0;
+  const selectedSegmentObjectIndex: number = 0;
   const { setPositionPresentation } = usePositionPresentationStore();
 
   // Hydration means that the RT is opened and segments are loaded into the
@@ -142,7 +142,13 @@ function OHIFCornerstoneRTViewport(props: withAppTypes) {
 
   const onSegmentChange = useCallback(
     direction => {
-      handleSegmentChange(direction, rtDisplaySet, viewportId, selectedSegmentObjectIndex);
+      utils.handleSegmentChange(
+        direction,
+        rtDisplaySet,
+        viewportId,
+        selectedSegmentObjectIndex,
+        segmentationService
+      );
     },
     [selectedSegmentObjectIndex]
   );

--- a/extensions/cornerstone-dicom-seg/src/viewports/OHIFCornerstoneSEGViewport.tsx
+++ b/extensions/cornerstone-dicom-seg/src/viewports/OHIFCornerstoneSEGViewport.tsx
@@ -7,6 +7,7 @@ import promptHydrateSEG from '../utils/promptHydrateSEG';
 import _getStatusComponent from './_getStatusComponent';
 import { usePositionPresentationStore } from '@ohif/extension-cornerstone';
 import { SegmentationRepresentations } from '@cornerstonejs/tools/enums';
+import { onSegmentChange as handleSegmentChange } from '../../../cornerstone/src/utils/segmentUtils';
 
 const SEG_TOOLGROUP_BASE_NAME = 'SEGToolGroup';
 
@@ -131,38 +132,7 @@ function OHIFCornerstoneSEGViewport(props: withAppTypes) {
 
   const onSegmentChange = useCallback(
     direction => {
-      const segmentationId = segDisplaySet.displaySetInstanceUID;
-      const segmentation = segmentationService.getSegmentation(segmentationId);
-
-      const { segments } = segmentation;
-
-      const numberOfSegments = Object.keys(segments).length;
-
-      //Get activeSegment each time because the user can select any segment from the list and thus the index should be updated
-      const activeSegment = segmentationService.getActiveSegment(viewportId);
-      if (activeSegment) {
-        const activeSegmentIndex = Object.values(segments).findIndex(
-          segment => segment.segmentIndex === activeSegment.segmentIndex
-        );
-        //from the activeSegment get the actual obeject array index to be used
-        selectedSegmentObjectIndex = activeSegmentIndex;
-      }
-      let newSelectedSegmentIndex = selectedSegmentObjectIndex + direction;
-
-      //Handle looping through list of segments
-      if (newSelectedSegmentIndex > numberOfSegments - 1) {
-        newSelectedSegmentIndex = 0;
-      } else if (newSelectedSegmentIndex < 0) {
-        newSelectedSegmentIndex = numberOfSegments - 1;
-      }
-
-      //convert segmentationId from object array index to property value of type Segment
-      //Functions below uses the segmentIndex object attribute so we have to do the conversion
-      const segmentIndex = Object.values(segments)[newSelectedSegmentIndex]?.segmentIndex;
-
-      segmentationService.setActiveSegment(segmentationId, segmentIndex);
-      segmentationService.jumpToSegmentCenter(segmentationId, segmentIndex, viewportId);
-      selectedSegmentObjectIndex = newSelectedSegmentIndex;
+      handleSegmentChange(direction, segDisplaySet, viewportId, selectedSegmentObjectIndex);
     },
     [selectedSegmentObjectIndex]
   );

--- a/extensions/cornerstone-dicom-seg/src/viewports/OHIFCornerstoneSEGViewport.tsx
+++ b/extensions/cornerstone-dicom-seg/src/viewports/OHIFCornerstoneSEGViewport.tsx
@@ -7,7 +7,7 @@ import promptHydrateSEG from '../utils/promptHydrateSEG';
 import _getStatusComponent from './_getStatusComponent';
 import { usePositionPresentationStore } from '@ohif/extension-cornerstone';
 import { SegmentationRepresentations } from '@cornerstonejs/tools/enums';
-import { onSegmentChange as handleSegmentChange } from '../../../cornerstone/src/utils/segmentUtils';
+import { utils } from '@ohif/extension-cornerstone';
 
 const SEG_TOOLGROUP_BASE_NAME = 'SEGToolGroup';
 
@@ -132,7 +132,13 @@ function OHIFCornerstoneSEGViewport(props: withAppTypes) {
 
   const onSegmentChange = useCallback(
     direction => {
-      handleSegmentChange(direction, segDisplaySet, viewportId, selectedSegmentObjectIndex);
+      utils.handleSegmentChange(
+        direction,
+        segDisplaySet,
+        viewportId,
+        selectedSegmentObjectIndex,
+        segmentationService
+      );
     },
     [selectedSegmentObjectIndex]
   );

--- a/extensions/cornerstone-dicom-seg/src/viewports/OHIFCornerstoneSEGViewport.tsx
+++ b/extensions/cornerstone-dicom-seg/src/viewports/OHIFCornerstoneSEGViewport.tsx
@@ -132,13 +132,13 @@ function OHIFCornerstoneSEGViewport(props: withAppTypes) {
 
   const onSegmentChange = useCallback(
     direction => {
-      utils.handleSegmentChange(
+      utils.handleSegmentChange({
         direction,
-        segDisplaySet,
+        segDisplaySet: segDisplaySet,
         viewportId,
         selectedSegmentObjectIndex,
-        segmentationService
-      );
+        segmentationService,
+      });
     },
     [selectedSegmentObjectIndex]
   );

--- a/extensions/cornerstone/src/index.tsx
+++ b/extensions/cornerstone/src/index.tsx
@@ -54,6 +54,7 @@ import PanelMeasurement from './panels/PanelMeasurement';
 import DicomUpload from './components/DicomUpload/DicomUpload';
 import { useSegmentations } from './hooks/useSegmentations';
 import { StudySummaryFromMetadata } from './components/StudySummaryFromMetadata';
+import utils from './utils';
 
 const { imageRetrieveMetadataProvider } = cornerstone.utilities;
 
@@ -254,5 +255,6 @@ export {
   PanelMeasurement,
   DicomUpload,
   StudySummaryFromMetadata,
+  utils,
 };
 export default cornerstoneExtension;

--- a/extensions/cornerstone/src/utils/index.ts
+++ b/extensions/cornerstone/src/utils/index.ts
@@ -1,0 +1,7 @@
+import { handleSegmentChange } from './segmentUtils';
+
+const utils = {
+  handleSegmentChange,
+};
+
+export default utils;

--- a/extensions/cornerstone/src/utils/segmentUtils.ts
+++ b/extensions/cornerstone/src/utils/segmentUtils.ts
@@ -1,14 +1,10 @@
-import { servicesManager } from '@ohif/app/src/App';
 
-const {
-  segmentationService,
-} = servicesManager.services;
-
-export const onSegmentChange = (
+export const handleSegmentChange = (
   direction: number,
   segDisplaySet: any,
   viewportId: string,
-  selectedSegmentObjectIndex: number
+  selectedSegmentObjectIndex: number,
+  segmentationService: any
 ) => {
   const segmentationId = segDisplaySet.displaySetInstanceUID;
   const segmentation = segmentationService.getSegmentation(segmentationId);

--- a/extensions/cornerstone/src/utils/segmentUtils.ts
+++ b/extensions/cornerstone/src/utils/segmentUtils.ts
@@ -1,11 +1,18 @@
+import SegmentationServiceType from '../services/SegmentationService';
 
-export const handleSegmentChange = (
-  direction: number,
-  segDisplaySet: any,
-  viewportId: string,
-  selectedSegmentObjectIndex: number,
-  segmentationService: any
-) => {
+export const handleSegmentChange = ({
+  direction,
+  segDisplaySet,
+  viewportId,
+  selectedSegmentObjectIndex,
+  segmentationService,
+}: {
+  direction: number;
+  segDisplaySet: AppTypes.DisplaySet;
+  viewportId: string;
+  selectedSegmentObjectIndex: number;
+  segmentationService: SegmentationServiceType;
+}) => {
   const segmentationId = segDisplaySet.displaySetInstanceUID;
   const segmentation = segmentationService.getSegmentation(segmentationId);
 
@@ -16,11 +23,10 @@ export const handleSegmentChange = (
   // Get activeSegment each time because the user can select any segment from the list and thus the index should be updated
   const activeSegment = segmentationService.getActiveSegment(viewportId);
   if (activeSegment) {
-    const activeSegmentIndex = Object.values(segments).findIndex(
+    // from the activeSegment get the actual object array index to be used
+    selectedSegmentObjectIndex = Object.values(segments).findIndex(
       segment => segment.segmentIndex === activeSegment.segmentIndex
     );
-    // from the activeSegment get the actual object array index to be used
-    selectedSegmentObjectIndex = activeSegmentIndex;
   }
   let newSelectedSegmentIndex = selectedSegmentObjectIndex + direction;
 

--- a/extensions/cornerstone/src/utils/segmentUtils.ts
+++ b/extensions/cornerstone/src/utils/segmentUtils.ts
@@ -1,0 +1,45 @@
+import { servicesManager } from '@ohif/app/src/App';
+
+const {
+  segmentationService,
+} = servicesManager.services;
+
+export const onSegmentChange = (
+  direction: number,
+  segDisplaySet: any,
+  viewportId: string,
+  selectedSegmentObjectIndex: number
+) => {
+  const segmentationId = segDisplaySet.displaySetInstanceUID;
+  const segmentation = segmentationService.getSegmentation(segmentationId);
+
+  const { segments } = segmentation;
+
+  const numberOfSegments = Object.keys(segments).length;
+
+  // Get activeSegment each time because the user can select any segment from the list and thus the index should be updated
+  const activeSegment = segmentationService.getActiveSegment(viewportId);
+  if (activeSegment) {
+    const activeSegmentIndex = Object.values(segments).findIndex(
+      segment => segment.segmentIndex === activeSegment.segmentIndex
+    );
+    // from the activeSegment get the actual object array index to be used
+    selectedSegmentObjectIndex = activeSegmentIndex;
+  }
+  let newSelectedSegmentIndex = selectedSegmentObjectIndex + direction;
+
+  // Handle looping through list of segments
+  if (newSelectedSegmentIndex > numberOfSegments - 1) {
+    newSelectedSegmentIndex = 0;
+  } else if (newSelectedSegmentIndex < 0) {
+    newSelectedSegmentIndex = numberOfSegments - 1;
+  }
+
+  // Convert segmentationId from object array index to property value of type Segment
+  // Functions below use the segmentIndex object attribute so we have to do the conversion
+  const segmentIndex = Object.values(segments)[newSelectedSegmentIndex]?.segmentIndex;
+
+  segmentationService.setActiveSegment(segmentationId, segmentIndex);
+  segmentationService.jumpToSegmentCenter(segmentationId, segmentIndex, viewportId);
+  selectedSegmentObjectIndex = newSelectedSegmentIndex;
+};

--- a/platform/ui-next/src/components/DataRow/DataRow.tsx
+++ b/platform/ui-next/src/components/DataRow/DataRow.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { Button } from '../../components/Button/Button';
 import {
   DropdownMenu,
@@ -97,6 +97,13 @@ const DataRow: React.FC<DataRowProps> = ({
 }) => {
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const isTitleLong = title?.length > 25;
+  const rowRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (isSelected && rowRef.current) {
+      rowRef.current.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+  }, [isSelected]);
 
   const handleAction = (action: string, e: React.MouseEvent) => {
     e.stopPropagation();
@@ -181,7 +188,9 @@ const DataRow: React.FC<DataRowProps> = ({
   };
 
   return (
-    <div className={`flex flex-col ${isVisible ? '' : 'opacity-60'}`}>
+    <div
+      ref={rowRef}
+      className={`flex flex-col ${isVisible ? '' : 'opacity-60'}`}>
       <div
         className={`flex items-center ${
           isSelected ? 'bg-popover' : 'bg-muted'


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context
Implements/fixes [[feat] Selected Segment is not used when iterating over #4614](https://github.com/OHIF/Viewers/issues/4614).
The navigation between segments when using viewport arrows was inconsistent when selecting manually a SEG and then using arrow. 

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results
The functionality was improved by
a) Synchronizing index of arrow looping with the selected segment. If the SEG is changed manually to any position the next time an arrow is pressed the selected segment is retrieved and used to continue navigation from there and not the previous position.
b) I noticed that Segments (and RTS segments also) can be so many that the list must be scrolled to detect the selected segment. Previously when arrows were used the selected segment was not visible on the list. Now it is but if you press right arrow multiple times the selection disappears as it is not visible anymore. This new issue was resolved by editing the dataRow component to ensure visibility always. (see attached video)

https://github.com/user-attachments/assets/a7591024-d8ee-4d8c-87ee-55aaf1178988


<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] OS: Windows 11 <!--[e.g. Windows 10, macOS 10.15.4]-->
- [x] Node version: Node version: v23.6.1 <!--[e.g. 18.16.1]-->
- [x] Browser: Vivaldi 7.1.3570.50 (Stable channel) (64-bit)
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
