### PR TITLE
fix(thumbnails): slow thumbnail rendering

### DIFF
--- a/extensions/default/src/Panels/StudyBrowser/PanelStudyBrowser.tsx
+++ b/extensions/default/src/Panels/StudyBrowser/PanelStudyBrowser.tsx
@@ -36,7 +36,6 @@ function PanelStudyBrowser({
   const [expandedStudyInstanceUIDs, setExpandedStudyInstanceUIDs] = useState([
     ...StudyInstanceUIDs,
   ]);
-  const [hasLoadedViewports, setHasLoadedViewports] = useState(false);
   const [studyDisplayList, setStudyDisplayList] = useState([]);
   const [displaySets, setDisplaySets] = useState([]);
   const [thumbnailImageSrcMap, setThumbnailImageSrcMap] = useState({});
@@ -139,18 +138,6 @@ function PanelStudyBrowser({
 
   // // ~~ Initial Thumbnails
   useEffect(() => {
-    if (!hasLoadedViewports) {
-      if (activeViewportId) {
-        // Once there is an active viewport id, it means the layout is ready
-        // so wait a bit of time to allow the viewports preferential loading
-        // which improves user experience of responsiveness significantly on slower
-        // systems.
-        window.setTimeout(() => setHasLoadedViewports(true), 250);
-      }
-
-      return;
-    }
-
     const currentDisplaySets = displaySetService.activeDisplaySets;
     currentDisplaySets.forEach(async dSet => {
       const newImageSrcEntry = {};
@@ -169,14 +156,7 @@ function PanelStudyBrowser({
         return { ...prevState, ...newImageSrcEntry };
       });
     });
-  }, [
-    StudyInstanceUIDs,
-    dataSource,
-    displaySetService,
-    getImageSrc,
-    hasLoadedViewports,
-    activeViewportId,
-  ]);
+  }, [StudyInstanceUIDs, dataSource, displaySetService, getImageSrc, activeViewportId]);
 
   // ~~ displaySets
   useEffect(() => {
@@ -194,10 +174,6 @@ function PanelStudyBrowser({
     const SubscriptionDisplaySetsAdded = displaySetService.subscribe(
       displaySetService.EVENTS.DISPLAY_SETS_ADDED,
       data => {
-        // for some reason this breaks thumbnail loading
-        // if (!hasLoadedViewports) {
-        //   return;
-        // }
         const { displaySetsAdded } = data;
         displaySetsAdded.forEach(async dSet => {
           const newImageSrcEntry = {};

--- a/extensions/measurement-tracking/src/panels/PanelStudyBrowserTracking/PanelStudyBrowserTracking.tsx
+++ b/extensions/measurement-tracking/src/panels/PanelStudyBrowserTracking/PanelStudyBrowserTracking.tsx
@@ -63,7 +63,6 @@ export default function PanelStudyBrowserTracking({
     ...StudyInstanceUIDs,
   ]);
   const [studyDisplayList, setStudyDisplayList] = useState([]);
-  const [hasLoadedViewports, setHasLoadedViewports] = useState(false);
   const [displaySets, setDisplaySets] = useState([]);
   const [displaySetsLoadingState, setDisplaySetsLoadingState] = useState({});
   const [thumbnailImageSrcMap, setThumbnailImageSrcMap] = useState({});
@@ -176,18 +175,6 @@ export default function PanelStudyBrowserTracking({
 
   // ~~ Initial Thumbnails
   useEffect(() => {
-    if (!hasLoadedViewports) {
-      if (activeViewportId) {
-        // Once there is an active viewport id, it means the layout is ready
-        // so wait a bit of time to allow the viewports preferential loading
-        // which improves user experience of responsiveness significantly on slower
-        // systems.
-        window.setTimeout(() => setHasLoadedViewports(true), 1000);
-      }
-
-      return;
-    }
-
     let currentDisplaySets = displaySetService.activeDisplaySets;
     // filter non based on the list of modalities that are supported by cornerstone
     currentDisplaySets = currentDisplaySets.filter(
@@ -215,7 +202,7 @@ export default function PanelStudyBrowserTracking({
         thumbnailSrc = await displaySet.getThumbnailSrc();
       }
       if (!thumbnailSrc) {
-        let thumbnailSrc = await getImageSrc(imageId);
+        const thumbnailSrc = await getImageSrc(imageId);
         displaySet.thumbnailSrc = thumbnailSrc;
       }
       newImageSrcEntry[dSet.displaySetInstanceUID] = thumbnailSrc;
@@ -224,7 +211,7 @@ export default function PanelStudyBrowserTracking({
         return { ...prevState, ...newImageSrcEntry };
       });
     });
-  }, [displaySetService, dataSource, getImageSrc, activeViewportId, hasLoadedViewports]);
+  }, [displaySetService, dataSource, getImageSrc, activeViewportId]);
 
   // ~~ displaySets
   useEffect(() => {
@@ -281,9 +268,6 @@ export default function PanelStudyBrowserTracking({
     const SubscriptionDisplaySetsAdded = displaySetService.subscribe(
       displaySetService.EVENTS.DISPLAY_SETS_ADDED,
       data => {
-        if (!hasLoadedViewports) {
-          return;
-        }
         const { displaySetsAdded, options } = data;
         displaySetsAdded.forEach(async dSet => {
           const displaySetInstanceUID = dSet.displaySetInstanceUID;


### PR DESCRIPTION
### Context

Thumbnails were very slow to render in master, and it was due to the recent increase for viewport loaded timeout from 250ms to 1000ms.

I took out the logic entirely because I think we should just handle this differently, using timeouts will cause issues because all systems are different. We should just implement something in the future to prioritize the viewports over the thumbnail panel requests.