### PR TITLE
Fix broken activateViewportBeforeInteraction behavior

### DIFF
--- a/platform/app/src/components/ViewportGrid.tsx
+++ b/platform/app/src/components/ViewportGrid.tsx
@@ -276,7 +276,7 @@ function ViewerViewportGrid(props: withAppTypes) {
           return;
         }
 
-        if (event) {
+        if (event && (appConfig?.activateViewportBeforeInteraction ?? true)) {
           event.preventDefault();
           event.stopPropagation();
         }
@@ -310,10 +310,7 @@ function ViewerViewportGrid(props: withAppTypes) {
         >
           <div
             data-cy="viewport-pane"
-            className={classNames('flex h-full w-full min-w-[5px] flex-col', {
-              'pointer-events-none':
-                !isActive && (appConfig?.activateViewportBeforeInteraction ?? true),
-            })}
+            className="flex h-full w-full min-w-[5px] flex-col"
           >
             <ViewportComponent
               displaySets={displaySets}


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context
This PR fixes the broken activateViewportBeforeInteraction setting that was causing issues with viewport interaction. The previous implementation was not properly controlling viewport activation behavior.

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results
Modified `onInteractionHandler` in `ViewerViewportGrid.jsx` to only call `preventDefault()` and `stopPropagation()` when `activateViewportBeforeInteraction` is enabled

#### Before
Previously, the activateViewportBeforeInteraction setting was not working correctly. The code attempted to use the pointer-events-none CSS class, but this approach was not effective for controlling viewport interaction.
#### After
Now, the `activateViewportBeforeInteraction` setting properly controls viewport behavior:

- When enabled: Users must first click a viewport to activate it before using tools
- When disabled: Users can interact with tools on any viewport without first activating it

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing
Tested the following scenarios:

1) `activateViewportBeforeInteraction: true` - First click activates the viewport, second click applies the selected tool

2) `activateViewportBeforeInteraction: false`  - First click both activates the viewport and applies the selected tool
<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] OS: <!--[e.g. Windows 10, macOS 10.15.4]-->
- [x] Node version: <!--[e.g. 18.16.1]-->
- [x] Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
