### PR TITLE
fix: dicom tag browser row height on toggle

### DIFF
--- a/extensions/default/src/DicomTagBrowser/DicomTagTable.tsx
+++ b/extensions/default/src/DicomTagBrowser/DicomTagTable.tsx
@@ -239,9 +239,11 @@ function DicomTagTable({ rows }: { rows: Row[] }) {
           return internalRow;
         });
         setInternalRows(newInternalRows);
+
+        listRef?.current?.resetAfterIndex(0);
       };
     },
-    [internalRows]
+    [internalRows, listRef]
   );
 
   const getRowComponent = useCallback(


### PR DESCRIPTION
### Context

Currently, when you collapse a row the heights of the rows are not recalculated, which may cause rows with wrong heights and missing/unreadable text. This PR fixed it by forcing it to recalculate the heights once a row is collapsed or expanded.

**Before:**

![image](https://github.com/user-attachments/assets/2d5a8bab-4110-4d2a-afd3-629221cd8326)
Expanded with correct heights

![image](https://github.com/user-attachments/assets/2b1aad4d-d7fc-4bad-9a62-8dd83ca77be0)
But collapsed with wrong heights


**After:**

![image](https://github.com/user-attachments/assets/f89042e7-f940-4fe1-bf3b-ac0d575c412d)
Expanded with correct heights

![image](https://github.com/user-attachments/assets/c201d3c7-b4fa-4173-9d9b-f2b0ac198159)
And also collapsed with correct heights

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] OS: <!--[e.g. Windows 10, macOS 10.15.4]-->
- [] Node version: <!--[e.g. 18.16.1]-->
- [] Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
