### PR TITLE
feat(viewport-gap): remove viewport gap and update border behavior

### DIFF
--- a/platform/app/src/components/ViewportGrid.tsx
+++ b/platform/app/src/components/ViewportGrid.tsx
@@ -284,19 +284,26 @@ function ViewerViewportGrid(props: withAppTypes) {
         viewportGridService.setActiveViewportId(viewportId);
       };
 
-      const getBorderStyle = index => {
+      const getBorderStyle = viewportIndex => {
         const style = {} as any;
-        if (numViewportPanes === 1) {
+        const layoutOptions = viewportGridService.getLayoutOptionsFromState(
+          viewportGridService.getState()
+        );
+        const vp = layoutOptions[viewportIndex];
+        if (!vp) {
           return style;
         }
-        const colIndex = index % numCols;
-        const rowIndex = Math.floor(index / numCols);
-        if (colIndex < numCols - 1) {
+        const { x, y, width, height } = vp;
+        const tolerance = 0.01;
+
+        if (x + width < 1 - tolerance) {
           style.borderRight = '1px solid #3a3f99';
         }
-        if (rowIndex < numRows - 1) {
+
+        if (y + height < 1 - tolerance) {
           style.borderBottom = '1px solid #3a3f99';
         }
+
         return style;
       };
 

--- a/platform/app/src/components/ViewportGrid.tsx
+++ b/platform/app/src/components/ViewportGrid.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useCallback, useRef } from 'react';
 import { useResizeDetector } from 'react-resize-detector';
 import { Types, MeasurementService } from '@ohif/core';
-import { ViewportGrid, ViewportPane } from '@ohif/ui';
+import { ViewportGrid, ViewportPane } from '@ohif/ui-next';
 import { useViewportGrid } from '@ohif/ui-next';
 import EmptyViewport from './EmptyViewport';
 import classNames from 'classnames';
@@ -284,6 +284,22 @@ function ViewerViewportGrid(props: withAppTypes) {
         viewportGridService.setActiveViewportId(viewportId);
       };
 
+      const getBorderStyle = index => {
+        const style = {} as any;
+        if (numViewportPanes === 1) {
+          return style;
+        }
+        const colIndex = index % numCols;
+        const rowIndex = Math.floor(index / numCols);
+        if (colIndex < numCols - 1) {
+          style.borderRight = '1px solid #3a3f99';
+        }
+        if (rowIndex < numRows - 1) {
+          style.borderBottom = '1px solid #3a3f99';
+        }
+        return style;
+      };
+
       viewportPanes[i] = (
         <ViewportPane
           // Note: It is highly important that the key is the viewportId here,
@@ -301,10 +317,11 @@ function ViewerViewportGrid(props: withAppTypes) {
           onInteraction={onInteractionHandler}
           customStyle={{
             position: 'absolute',
-            top: viewportY * 100 + 0.2 + '%',
-            left: viewportX * 100 + 0.2 + '%',
-            width: viewportWidth * 100 - 0.3 + '%',
-            height: viewportHeight * 100 - 0.3 + '%',
+            top: viewportY * 100 + '%',
+            left: viewportX * 100 + '%',
+            width: viewportWidth * 100 + '%',
+            height: viewportHeight * 100 + '%',
+            ...getBorderStyle(i),
           }}
           isActive={isActive}
         >
@@ -343,7 +360,7 @@ function ViewerViewportGrid(props: withAppTypes) {
   return (
     <div
       ref={resizeRef}
-      className="h-full w-full"
+      className="border-secondary-light h-full w-full border"
     >
       <ViewportGrid
         numRows={numRows}

--- a/platform/ui-next/src/components/Viewport/ViewportPane.tsx
+++ b/platform/ui-next/src/components/Viewport/ViewportPane.tsx
@@ -57,21 +57,21 @@ function ViewportPane({
       onClick={onInteractionHandler}
       onScroll={onInteractionHandler}
       onWheel={onInteractionHandler}
-      className={classNames('h-full w-full overflow-hidden transition duration-300', className)}
+      className={classNames(
+        'group relative h-full w-full overflow-hidden transition duration-300',
+        className
+      )}
       style={customStyle}
     >
+      <div className={classNames('relative h-full w-full', className)}>{children}</div>
+
+      {/* Border overlay */}
       <div
-        className={classNames(
-          'h-full w-full overflow-hidden border',
-          {
-            'border-primary-light': isActive,
-            'hover:border-primary-light/70 border-transparent': !isActive,
-          },
-          className
-        )}
-      >
-        {children}
-      </div>
+        className={classNames('pointer-events-none absolute inset-0', {
+          'border-primary-light border': isActive,
+          'group-hover:border-primary-light/70 border border-transparent': !isActive,
+        })}
+      />
     </div>
   );
 }

--- a/platform/ui-next/src/components/Viewport/ViewportPane.tsx
+++ b/platform/ui-next/src/components/Viewport/ViewportPane.tsx
@@ -57,22 +57,15 @@ function ViewportPane({
       onClick={onInteractionHandler}
       onScroll={onInteractionHandler}
       onWheel={onInteractionHandler}
-      className={classNames(
-        'group/pane h-full w-full overflow-hidden rounded-md transition duration-300',
-        {
-          'border-primary-light border-2': isActive,
-          'border-2 border-transparent': !isActive,
-        },
-        className
-      )}
+      className={classNames('h-full w-full overflow-hidden transition duration-300', className)}
       style={customStyle}
     >
       <div
         className={classNames(
-          'h-full w-full overflow-hidden rounded-md',
+          'h-full w-full overflow-hidden border',
           {
-            'border border-transparent': isActive,
-            'border-secondary-light group-hover/pane:border-primary-light/70 border': !isActive,
+            'border-primary-light': isActive,
+            'hover:border-primary-light/70 border-transparent': !isActive,
           },
           className
         )}

--- a/platform/ui-next/src/contextProviders/ViewportGridProvider.tsx
+++ b/platform/ui-next/src/contextProviders/ViewportGridProvider.tsx
@@ -503,6 +503,7 @@ export function ViewportGridProvider({ children, service }: ViewportGridProvider
     getActiveViewportOptionByKey,
     setViewportGridSizeChanged: props => service.setViewportGridSizeChanged(props),
     publishViewportsReady: () => service.publishViewportsReady(),
+    getLayoutOptionsFromState: state => service.getLayoutOptionsFromState(state),
   };
 
   return (


### PR DESCRIPTION
### Context

This removes the viewport gap and updates the border behavior.

I weighted different options to achieve this, and I believe this is the most reasonable. I wanted to go for a grid approach, but that would break how hanging protocols work and their custom viewport positioning, so we need to stay on the current approach of absolute positioning with a calculated width and a height. For this reason I added a `getBorderStyle` function that can help us get the right borders without needing a display grid parent.


https://github.com/user-attachments/assets/f723a49c-f8e6-48e1-a94b-01c3d3de515d

Fixes: https://linear.app/ohif/issue/OHI-1640

@sedghi @dan-rukas 

