### PR TITLE
ui(components) Adds FilterInput component to ui-next

### DIFF
--- a/extensions/default/src/DicomTagBrowser/DicomTagBrowser.tsx
+++ b/extensions/default/src/DicomTagBrowser/DicomTagBrowser.tsx
@@ -2,7 +2,7 @@ import dcmjs from 'dcmjs';
 import moment from 'moment';
 import React, { useState, useMemo, useCallback } from 'react';
 import { classes, Types } from '@ohif/core';
-import { InputFilterText } from '@ohif/ui';
+import { FilterInput } from '@ohif/ui-next';
 import { Select, SelectTrigger, SelectContent, SelectItem, Slider } from '@ohif/ui-next';
 
 import DicomTagTable from './DicomTagTable';
@@ -173,11 +173,17 @@ const DicomTagBrowser = ({
             <span className="text-muted-foreground flex h-6 items-center text-xs">
               Search metadata
             </span>
-            <InputFilterText
-              placeholder="Search metadata..."
+            <FilterInput.Root
+              className="text-muted-foreground"
               onDebounceChange={setFilterValue}
-              className="text-foreground"
-            />
+            >
+              <FilterInput.SearchIcon />
+              <FilterInput.Input
+                placeholder="Search metadata"
+                className="pl-9 pr-9"
+              />
+              <FilterInput.ClearButton />
+            </FilterInput.Root>
           </div>
         </div>
       </div>

--- a/platform/ui-next/src/components/FilterInput/FilterInput.tsx
+++ b/platform/ui-next/src/components/FilterInput/FilterInput.tsx
@@ -1,0 +1,198 @@
+import * as React from 'react';
+import { createContext, useContext, useState, useEffect, useMemo, useCallback } from 'react';
+import debounce from 'lodash.debounce';
+import { cn } from '../../lib/utils';
+import { Input } from '../Input';
+import { Icons } from '../Icons';
+
+// Context to share state between compound components
+type FilterInputContextType = {
+  value: string;
+  setValue: (value: string) => void;
+  handleChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  clearValue: () => void;
+  inputRef: React.RefObject<HTMLInputElement>;
+};
+
+const FilterInputContext = createContext<FilterInputContextType | undefined>(undefined);
+
+function useFilterInputContext() {
+  const context = useContext(FilterInputContext);
+  if (!context) {
+    throw new Error('FilterInput compound components must be used within FilterInput.Root');
+  }
+  return context;
+}
+
+// Root component
+interface RootProps {
+  children: React.ReactNode;
+  className?: string;
+  defaultValue?: string;
+  value?: string;
+  onChange?: (value: string) => void;
+  onDebounceChange?: (value: string) => void;
+  debounceTime?: number;
+}
+
+function Root({
+  children,
+  className,
+  defaultValue = '',
+  value: controlledValue,
+  onChange,
+  onDebounceChange,
+  debounceTime = 200,
+}: RootProps) {
+  const [uncontrolledValue, setUncontrolledValue] = useState(defaultValue);
+  const inputRef = React.useRef<HTMLInputElement>(null);
+
+  // Determine if this is a controlled or uncontrolled component
+  const isControlled = controlledValue !== undefined;
+  const value = isControlled ? controlledValue : uncontrolledValue;
+
+  const debouncedOnChange = useMemo(() => {
+    return debounce(onDebounceChange || (() => {}), debounceTime);
+  }, [onDebounceChange, debounceTime]);
+
+  useEffect(() => {
+    return () => debouncedOnChange.cancel();
+  }, [debouncedOnChange]);
+
+  const setValue = useCallback(
+    (newValue: string) => {
+      if (!isControlled) {
+        setUncontrolledValue(newValue);
+      }
+
+      if (onChange) {
+        onChange(newValue);
+      }
+
+      if (onDebounceChange) {
+        debouncedOnChange(newValue);
+      }
+    },
+    [isControlled, onChange, onDebounceChange, debouncedOnChange]
+  );
+
+  const handleChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      setValue(event.target.value);
+    },
+    [setValue]
+  );
+
+  const clearValue = useCallback(() => {
+    setValue('');
+    inputRef.current?.focus();
+  }, [setValue]);
+
+  return (
+    <FilterInputContext.Provider value={{ value, setValue, handleChange, clearValue, inputRef }}>
+      <div className={cn('relative', className)}>{children}</div>
+    </FilterInputContext.Provider>
+  );
+}
+
+// Input component
+interface InputProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange'> {
+  className?: string;
+}
+
+function InputComponent({ className, placeholder, ...props }: InputProps) {
+  const { value, handleChange, inputRef } = useFilterInputContext();
+
+  return (
+    <Input
+      ref={inputRef}
+      className={cn('w-full', className)}
+      placeholder={placeholder}
+      value={value}
+      onChange={handleChange}
+      {...props}
+    />
+  );
+}
+
+// Search icon component
+interface SearchIconProps {
+  className?: string;
+}
+
+function SearchIcon({ className }: SearchIconProps) {
+  return (
+    <span className={cn('absolute inset-y-0 left-0 flex items-center pl-2', className)}>
+      <Icons.Search className="text-muted-foreground" />
+    </span>
+  );
+}
+
+// Clear button component
+interface ClearButtonProps {
+  className?: string;
+}
+
+function ClearButton({ className }: ClearButtonProps) {
+  const { value, clearValue } = useFilterInputContext();
+
+  if (!value) {
+    return null;
+  }
+
+  return (
+    <span className={cn('absolute inset-y-0 right-0 flex items-center pr-2', className)}>
+      <Icons.Clear
+        className={cn('cursor-pointer', className)}
+        onClick={clearValue}
+      />
+    </span>
+  );
+}
+
+// Pre-composed component for simpler usage
+interface FilterInputProps {
+  className?: string;
+  placeholder?: string;
+  value?: string;
+  defaultValue?: string;
+  onChange?: (value: string) => void;
+  onDebounceChange?: (value: string) => void;
+  debounceTime?: number;
+}
+
+function FilterInput({
+  className,
+  placeholder = 'Search...',
+  value,
+  defaultValue = '',
+  onChange,
+  onDebounceChange,
+  debounceTime = 200,
+}: FilterInputProps) {
+  return (
+    <Root
+      className={className}
+      value={value}
+      defaultValue={defaultValue}
+      onChange={onChange}
+      onDebounceChange={onDebounceChange}
+      debounceTime={debounceTime}
+    >
+      <SearchIcon />
+      <InputComponent
+        placeholder={placeholder}
+        className="pl-9 pr-9"
+      />
+      <ClearButton />
+    </Root>
+  );
+}
+
+// Attach subcomponents as static properties
+FilterInput.Root = Root;
+FilterInput.Input = InputComponent;
+FilterInput.SearchIcon = SearchIcon;
+FilterInput.ClearButton = ClearButton;
+
+export { FilterInput, type FilterInputProps };

--- a/platform/ui-next/src/components/FilterInput/index.ts
+++ b/platform/ui-next/src/components/FilterInput/index.ts
@@ -1,0 +1,2 @@
+export { FilterInput } from './FilterInput';
+export type { FilterInputProps } from './FilterInput';

--- a/platform/ui-next/src/components/index.ts
+++ b/platform/ui-next/src/components/index.ts
@@ -58,6 +58,7 @@ import { InputDialog, PresetDialog } from './OHIFDialogs';
 import { AboutModal, ImageModal, UserPreferencesModal } from './OHIFModals';
 import Modal from './Modal/Modal';
 import { FooterAction } from './FooterAction';
+import { FilterInput } from './FilterInput';
 
 import {
   DropdownMenu,
@@ -237,4 +238,5 @@ export {
   UserPreferencesModal,
   FooterAction,
   ToolSettings,
+  FilterInput,
 };

--- a/platform/ui-next/src/index.ts
+++ b/platform/ui-next/src/index.ts
@@ -107,6 +107,7 @@ import {
   ImageModal,
   UserPreferencesModal,
   FooterAction,
+  FilterInput,
 } from './components';
 import { DataRow } from './components/DataRow';
 
@@ -245,4 +246,5 @@ export {
   useDialog,
   ManagedDialog,
   ToolSettings,
+  FilterInput,
 };


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

Introduces a new `FilterInput` compound component to replace the legacy `InputFilterText` from the old UI package. The component provides a flexible search input with integrated search icon, text filtering, and clear button functionality.
In addition, the `DicomTagBrowser` has been updated with this component.

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

#### Key Features

- **Compound Component Architecture**: Follows modern React patterns for maximum flexibility and composition
- **Debounced Filtering**: Built-in debounce mechanism for performance optimization
- **Accessibility**: Proper focus management and keyboard interactions
- **Flexible Composition**: Can be used as a pre-composed component or custom-assembled from subcomponents
- **Consistent Styling**: Matches the design system with proper theming support

#### Usage

Simple usage:

```tsx
<FilterInput 
  placeholder="Search records..." 
  onDebounceChange={handleSearch} 
  className="w-full"
/>
```

Custom composition:

```tsx
<FilterInput.Root onDebounceChange={handleSearch}>
  <FilterInput.SearchIcon />
  <FilterInput.Input placeholder="Search..." className="pl-9 pr-9" />
  <FilterInput.ClearButton />
</FilterInput.Root>
```

#### Migration

This component directly replaces `InputFilterText` from the old UI package with identical API, making migration straightforward while providing additional flexibility for future enhancements.

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

Tested in Chrome (macOS)

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] OS: macOS Sequoia 15.3 (24D60), Apple M4 Pro
- [x] Node version: 23.7.0
- [x] Browser: 134.0.6998.89 (Current)
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
