### PR TITLE
Fix issue #4241 - add history.navigate to worklist

### DIFF
--- a/platform/app/src/routes/WorkList/WorkList.tsx
+++ b/platform/app/src/routes/WorkList/WorkList.tsx
@@ -41,6 +41,8 @@ import { Types } from '@ohif/ui';
 
 import { preserveQueryParameters, preserveQueryStrings } from '../../utils/preserveQueryParameters';
 
+import { history } from '../../utils/history';
+
 const PatientInfoVisibility = Types.PatientInfoVisibility;
 
 const { sortBySeriesDate } = utils;
@@ -61,6 +63,7 @@ function WorkList({
   onRefresh,
   servicesManager,
 }: withAppTypes) {
+  history.navigate = useNavigate(); // Expose the react router dom navigation.
   const { hotkeyDefinitions, hotkeyDefaults } = hotkeysManager;
   const { show, hide } = useModal();
   const { t } = useTranslation();


### PR DESCRIPTION


### Context

Issue:  https://github.com/OHIF/Viewers/issues/4241

Currently, the navigateHistory command of commandsManager is only initialized in Mode.tsx.

Therefore it is not available right after the client is started; before a study is opened.

This prevents integation methods that do not use URL launch from working (for example FHIRcast).

This is not required for v10 but I would like the PR ready to merge shorthly after v10 release.

### Changes & Results

Added the initialization in Worklist.tsx


### Testing
No simple way to test .


<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
