### PR TITLE
Import Path Dicom Microscopy viewer

### DIFF
--- a/platform/app/.webpack/writePluginImportsFile.js
+++ b/platform/app/.webpack/writePluginImportsFile.js
@@ -10,10 +10,6 @@ const extractName = val => (typeof val === 'string' ? val : val.packageName);
 
 const publicURL = process.env.PUBLIC_URL || '/';
 
-function isAbsolutePath(path) {
-  return path.startsWith('http') || path.startsWith('/');
-}
-
 function constructLines(input, categoryName) {
   let pluginCount = 0;
 
@@ -77,7 +73,7 @@ function getRuntimeLoadModesExtensions(modules) {
     if (module.importPath) {
       dynamicLoad.push(
         `  if( module==="${packageName}") {`,
-        `    const imported = await window.browserImportFunction('${isAbsolutePath(module.importPath) ? '' : publicURL}${module.importPath}');`,
+        `    const imported = await window.browserImportFunction('${publicURL}${module.importPath}');`,
         '    return ' +
           (module.globalName
             ? `window["${module.globalName}"];`

--- a/platform/app/pluginConfig.json
+++ b/platform/app/pluginConfig.json
@@ -96,7 +96,7 @@
     },
     {
       "packageName": "dicom-microscopy-viewer",
-      "importPath": "/dicom-microscopy-viewer/dicomMicroscopyViewer.min.js",
+      "importPath": "dicom-microscopy-viewer/dicomMicroscopyViewer.min.js",
       "globalName": "dicomMicroscopyViewer",
       "directory": "./node_modules/dicom-microscopy-viewer/dist/dynamic-import"
     }

--- a/platform/docs/versioned_docs/version-3.9/migration-guide/3p8-to-3p9/9-other.md
+++ b/platform/docs/versioned_docs/version-3.9/migration-guide/3p8-to-3p9/9-other.md
@@ -34,7 +34,7 @@ dependency.  The example is part of the default `pluginConfig.json` file.
     },
     {
       "packageName": "dicom-microscopy-viewer",
-      "importPath": "/dicom-microscopy-viewer/dicomMicroscopyViewer.min.js",
+      "importPath": "dicom-microscopy-viewer/dicomMicroscopyViewer.min.js",
       "globalName": "dicomMicroscopyViewer",
       "directory": "./node_modules/dicom-microscopy-viewer/dist/dynamic-import"
     }


### PR DESCRIPTION
### Context
Following https://github.com/OHIF/Viewers/pull/4891 trying to solve the import of dicom microscopy viewer if served by non root path.

When using publicURL, dicom-microscopy-viewer retrieve from OHIF still miss the basename prefix,

### Changes & Results

In importPath of pluginConfig was settings "/dicom-microscopy-viewer/dicomMicroscopyViewer.min.js " so was evaluated as absolute path and thus PUBLIC_URL was not applyed in write pluginImportFile.js

Removing the first '/' to make it relative solve the issue for retrieving the assets but OHIF crashes on another issue by calling
"/dicom-microscopy-viewer/index.worker.min.worker.js" from with an absolute path without adding the PUBLIC_URL in this http request (but didn't found where it comes from)

### Testing

Use a build with PUBLIC_URL, with this fix retrieve of dicomMicroscopyViewer.min.js is OK but fails for index.worker.min.worker.js

### Checklist

#### PR


#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

