### PR TITLE
fix: x-ray pixel spacing calibration

### DIFF
--- a/platform/core/src/classes/MetadataProvider.ts
+++ b/platform/core/src/classes/MetadataProvider.ts
@@ -1,5 +1,6 @@
 import queryString from 'query-string';
 import dicomParser from 'dicom-parser';
+import { utilities } from '@cornerstonejs/core';
 import { imageIdToURI } from '../utils';
 import getPixelSpacingInformation from '../utils/metadataProvider/getPixelSpacingInformation';
 import DicomMetadataStore from '../services/DicomMetadataStore';
@@ -7,6 +8,7 @@ import fetchPaletteColorLookupTableData from '../utils/metadataProvider/fetchPal
 import toNumber from '../utils/toNumber';
 import combineFrameInstance from '../utils/combineFrameInstance';
 import formatPN from '../utils/formatPN';
+const { calibratedPixelSpacingMetadataProvider } = utilities;
 
 class MetadataProvider {
   private readonly imageURIToUIDs: Map<string, any> = new Map();
@@ -531,6 +533,11 @@ const WADO_IMAGE_LOADER = {
     let imageOrientationPatient;
     if (PixelSpacing) {
       [rowPixelSpacing, columnPixelSpacing] = PixelSpacing;
+      calibratedPixelSpacingMetadataProvider.add(instance.imageId, {
+        rowPixelSpacing: parseFloat(PixelSpacing[0]),
+        columnPixelSpacing: parseFloat(PixelSpacing[1]),
+        type: null,
+      });
     } else {
       rowPixelSpacing = columnPixelSpacing = 1;
       usingDefaultValues = true;


### PR DESCRIPTION
### Context

Fixes: https://github.com/OHIF/Viewers/issues/4921

But depends on https://github.com/cornerstonejs/cornerstone3D/pull/1966 being merged first. Also need to update packages after it's merged.

### Changes & Results

Before:
![image](https://github.com/user-attachments/assets/2fdc25d0-ee19-47cd-804d-cc9442aa6458)

After:
![image](https://github.com/user-attachments/assets/b2c529d6-ee4a-4190-883a-620550d96720)


### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] OS: <!--[e.g. Windows 10, macOS 10.15.4]-->
- [] Node version: <!--[e.g. 18.16.1]-->
- [] Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
