### PR TITLE
fix: make datasource selection work

### DIFF
--- a/extensions/default/src/customizations/reportDialogCustomization.tsx
+++ b/extensions/default/src/customizations/reportDialogCustomization.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useMemo, useState } from 'react';
-import { InputDialog, cn } from '@ohif/ui-next';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { InputDialog } from '@ohif/ui-next';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@ohif/ui-next';
 import { useSystem } from '@ohif/core';
 
@@ -54,19 +54,19 @@ function ReportDialog({ dataSources, hide, onSave, onCancel }: ReportDialogProps
     setReportName(newReportName);
   }, [selectedSeries, seriesOptions]);
 
-  const handleSave = () => {
+  const handleSave = useCallback(() => {
     onSave({
       reportName,
       dataSource: selectedDataSource,
       series: selectedSeries,
     });
     hide();
-  };
+  }, [selectedDataSource, selectedSeries, reportName, hide, onSave]);
 
-  const handleCancel = () => {
+  const handleCancel = useCallback(() => {
     onCancel();
     hide();
-  };
+  }, [onCancel, hide]);
 
   const showDataSourceSelect = dataSources?.length > 1;
 

--- a/extensions/default/src/utils/promptSaveReport.tsx
+++ b/extensions/default/src/utils/promptSaveReport.tsx
@@ -40,7 +40,7 @@ async function promptSaveReport({ servicesManager, commandsManager, extensionMan
     });
 
     if (promptResult.action === PROMPT_RESPONSES.CREATE_REPORT) {
-      const dataSources = extensionManager.getDataSources();
+      const dataSources = extensionManager.getDataSources(promptResult.dataSourceName);
       const dataSource = dataSources[0];
       const measurementData = measurementService.getMeasurements(measurementFilter);
 


### PR DESCRIPTION
### Context

Datasource selection is not working when saving a SR. Instead it is always saving to the active datasource. 

This PR will accomplish the following:

1. Now the datasource selection will work and OHIF will attempt to save to the selected datasource
2. The first suggestions will always be the active datasource for a better UX
3. Improve naming of the `activeDatasource` private variable inside the ExtensionManager, which actually representes only the name of the active datasource.

### Changes & Results

Before:

https://github.com/user-attachments/assets/52001fbe-1eda-478e-ab16-cef8b0195183


After:

https://github.com/user-attachments/assets/ba2f136c-3ce9-4146-804e-8daab964e544



### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] OS: <!--[e.g. Windows 10, macOS 10.15.4]-->
- [] Node version: <!--[e.g. 18.16.1]-->
- [] Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
