### PR TITLE
fix(dicomWebClient): use public getter for activeDataSourceName instead of accessing private property

### DIFF
--- a/extensions/dicom-microscopy/src/utils/dicomWebClient.ts
+++ b/extensions/dicom-microscopy/src/utils/dicomWebClient.ts
@@ -11,7 +11,7 @@ import { StaticWadoClient } from '@ohif/extension-default';
  */
 export default function getDicomWebClient({ extensionManager, servicesManager }: withAppTypes) {
   const dataSourceConfig = window.config.dataSources.find(
-    ds => ds.sourceName === extensionManager.activeDataSource
+    ds => ds.sourceName === extensionManager.activeDataSourceName
   );
   const { userAuthenticationService } = servicesManager.services;
 
@@ -28,7 +28,7 @@ export default function getDicomWebClient({ extensionManager, servicesManager }:
   const client = new StaticWadoClient(wadoConfig);
   client.wadoURL = wadoConfig.url;
 
-  if (extensionManager.activeDataSource === 'dicomlocal') {
+  if (extensionManager.activeDataSourceName === 'dicomlocal') {
     /**
      * For local data source, override the retrieveInstanceFrames() method of the
      * dicomweb-client to retrieve image data from memory cached metadata.

--- a/platform/core/src/extensions/ExtensionManager.ts
+++ b/platform/core/src/extensions/ExtensionManager.ts
@@ -87,7 +87,7 @@ export default class ExtensionManager extends PubSubService {
   };
   private dataSourceMap: Record<string, any>;
   private dataSourceDefs: Record<string, any>;
-  private activeDataSourceName: string;
+  private _activeDataSourceName: string;
 
   constructor({
     commandsManager,
@@ -115,20 +115,20 @@ export default class ExtensionManager extends PubSubService {
     this.dataSourceMap = {};
     this.dataSourceDefs = {};
     this.defaultDataSourceName = appConfig.defaultDataSourceName;
-    this.activeDataSourceName = appConfig.defaultDataSourceName;
+    this._activeDataSourceName = appConfig.defaultDataSourceName;
     this.peerImport = appConfig.peerImport;
   }
 
   public setActiveDataSource(dataSource: string): void {
-    if (this.activeDataSourceName === dataSource) {
+    if (this._activeDataSourceName === dataSource) {
       return;
     }
 
-    this.activeDataSourceName = dataSource;
+    this._activeDataSourceName = dataSource;
 
     this._broadcastEvent(
       ExtensionManager.EVENTS.ACTIVE_DATA_SOURCE_CHANGED,
-      this.dataSourceDefs[this.activeDataSourceName]
+      this.dataSourceDefs[this._activeDataSourceName]
     );
   }
 
@@ -373,7 +373,7 @@ export default class ExtensionManager extends PubSubService {
   getDataSources = dataSourceName => {
     if (!dataSourceName) {
       // Default to the activeDataSource
-      dataSourceName = this.activeDataSourceName;
+      dataSourceName = this._activeDataSourceName;
     }
 
     // Note: this currently uses the data source name, which feels weird...
@@ -385,7 +385,7 @@ export default class ExtensionManager extends PubSubService {
   };
 
   getActiveDataSource = () => {
-    return this.dataSourceMap[this.activeDataSourceName];
+    return this.dataSourceMap[this._activeDataSourceName];
   };
 
   /**
@@ -398,7 +398,7 @@ export default class ExtensionManager extends PubSubService {
   getDataSourceDefinition = dataSourceName => {
     if (dataSourceName === undefined) {
       // Default to the activeDataSource
-      dataSourceName = this.activeDataSourceName;
+      dataSourceName = this._activeDataSourceName;
     }
 
     return this.dataSourceDefs[dataSourceName];
@@ -408,7 +408,7 @@ export default class ExtensionManager extends PubSubService {
    * Gets the data source definition for the active data source.
    */
   getActiveDataSourceDefinition = () => {
-    return this.getDataSourceDefinition(this.activeDataSourceName);
+    return this.getDataSourceDefinition(this._activeDataSourceName);
   };
 
   /**
@@ -425,16 +425,18 @@ export default class ExtensionManager extends PubSubService {
     const inactiveDataSourceNames = Object.keys(this.dataSourceMap).filter(ds => {
       const configuration = this.dataSourceDefs[ds]?.configuration;
       const isNotActiveDataSource =
-        this.dataSourceDefs[ds].sourceName !== this.activeDataSourceName;
+        this.dataSourceDefs[ds].sourceName !== this._activeDataSourceName;
       const supportsStowOrWado = configuration?.supportsStow ?? configuration?.wadoRoot;
       return supportsStowOrWado && isNotActiveDataSource;
     });
 
-    const allDatasourcesForUI = [this.activeDataSourceName, ...inactiveDataSourceNames].map(ds => ({
-      value: ds,
-      label: ds,
-      placeHolder: ds,
-    }));
+    const allDatasourcesForUI = [this._activeDataSourceName, ...inactiveDataSourceNames].map(
+      ds => ({
+        value: ds,
+        label: ds,
+        placeHolder: ds,
+      })
+    );
 
     return allDatasourcesForUI;
   };
@@ -558,7 +560,7 @@ export default class ExtensionManager extends PubSubService {
     dataSourceDef.configuration = dataSourceConfiguration;
     this._createDataSourceInstance(dataSourceDef);
 
-    if (this.activeDataSourceName === dataSourceName) {
+    if (this._activeDataSourceName === dataSourceName) {
       // When the active data source is changed/set, fire an event to indicate that its configuration has changed.
       this._broadcastEvent(ExtensionManager.EVENTS.ACTIVE_DATA_SOURCE_CHANGED, dataSourceDef);
     }
@@ -648,6 +650,10 @@ export default class ExtensionManager extends PubSubService {
 
   public get appConfig() {
     return this._appConfig;
+  }
+
+  public get activeDataSourceName() {
+    return this._activeDataSourceName;
   }
 }
 


### PR DESCRIPTION
### Context

The `dicomWebClient.ts` file was directly accessing a private property (named `activeDataSource` in the past, but recently renamed to `activeDataSourceName`) from the `ExtensionsManager`. This private access caused issues in certain features, such as microscopy mode which was broken.

This PR resolves the issue by introducing a public getter for `activeDataSourceName` in `ExtensionsManager` and updates `dicomWebClient` to use the getter, ensuring proper encapsulation and avoiding direct access to internal properties.

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] OS: <!--[e.g. Windows 10, macOS 10.15.4]-->
- [] Node version: <!--[e.g. 18.16.1]-->
- [] Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
