### PR TITLE
wip-feat(renderingEngine): per viewport rendering engine flag

### DIFF
--- a/extensions/cornerstone-dynamic-volume/src/panels/PanelGenerateImage.tsx
+++ b/extensions/cornerstone-dynamic-volume/src/panels/PanelGenerateImage.tsx
@@ -171,7 +171,7 @@ export default function PanelGenerateImage({ servicesManager, commandsManager }:
       commandsManager.runCommand('updateVolumeData', {
         volume: computedVolume,
       });
-      cornerstoneViewportService.getRenderingEngine().render();
+      cornerstoneViewportService.getRenderingEngine(activeViewportId).render();
       renderGeneratedImage(computedDisplaySet);
     }
   }

--- a/extensions/cornerstone/src/index.tsx
+++ b/extensions/cornerstone/src/index.tsx
@@ -153,8 +153,10 @@ const cornerstoneExtension: Types.Extensions.Extension = {
    * @param configuration.csToolsConfig - Passed directly to `initCornerstoneTools`
    */
   preRegistration: async function (props: Types.Extensions.ExtensionParams): Promise<void> {
-    const { servicesManager, serviceProvidersManager } = props;
-    servicesManager.registerService(CornerstoneViewportService.REGISTRATION);
+    const { servicesManager, serviceProvidersManager, appConfig } = props;
+    servicesManager.registerService(CornerstoneViewportService.REGISTRATION, {
+      appConfig,
+    });
     servicesManager.registerService(ToolGroupService.REGISTRATION);
     servicesManager.registerService(SyncGroupService.REGISTRATION);
     servicesManager.registerService(SegmentationService.REGISTRATION);

--- a/extensions/cornerstone/src/services/ToolGroupService/ToolGroupService.ts
+++ b/extensions/cornerstone/src/services/ToolGroupService/ToolGroupService.ts
@@ -106,7 +106,7 @@ export default class ToolGroupService {
   }
 
   public getToolGroupForViewport(viewportId: string): Types.IToolGroup | void {
-    const renderingEngine = this.cornerstoneViewportService.getRenderingEngine();
+    const renderingEngine = this.cornerstoneViewportService.getRenderingEngine(viewportId);
     return ToolGroupManager.getToolGroupForViewport(viewportId, renderingEngine.id);
   }
 

--- a/extensions/cornerstone/src/services/ViewportService/CornerstoneViewportService.ts
+++ b/extensions/cornerstone/src/services/ViewportService/CornerstoneViewportService.ts
@@ -80,7 +80,7 @@ class CornerstoneViewportService extends PubSubService implements IViewportServi
     this.viewportGridResizeObserver = null;
     this.servicesManager = servicesManager;
     this.perViewportRenderingEngine = configuration?.appConfig?.perViewportRenderingEngine;
-    this._configureServiceFunctions();
+    //this._configureServiceFunctions();
   }
   hangingProtocolService: unknown;
   viewportsInfo: unknown;

--- a/extensions/cornerstone/src/services/ViewportService/CornerstoneViewportService.ts
+++ b/extensions/cornerstone/src/services/ViewportService/CornerstoneViewportService.ts
@@ -11,6 +11,7 @@ import {
   cache,
   Enums as csEnums,
   BaseVolumeViewport,
+  getRenderingEngines,
 } from '@cornerstonejs/core';
 
 import { utilities as csToolsUtils, Enums as csToolsEnums } from '@cornerstonejs/tools';
@@ -246,23 +247,11 @@ class CornerstoneViewportService extends PubSubService implements IViewportServi
     this._removeResizeObserver();
     this.viewportGridResizeObserver = null;
 
-    // Destroy all stack rendering engines
-    this.stackRenderingEngines.forEach(renderingEngine => {
-      try {
-        renderingEngine.destroy?.();
-      } catch (e) {
-        console.warn('Stack rendering engine not destroyed', e);
-      }
-    });
+    const renderingEngines = getRenderingEngines();
 
-    // Destroy the shared volume rendering engine
-    if (this.sharedVolumeRenderingEngine) {
-      try {
-        this.sharedVolumeRenderingEngine.destroy?.();
-      } catch (e) {
-        console.warn('Shared volume rendering engine not destroyed', e);
-      }
-    }
+    renderingEngines.forEach(renderingEngine => {
+      renderingEngine.destroy?.();
+    });
 
     this.stackRenderingEngines.clear();
     this.sharedVolumeRenderingEngine = null;

--- a/extensions/cornerstone/src/utils/CornerstoneViewportDownloadForm.tsx
+++ b/extensions/cornerstone/src/utils/CornerstoneViewportDownloadForm.tsx
@@ -47,7 +47,7 @@ const CornerstoneViewportDownloadForm = ({
   const { viewportId: activeViewportId, renderingEngineId } =
     getEnabledElement(activeViewportElement);
 
-  const renderingEngine = cornerstoneViewportService.getRenderingEngine();
+  const renderingEngine = cornerstoneViewportService.getRenderingEngine(activeViewportId);
   const toolGroup = ToolGroupManager.getToolGroupForViewport(activeViewportId, renderingEngineId);
 
   useEffect(() => {

--- a/extensions/measurement-tracking/src/viewports/TrackedCornerstoneViewport.tsx
+++ b/extensions/measurement-tracking/src/viewports/TrackedCornerstoneViewport.tsx
@@ -107,7 +107,7 @@ function TrackedCornerstoneViewport(
         },
       });
 
-      cornerstoneViewportService.getRenderingEngine().renderViewport(viewportId);
+      cornerstoneViewportService.getRenderingEngine(viewportId).renderViewport(viewportId);
 
       return;
     }
@@ -118,7 +118,7 @@ function TrackedCornerstoneViewport(
       },
     });
 
-    cornerstoneViewportService.getRenderingEngine().renderViewport(viewportId);
+    cornerstoneViewportService.getRenderingEngine(viewportId).renderViewport(viewportId);
 
     return () => {
       annotation.config.style.setViewportToolStyles(viewportId, {});

--- a/package.json
+++ b/package.json
@@ -129,5 +129,6 @@
     "sharp": "^0.32.6",
     "rollup": "2.79.2",
     "body-parser": "1.20.3"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/platform/app/public/config/default.js
+++ b/platform/app/public/config/default.js
@@ -275,6 +275,7 @@ window.config = {
     // Could use services manager here to bring up a dialog/modal if needed.
     console.warn('test, navigate to https://ohif.org/');
   },
+  perViewportRenderingEngine: false,
   // whiteLabeling: {
   //   createLogoComponentFn: function (React) {
   //     return React.createElement(

--- a/platform/app/public/config/netlify.js
+++ b/platform/app/public/config/netlify.js
@@ -158,6 +158,7 @@ window.config = {
     // Could use services manager here to bring up a dialog/modal if needed.
     console.warn('test, navigate to https://ohif.org/');
   },
+  perViewportRenderingEngine: false,
 };
 
 function waitForElement(selector, maxAttempts = 20, interval = 25) {


### PR DESCRIPTION
issues:

- cornerstone3D tools that assume a single rendering engine, like some synchronizers, reference lines tool etc
- max webgl active contexts is 16, so 16 viewports only
- volume viewports need to share the same engine