### PR TITLE
Improve unsupported displayset messages

### DIFF
--- a/extensions/default/src/getDisplaySetsFromUnsupportedSeries.js
+++ b/extensions/default/src/getDisplaySetsFromUnsupportedSeries.js
@@ -6,8 +6,20 @@ import { DisplaySetMessage, DisplaySetMessageList } from '@ohif/core';
 export default function getDisplaySetsFromUnsupportedSeries(instances) {
   const imageSet = new ImageSet(instances);
   const messages = new DisplaySetMessageList();
-  messages.addMessage(DisplaySetMessage.CODES.UNSUPPORTED_DISPLAYSET);
   const instance = instances[0];
+
+  if (!instances.length) {
+    messages.addMessage(DisplaySetMessage.CODES.NO_VALID_INSTANCES);
+  } else {
+    const sopClassUid = instance.SOPClassUID;
+    if (sopClassUid) {
+      messages.addMessage(DisplaySetMessage.CODES.UNSUPPORTED_SOP_CLASS_UID, {
+        sopClassUid,
+      });
+    } else {
+      messages.addMessage(DisplaySetMessage.CODES.MISSING_SOP_CLASS_UID);
+    }
+  }
 
   imageSet.setAttributes({
     displaySetInstanceUID: imageSet.uid, // create a local alias for the imageSet UID

--- a/platform/core/src/services/DisplaySetService/DisplaySetMessage.ts
+++ b/platform/core/src/services/DisplaySetService/DisplaySetMessage.ts
@@ -1,8 +1,12 @@
 /**
- * Defines a displaySet message, that could be any pf the potential problems of a displaySet
+ * Defines a displaySet message, that could be any pf the potential problems of a displaySet.
+ *
+ * @property {number} id - message ID.
+ * @property {Record<string, any>} args - message arguments, will be passed to the translation function when the message is rendered.
  */
 class DisplaySetMessage {
   id: number;
+  args: Record<string, any>;
   static CODES = {
     NO_VALID_INSTANCES: 1,
     NO_POSITION_INFORMATION: 2,
@@ -17,10 +21,13 @@ class DisplaySetMessage {
     INCONSISTENT_ORIENTATIONS: 11,
     INCONSISTENT_POSITION_INFORMATION: 12,
     UNSUPPORTED_DISPLAYSET: 13,
+    UNSUPPORTED_SOP_CLASS_UID: 14,
+    MISSING_SOP_CLASS_UID: 15,
   };
 
-  constructor(id: number) {
+  constructor(id: number, args: Record<string, any> = {}) {
     this.id = id;
+    this.args = args;
   }
 }
 /**
@@ -29,8 +36,8 @@ class DisplaySetMessage {
 class DisplaySetMessageList {
   messages = [];
 
-  public addMessage(messageId: number): void {
-    const message = new DisplaySetMessage(messageId);
+  public addMessage(messageId: number, args: Record<string, any> = {}): void {
+    const message = new DisplaySetMessage(messageId, args);
     this.messages.push(message);
   }
 
@@ -43,7 +50,7 @@ class DisplaySetMessageList {
   }
 
   public includesAllMessages(messageIdList: number[]): boolean {
-    return messageIdList.every(messageId => this.include(messageId));
+    return messageIdList.every(messageId => this.includesMessage(messageId));
   }
 }
 

--- a/platform/i18n/src/locales/en-US/Messages.json
+++ b/platform/i18n/src/locales/en-US/Messages.json
@@ -12,5 +12,7 @@
   "10": "Display set has frames with inconsistent number of components.",
   "11": "Display set has frames with inconsistent orientations.",
   "12": "Display set has inconsistent position information.",
-  "13": "Unsupported display set."
+  "13": "Unsupported display set.",
+  "14": "SOP Class UID {{ sopClassUid }} is not supported.",
+  "15": "Display Set is missing a SOP Class UID. Please check the file."
 }


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

We do not display a descriptive message to users when they attempt to load an image from an unsupported SOP Class UID, or when the image lacks a SOP Class UID in some user data, even though it is a required tag. Currently, the only indication users receive in such cases is a brief warning: "Unsupported display set."

![Image](https://github.com/user-attachments/assets/100a9465-ecf4-4878-a8c1-3b07ede2f1db)

This PR is incorporated by [FlyWheel.io](https://flywheel.io/)

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

Now message indicates the image is loaded from an unsupported SOP Class

![image](https://github.com/user-attachments/assets/82ae1c4b-2b5a-4c0f-8815-efb096d91ee8)

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] OS: <!--[e.g. Windows 10, macOS 10.15.4]--> Linux x86_64
- [x] Node version: <!--[e.g. 18.16.1]--> 18.20.5
- [x] Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]-->Chrome 134.0.0

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
