### PR TITLE
fix(NotFoundStudy): Fixed the viewer not-found page when showStudyList: false

### DIFF
--- a/platform/app/src/routes/index.tsx
+++ b/platform/app/src/routes/index.tsx
@@ -12,6 +12,7 @@ import buildModeRoutes from './buildModeRoutes';
 import PrivateRoute from './PrivateRoute';
 import PropTypes from 'prop-types';
 import { routerBase, routerBasename } from '../utils/publicUrl';
+import { useAppConfig } from '@state';
 
 const NotFoundServer = ({
   message = 'Unable to query for studies at this time. Check your data source configuration or network connection',
@@ -30,19 +31,20 @@ NotFoundServer.propTypes = {
 };
 
 const NotFoundStudy = () => {
+  const [appConfig] = useAppConfig();
+  const { showStudyList } = appConfig;
+
   return (
     <div className="absolute flex h-full w-full items-center justify-center text-white">
       <div>
         <h4>
-          One or more of the requested studies are not available at this time. Return to the{' '}
-          <Link
-            className="text-primary-light"
-            to={'/'}
-          >
-            study list
-          </Link>{' '}
-          to select a different study to view.
+          One or more of the requested studies are not available at this time.
         </h4>
+        {showStudyList && (
+          <p className="mt-2">
+            Return to the <Link className="text-primary-light" to="/">study list</Link> to select a different study to view.
+          </p>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

When `showStudyList` is set to `false`, the not found boundary redirects to an inexisting study list. 
I've fixed the code so that it only redirects if `showStudyList` is `true`

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

#### When `showStudyList: true` 
<img width="817" alt="image" src="https://github.com/user-attachments/assets/c2d40d67-5df4-4b4a-ae84-adb088d0d17c" />

#### When `showStudyList: false`
<img width="791" alt="image" src="https://github.com/user-attachments/assets/315b7d8f-e583-4909-95e5-4234665e7eb6" />


### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

You can test it by visiting http://localhost:3000/notfoundstudy, in `default.js` you toggle `showStudyList` between true and false.

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals. 

#### Tested Environment

- [x] OS: MacOS <!--[e.g. Windows 10, macOS 10.15.4]-->
- [x] Node version: v20.18.2
- [x] Browser:  Google Chrome 135.0.7049.11

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
