### PR TITLE
feat(viewport): Added getter for presentation id provider.

### DIFF
--- a/platform/core/src/services/ViewportGridService/ViewportGridService.ts
+++ b/platform/core/src/services/ViewportGridService/ViewportGridService.ts
@@ -1,5 +1,10 @@
 import { PubSubService } from '../_shared/pubSubServiceInterface';
 
+type PresentationIdProvider = (
+  id: string,
+  { viewport, viewports, isUpdatingSameViewport }
+) => unknown;
+
 class ViewportGridService extends PubSubService {
   public static readonly EVENTS = {
     ACTIVE_VIEWPORT_ID_CHANGED: 'event::activeviewportidchanged',
@@ -20,10 +25,7 @@ class ViewportGridService extends PubSubService {
 
   serviceImplementation = {};
   servicesManager: AppTypes.ServicesManager;
-  presentationIdProviders: Map<
-    string,
-    (id: string, { viewport, viewports, isUpdatingSameViewport, servicesManager }) => unknown
-  >;
+  presentationIdProviders: Map<string, PresentationIdProvider>;
 
   constructor({ servicesManager }) {
     super(ViewportGridService.EVENTS);
@@ -32,11 +34,15 @@ class ViewportGridService extends PubSubService {
     this.presentationIdProviders = new Map();
   }
 
-  public addPresentationIdProvider(
-    id: string,
-    provider: (id: string, { viewport, viewports, isUpdatingSameViewport }) => unknown
-  ): void {
+  public addPresentationIdProvider(id: string, provider: PresentationIdProvider): void {
     this.presentationIdProviders.set(id, provider);
+  }
+
+  /**
+   * Gets the presentation provider with the given id.
+   */
+  public getPresentationIdProvider(id: string): PresentationIdProvider {
+    return this.presentationIdProviders.get(id);
   }
 
   public setIsReferenceViewable(viewportId: string, isReferenceViewable: boolean): void {


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

This allows for creating a decorated version of an existing provider.

Take for example the following snippet of code that replaces the base, cornerstone seg presentation id provider to limit which viewports display segmentations.

```
        const segmentationPresentationTypeId = 'segmentationPresentationId';

        baseSegPresentationIdProvider = viewportGridService.getPresentationIdProvider(
          segmentationPresentationTypeId
        );
        const mySegPresentationIdProvider = (
          id: string,
          props: {
            viewport: AppTypes.ViewportGrid.Viewport;
            viewports: AppTypes.ViewportGrid.Viewports;
            isUpdatingSameViewport: boolean;
            servicesManager: AppTypes.ServicesManager;
          }
        ): string | undefined => {
          if (id !== segmentationPresentationTypeId) {
            return;
          }

          const baseSegPresentationId = baseSegPresentationIdProvider(id, props);

          const { viewport } = props;
          const {viewportId} = viewport;

          if (viewportId === 'doNotShowSegs') {
            return `noSegs&${baseSegPresentationId}`;
          } else {
            return baseSegPresentationId;
          }
        };

        viewportGridService.addPresentationIdProvider(
          segmentationPresentationTypeId,
          mySegPresentationIdProvider
        );

```
<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

Simply added a getter for the presentation id provider.

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

N/A

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] OS: Windows 11<!--[e.g. Windows 10, macOS 10.15.4]-->
- [x] Node version: 21.1.0<!--[e.g. 18.16.1]-->
- [x] Browser: Chrome 136.0.7103.93
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
