### PR TITLE
feat(commandsModule): Added optional viewportId to flip/rotate commands

### DIFF
--- a/extensions/cornerstone/src/commandsModule.ts
+++ b/extensions/cornerstone/src/commandsModule.ts
@@ -29,6 +29,7 @@ import {
 import { vec3, mat4 } from 'gl-matrix';
 import toggleImageSliceSync from './utils/imageSliceSync/toggleImageSliceSync';
 import { getFirstAnnotationSelected } from './utils/measurementServiceMappings/utils/selection';
+import { getViewportEnabledElement } from './utils/getViewportEnabledElement';
 import getActiveViewportEnabledElement from './utils/getActiveViewportEnabledElement';
 import toggleVOISliceSync from './utils/toggleVOISliceSync';
 import { usePositionPresentationStore, useSegmentationPresentationStore } from './stores';
@@ -108,6 +109,10 @@ function commandsModule({
 
   function _getActiveViewportEnabledElement() {
     return getActiveViewportEnabledElement(viewportGridService);
+  }
+
+  function _getViewportEnabledElement(viewportId: string) {
+    return getViewportEnabledElement(viewportId);
   }
 
   function _getActiveViewportToolGroupId() {
@@ -881,8 +886,15 @@ function commandsModule({
         });
       }
     },
-    rotateViewport: ({ rotation }) => {
-      const enabledElement = _getActiveViewportEnabledElement();
+    rotateViewport: ({ rotation, viewportId }) => {
+      let enabledElement;
+
+      if (viewportId && viewportId !== 'currentlyActive') {
+        enabledElement = _getViewportEnabledElement(viewportId);
+      } else {
+        enabledElement = _getActiveViewportEnabledElement();
+      }
+
       if (!enabledElement) {
         return;
       }
@@ -905,8 +917,13 @@ function commandsModule({
         viewport.render();
       }
     },
-    flipViewportHorizontal: () => {
-      const enabledElement = _getActiveViewportEnabledElement();
+    flipViewportHorizontal: ({ viewportId }) => {
+      let enabledElement;
+      if (viewportId && viewportId !== 'currentlyActive') {
+        enabledElement = _getViewportEnabledElement(viewportId);
+      } else {
+        enabledElement = _getActiveViewportEnabledElement();
+      }
 
       if (!enabledElement) {
         return;
@@ -918,8 +935,13 @@ function commandsModule({
       viewport.setCamera({ flipHorizontal: !flipHorizontal });
       viewport.render();
     },
-    flipViewportVertical: () => {
-      const enabledElement = _getActiveViewportEnabledElement();
+    flipViewportVertical: ({ viewportId }) => {
+      let enabledElement;
+      if (viewportId && viewportId !== 'currentlyActive') {
+        enabledElement = _getViewportEnabledElement(viewportId);
+      } else {
+        enabledElement = _getActiveViewportEnabledElement();
+      }
 
       if (!enabledElement) {
         return;
@@ -1954,11 +1976,11 @@ function commandsModule({
     },
     rotateViewportCW: {
       commandFn: actions.rotateViewport,
-      options: { rotation: 90 },
+      options: { rotation: 90, viewportId: 'currentlyActive' },
     },
     rotateViewportCCW: {
       commandFn: actions.rotateViewport,
-      options: { rotation: -90 },
+      options: { rotation: -90, viewportId: 'currentlyActive' },
     },
     incrementActiveViewport: {
       commandFn: actions.changeActiveViewport,
@@ -1969,9 +1991,11 @@ function commandsModule({
     },
     flipViewportHorizontal: {
       commandFn: actions.flipViewportHorizontal,
+      options: { viewportId: 'currentlyActive' },
     },
     flipViewportVertical: {
       commandFn: actions.flipViewportVertical,
+      options: { viewportId: 'currentlyActive' },
     },
     invertViewport: {
       commandFn: actions.invertViewport,

--- a/extensions/cornerstone/src/utils/getActiveViewportEnabledElement.ts
+++ b/extensions/cornerstone/src/utils/getActiveViewportEnabledElement.ts
@@ -1,11 +1,8 @@
-import { getEnabledElement } from '@cornerstonejs/core';
 import { IEnabledElement } from '@cornerstonejs/core/types';
 
-import { getEnabledElement as OHIFgetEnabledElement } from '../state';
+import { getViewportEnabledElement } from './getViewportEnabledElement';
 
 export default function getActiveViewportEnabledElement(viewportGridService): IEnabledElement {
   const { activeViewportId } = viewportGridService.getState();
-  const { element } = OHIFgetEnabledElement(activeViewportId) || {};
-  const enabledElement = getEnabledElement(element);
-  return enabledElement;
+  return getViewportEnabledElement(activeViewportId);
 }

--- a/extensions/cornerstone/src/utils/getViewportEnabledElement.ts
+++ b/extensions/cornerstone/src/utils/getViewportEnabledElement.ts
@@ -1,0 +1,8 @@
+import { getEnabledElement } from '@cornerstonejs/core';
+import { getEnabledElement as OHIFgetEnabledElement } from '../state';
+
+export function getViewportEnabledElement(viewportId: string) {
+  const { element } = OHIFgetEnabledElement(viewportId) || {};
+  const enabledElement = getEnabledElement(element);
+  return enabledElement;
+}


### PR DESCRIPTION

<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

I've added an optional viewportId to the rotate/flip commands, so that specific views can be controlled in a gridpane. 

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

https://github.com/user-attachments/assets/9c13a2e7-480f-4369-9d37-1eeb4b3a626a

Added optional viewportId to the rotate/flip commands 


<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->



### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

See the attached video, you can test by calling rotate and flip command from the console 

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] OS: MacOS <!--[e.g. Windows 10, macOS 10.15.4]-->
- [x] Node version: v20.18.2
- [x] Browser:  Google Chrome 135.0.7049.11
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
