### PR TITLE
feat(hooks): Added useCustomization hook

### DIFF
--- a/platform/core/src/hooks/index.ts
+++ b/platform/core/src/hooks/index.ts
@@ -3,3 +3,4 @@ export * from './types';
 export * from './useViewportRef';
 export * from './useViewportSize';
 export * from './useViewportMousePosition';
+export * from './useCustomization';

--- a/platform/core/src/hooks/useCustomization.ts
+++ b/platform/core/src/hooks/useCustomization.ts
@@ -1,0 +1,59 @@
+import { useEffect, useState, useRef, useCallback } from 'react';
+import { useSystem } from '../contextProviders/SystemProvider';
+import type { Customization } from '../services/CustomizationService/types';
+
+/**
+ * Hook that subscribes to customization changes and triggers rerenders when they occur.
+ */
+export function useCustomization(customizationKey: string): Customization | undefined {
+  const { servicesManager } = useSystem();
+  const { customizationService } = servicesManager.services;
+
+  // Use a ref to store the key(s) for comparison
+  const keyRef = useRef(customizationKey);
+
+  const getCustomizationValue = useCallback(() => {
+    return customizationService.getCustomization(customizationKey);
+  }, [customizationKey, customizationService]);
+
+  // Initialize with current value
+  const [value, setValue] = useState(getCustomizationValue);
+
+  useEffect(() => {
+    // Check if keys have changed
+    const keysChanged = keyRef.current !== customizationKey;
+    if (keysChanged) {
+      keyRef.current = customizationKey;
+      setValue(getCustomizationValue());
+    }
+
+    // Handler for customization changes
+    const handleCustomizationChange = () => {
+      const newValue = getCustomizationValue();
+      setValue(newValue);
+    };
+
+    // Subscribe to all customization events
+    const subscriptions = [
+      customizationService.subscribe(
+        customizationService.EVENTS.MODE_CUSTOMIZATION_MODIFIED,
+        handleCustomizationChange
+      ),
+      customizationService.subscribe(
+        customizationService.EVENTS.GLOBAL_CUSTOMIZATION_MODIFIED,
+        handleCustomizationChange
+      ),
+      customizationService.subscribe(
+        customizationService.EVENTS.DEFAULT_CUSTOMIZATION_MODIFIED,
+        handleCustomizationChange
+      ),
+    ];
+
+    // Cleanup subscriptions on unmount or when keys change
+    return () => {
+      subscriptions.forEach(subscription => subscription.unsubscribe());
+    };
+  }, [customizationService, customizationKey, getCustomizationValue]);
+
+  return value;
+}

--- a/platform/core/src/services/CustomizationService/types.ts
+++ b/platform/core/src/services/CustomizationService/types.ts
@@ -9,6 +9,8 @@ export interface BaseCustomization extends Obj {
   description?: string;
   label?: string;
   commands?: Command[];
+  classnames?: string;
+  styles?: React.CSSProperties;
 }
 
 export interface LabelCustomization extends BaseCustomization {
@@ -25,6 +27,14 @@ export interface CommandCustomization extends BaseCustomization {
 
 export interface ComponentCustomization extends BaseCustomization {
   content: (...props: any) => React.JSX.Element;
+}
+
+export interface CSSClassnamesCustomization extends BaseCustomization {
+  classnames: string;
+}
+
+export interface CSSStylesCustomization extends BaseCustomization {
+  styles: React.CSSProperties;
 }
 
 export interface CallbackCustomization extends BaseCustomization {
@@ -45,6 +55,7 @@ export type Customization =
   | CommandCustomization
   | CodeCustomization
   | ComponentCustomization
+  | CSSClassnamesCustomization
   | CallbackCustomization;
 
 export default Customization;

--- a/platform/docs/docs/platform/hooks/index.md
+++ b/platform/docs/docs/platform/hooks/index.md
@@ -31,3 +31,6 @@ A React hook that calculates the maximum height for an element based on its posi
 
 ## [useSessionStorage](./useSessionStorage.md)
 A React hook that provides sessionStorage access with automatic JSON parsing/stringifying and an option to clear data when the page unloads.
+
+## [useCustomization](./useCustomization.md)
+A React hook that provides access to customization values and updates from the customization service, allowing components to reactively consume configuration changes.

--- a/platform/docs/docs/platform/hooks/useCustomization.md
+++ b/platform/docs/docs/platform/hooks/useCustomization.md
@@ -1,0 +1,74 @@
+---
+title: useCustomization
+summary: A React hook that provides reactive access to customization values from the customization service so UI components automatically reflect configuration changes.
+---
+
+# useCustomization
+
+The `useCustomization` hook lets your component access a customization value from the **Customization Service** and automatically re-render whenever that value changes in any scope (default, mode, or global).
+
+## Overview
+
+Pass the customization key (path) you are interested in, and the hook returns the current value.  Behind the scenes it subscribes to all customization-change events and updates state for you, keeping your UI in sync with configuration changes at runtime.
+
+Typical use-cases include:
+
+- Styling a component (e.g. thumbnail size, colours) via remote configuration.
+- Toggling feature flags that may be overridden by modes or global config.
+- Reading extension-defined defaults that a deployment may adapt.
+
+## Import
+
+```js
+import { useCustomization } from '@ohif/core';
+```
+
+## Usage
+
+```jsx
+function Thumbnail({ displaySetInstanceUID }) {
+  // The key format is up to the extension / app that registered it
+  const styles = useCustomization(`ui.thumbnail#${displaySetInstanceUID}`);
+
+  return (
+    <div style={styles?.container} className="thumbnail">
+      {/* ... */}
+    </div>
+  );
+}
+```
+
+If no customization is registered for the key, the hook returns `undefined` so you can fall back to defaults.
+
+## Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `customizationKey` | `string` | ✅ | A fully-qualified key or path identifying the customization value to retrieve (e.g. `studyBrowser.sortFunctions`, `ui.thumbnail#12345`). |
+
+## Returns
+
+`Customization | undefined`
+
+The current value stored under the provided key in the Customization Service, or `undefined` if none is registered.
+
+## Events
+
+The hook automatically re-subscribes and updates when any of the following Customization Service events fire:
+
+- `DEFAULT_CUSTOMIZATION_MODIFIED`
+- `MODE_CUSTOMIZATION_MODIFIED`
+- `GLOBAL_CUSTOMIZATION_MODIFIED`
+
+No manual subscription / cleanup is required – the hook handles it for you.
+
+## Implementation Details
+
+Internally the hook:
+
+1. Retrieves the `customizationService` from the `SystemProvider`.
+2. Fetches the current value with `getCustomization(customizationKey)`.
+3. Subscribes to all customization modification events and sets state when the value changes.
+4. Cleans up all subscriptions when the component is unmounted or the key changes.
+
+Since it stores the key in a `ref`, switching to a different key within the same component correctly triggers a fresh lookup and event subscription.

--- a/platform/ui-next/src/components/Thumbnail/Thumbnail.tsx
+++ b/platform/ui-next/src/components/Thumbnail/Thumbnail.tsx
@@ -5,6 +5,8 @@ import { useDrag } from 'react-dnd';
 import { Icons } from '../Icons';
 import { DisplaySetMessageListTooltip } from '../DisplaySetMessageListTooltip';
 import { TooltipTrigger, TooltipContent, Tooltip } from '../Tooltip';
+import { useCustomization } from '@ohif/core';
+import { CSSStylesCustomization } from '@ohif/core/src/services/CustomizationService/types';
 
 /**
  * Display a thumbnail for a display set.
@@ -47,6 +49,10 @@ const Thumbnail = ({
 
   const [lastTap, setLastTap] = useState(0);
 
+  const thumbnailStylesCustomization = useCustomization(`ui.thumbnail#${displaySetInstanceUID}`) as
+    | CSSStylesCustomization
+    | undefined;
+
   const handleTouchEnd = e => {
     const currentTime = new Date().getTime();
     const tapLength = currentTime - lastTap;
@@ -65,6 +71,7 @@ const Thumbnail = ({
           'flex h-full w-full flex-col items-center justify-center gap-[2px] p-[4px]',
           isActive && 'bg-popover rounded'
         )}
+        style={thumbnailStylesCustomization?.styles}
       >
         <div className="h-[114px] w-[128px]">
           <div className="relative bg-black">


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

Added a `useCustomization` hook, which allows React components to read customization values, and re-render when they change. (e.g. via `setCustomizations()`) 

I've added an example customization for thumbnails. 
My use case was highlighting the borders via an AI tool. 

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

* Created useCustomization hook, with public documentation.
* Added customizations of type CSS classes and CSS styles. 
* Added a usage of useCustomization in `Thumbnail.tsx`, which uses modified styles for the displayset. 



https://github.com/user-attachments/assets/d0925e2b-98e1-4904-ab6d-e25e933cc9e6


<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

Can be tested with these console commands:
<img width="1032" alt="image" src="https://github.com/user-attachments/assets/23d354a6-869b-4dfd-83fc-63c2943658e8" />


### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] OS: MacOS <!--[e.g. Windows 10, macOS 10.15.4]-->
- [x] Node version: v20.18.2
- [x] Browser:  Google Chrome 135.0.7049.11
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
