### PR TITLE
fix(segmentation): Allow for debounced pub/sub events to be reliably cancelled when unsubscribed to.

### DIFF
--- a/extensions/cornerstone/src/index.tsx
+++ b/extensions/cornerstone/src/index.tsx
@@ -132,6 +132,10 @@ const cornerstoneExtension: Types.Extensions.Extension = {
   },
   getPanelModule,
   onModeExit: ({ servicesManager }: withAppTypes): void => {
+    unsubscriptions.forEach(unsubscribe => unsubscribe());
+    // Clear the unsubscriptions
+    unsubscriptions.length = 0;
+
     const { cineService, segmentationService } = servicesManager.services;
     // Empty out the image load and retrieval pools to prevent memory leaks
     // on the mode exits
@@ -150,10 +154,6 @@ const cornerstoneExtension: Types.Extensions.Extension = {
     useToggleOneUpViewportGridStore.getState().clearToggleOneUpViewportGridStore();
     useSegmentationPresentationStore.getState().clearSegmentationPresentationStore();
     segmentationService.removeAllSegmentations();
-
-    unsubscriptions.forEach(unsubscribe => unsubscribe());
-    // Clear the unsubscriptions
-    unsubscriptions.length = 0;
   },
 
   /**

--- a/extensions/cornerstone/src/services/SegmentationService/SegmentationService.ts
+++ b/extensions/cornerstone/src/services/SegmentationService/SegmentationService.ts
@@ -255,7 +255,7 @@ class SegmentationService extends PubSubService {
       this._onSegmentationAddedFromSource
     );
 
-    this.listeners = {};
+    this.reset();
   };
 
   public async addSegmentationRepresentation(

--- a/platform/core/src/services/_shared/pubSubServiceInterface.ts
+++ b/platform/core/src/services/_shared/pubSubServiceInterface.ts
@@ -54,7 +54,10 @@ function _unsubscribe(eventName, listenerId) {
 
   const listeners = this.listeners[eventName];
   if (Array.isArray(listeners)) {
-    this.listeners[eventName] = listeners.filter(({ id }) => id !== listenerId);
+    this.listeners[eventName] = listeners.filter(({ id, callback }) => {
+      callback?.clearDebounceTimeout?.();
+      return id !== listenerId;
+    });
   } else {
     this.listeners[eventName] = undefined;
   }
@@ -134,6 +137,13 @@ export class PubSubService {
   reset() {
     this.unsubscriptions.forEach(unsub => unsub());
     this.unsubscriptions = [];
+
+    Object.keys(this.listeners).forEach(eventName =>
+      this.listeners[eventName].forEach(({ callback }) => {
+        callback?.clearDebounceTimeout?.();
+      })
+    );
+    this.listeners = {};
   }
 
   /**

--- a/platform/core/src/utils/debounce.js
+++ b/platform/core/src/utils/debounce.js
@@ -2,9 +2,11 @@
 // be triggered. The function will be called after it stops being called for
 // N milliseconds. If `immediate` is passed, trigger the function on the
 // leading edge, instead of the trailing.
+// The callback function returned is assigned a clearDebounceTimeout function
+// that provides for clearing the timeout/debounced function so that it is not called.
 function debounce(func, wait, immediate) {
   var timeout;
-  return function () {
+  const callback = function () {
     var context = this,
       args = arguments;
     var later = function () {
@@ -20,6 +22,13 @@ function debounce(func, wait, immediate) {
       func.apply(context, args);
     }
   };
+
+  callback.clearDebounceTimeout = () => {
+    clearTimeout(timeout);
+    timeout = null;
+  };
+
+  return callback;
 }
 
 export default debounce;


### PR DESCRIPTION

<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context
See #5087.


<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results
The approach to fixing this bug was done in stages per se.

At first it was noticed that the callbacks where the exception was thrown were not being unsubscribed to in a timely manner. So the first logical step was to ensure they were unsubscribed to as the very first thing in the `onModeExit` call. This did NOTHING to fix the problem, however the code was left as in practice unsubscribing "earlier" is the right thing to do.

The next item noticed was that the `SegmentationService` that the callbacks listen to was blindly clearing all the listeners in its `destroy` method prior to the `unsubscribe` calls. In practice this  clearing of the listeners is equivalent to `unsubscribe` calls except of course if the callbacks are debounced and just so happen are queued when the listeners are cleared. This resulted in the `SegmentationService` calling `reset` on the pub/sub service. The `reset` was coded to now not only clear the listeners, but also cancel any pending/debounced callbacks.

For the most part this proved fruitful. However there was the odd/occasional callback still sneaking through and causing an exception. This was because once of the debounced callbacks was also doing some asynchronous work and then calling the `SegmentationService`. So in this case, the `reset`/`unsubscribe` was called during the asynchronous work. A guard/check was added after the asynchronous work in case the callback was unsubscribed during the asynchronous call.

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

See #5087 

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] OS: Windows 11<!--[e.g. Windows 10, macOS 10.15.4]-->
- [x] Node version: 20.9.0<!--[e.g. 18.16.1]-->
- [x] Browser: Chrome 137.0.7151.56
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
