### PR TITLE
fix(labeling): measurement labeling dialog was overwriting the entire measurement and breaking it

### DIFF
--- a/extensions/cornerstone/src/commandsModule.ts
+++ b/extensions/cornerstone/src/commandsModule.ts
@@ -432,7 +432,7 @@ function commandsModule({
       });
 
       if (val !== undefined && val !== null) {
-        measurementService.update(uid, { ...val }, true);
+        measurementService.update(uid, { ...measurement, label: val }, true);
       }
     },
     /**


### PR DESCRIPTION
### Context

The measurement update call was not passing in the existing measurement and just the label, leading to the measurement becoming just a label...

