### PR TITLE
fix(metadata): Update palette data handling for ArrayBuffer conversion

### DIFF
--- a/platform/core/src/utils/metadataProvider/fetchPaletteColorLookupTableData.js
+++ b/platform/core/src/utils/metadataProvider/fetchPaletteColorLookupTableData.js
@@ -13,12 +13,20 @@
  */
 export default function fetchPaletteColorLookupTableData(item, tag, descriptorTag) {
   const { PaletteColorLookupTableUID } = item;
-  const paletteData = item[tag];
+  let paletteData = item[tag];
   if (paletteData === undefined && PaletteColorLookupTableUID === undefined) {
     return;
   }
+  // Handle dicomfile loader
+  if (typeof paletteData === 'object' && paletteData[0] instanceof ArrayBuffer) {
+    // Convert ArrayBuffer to Uint8Array for processing
+    paletteData = {
+      InlineBinary: btoa(String.fromCharCode.apply(null, new Uint8Array(paletteData[0]))),
+    };
+  }
+
   // performance optimization - read UID and cache by UID
-  return _getPaletteColor(item[tag], item[descriptorTag]);
+  return _getPaletteColor(paletteData, item[descriptorTag]);
 }
 
 function _getPaletteColor(paletteColorLookupTableData, lutDescriptor) {

--- a/platform/core/src/utils/metadataProvider/fetchPaletteColorLookupTableData.js
+++ b/platform/core/src/utils/metadataProvider/fetchPaletteColorLookupTableData.js
@@ -30,9 +30,22 @@ function _getPaletteColor(paletteColorLookupTableData, lutDescriptor) {
   }
 
   const arrayBufferToPaletteColorLUT = arraybuffer => {
-    // Handle both ArrayBuffer and TypedArray inputs
-    const buffer = arraybuffer.buffer || arraybuffer;
-    const data = bits === 16 ? new Uint16Array(buffer) : new Uint8Array(buffer);
+    const data =
+      arraybuffer instanceof ArrayBuffer
+        ? bits === 16
+          ? new Uint16Array(arraybuffer)
+          : new Uint8Array(arraybuffer)
+        : bits === 16
+          ? new Uint16Array(
+              arraybuffer.buffer,
+              arraybuffer.byteOffset,
+              arraybuffer.byteLength / 2
+            )
+          : new Uint8Array(
+              arraybuffer.buffer,
+              arraybuffer.byteOffset,
+              arraybuffer.byteLength
+            );
     const lut = [];
 
     for (let i = 0; i < numLutEntries; i++) {

--- a/platform/core/src/utils/metadataProvider/fetchPaletteColorLookupTableData.js
+++ b/platform/core/src/utils/metadataProvider/fetchPaletteColorLookupTableData.js
@@ -13,20 +13,12 @@
  */
 export default function fetchPaletteColorLookupTableData(item, tag, descriptorTag) {
   const { PaletteColorLookupTableUID } = item;
-  let paletteData = item[tag];
+  const paletteData = item[tag];
   if (paletteData === undefined && PaletteColorLookupTableUID === undefined) {
     return;
   }
-  // Handle dicomfile loader
-  if (typeof paletteData === 'object' && paletteData[0] instanceof ArrayBuffer) {
-    // Convert ArrayBuffer to Uint8Array for processing
-    paletteData = {
-      InlineBinary: btoa(String.fromCharCode.apply(null, new Uint8Array(paletteData[0]))),
-    };
-  }
-
   // performance optimization - read UID and cache by UID
-  return _getPaletteColor(paletteData, item[descriptorTag]);
+  return _getPaletteColor(item[tag], item[descriptorTag]);
 }
 
 function _getPaletteColor(paletteColorLookupTableData, lutDescriptor) {
@@ -38,18 +30,15 @@ function _getPaletteColor(paletteColorLookupTableData, lutDescriptor) {
   }
 
   const arrayBufferToPaletteColorLUT = arraybuffer => {
+    // Handle both ArrayBuffer and TypedArray inputs
+    const buffer = arraybuffer.buffer || arraybuffer;
+    const data = bits === 16 ? new Uint16Array(buffer) : new Uint8Array(buffer);
     const lut = [];
 
-    if (bits === 16) {
-      let j = 0;
-      for (let i = 0; i < numLutEntries; i++) {
-        lut[i] = (arraybuffer[j++] + arraybuffer[j++]) << 8;
-      }
-    } else {
-      for (let i = 0; i < numLutEntries; i++) {
-        lut[i] = arraybuffer[i];
-      }
+    for (let i = 0; i < numLutEntries; i++) {
+      lut[i] = data[i];
     }
+
     return lut;
   };
 
@@ -59,10 +48,10 @@ function _getPaletteColor(paletteColorLookupTableData, lutDescriptor) {
 
   if (paletteColorLookupTableData.InlineBinary) {
     try {
-      const arraybuffer = Uint8Array.from(atob(paletteColorLookupTableData.InlineBinary), c =>
+      const uint8Array = Uint8Array.from(atob(paletteColorLookupTableData.InlineBinary), c =>
         c.charCodeAt(0)
       );
-      return (paletteColorLookupTableData.palette = arrayBufferToPaletteColorLUT(arraybuffer));
+      return (paletteColorLookupTableData.palette = arrayBufferToPaletteColorLUT(uint8Array));
     } catch (e) {
       console.log("Couldn't decode", paletteColorLookupTableData.InlineBinary, e);
       return undefined;


### PR DESCRIPTION
### Context

Image of photometric interpretation type "palette color" did not display properly.
 
Related issue:
https://github.com/OHIF/Viewers/issues/4642
https://github.com/OHIF/Viewers/issues/4775
https://github.com/OHIF/Viewers/issues/4881
https://github.com/OHIF/Viewers/issues/5012


### Changes & Results

This change is to handle palette data returned by the local datasource (file) loader.
The wado loaders did not need a change.
This cornerstone PR is required:
https://github.com/cornerstonejs/cornerstone3D/pull/2113


### Testing

Load an image with palette color data using the ../local url path.



<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes palette-color image rendering for the local file datasource by correctly handling both `ArrayBuffer` and `TypedArray` inputs in `arrayBufferToPaletteColorLUT`, and by replacing a clearly incorrect 16-bit byte-reconstruction formula with a proper `Uint16Array` view.

- **ArrayBuffer/TypedArray branching**: the new `instanceof ArrayBuffer` guard correctly routes plain buffers to the 2-argument `Uint16Array`/`Uint8Array` constructor and TypedArray inputs to the 3-argument form, preserving `byteOffset` for sub-view safety.
- **16-bit formula fix**: the old `(byte[j++] + byte[j++]) << 8` was arithmetically wrong (addition instead of bitwise OR, and the shift doubles the scale); the new code reads directly from a `Uint16Array`, which is correct per the DICOM LUT spec.
- **`InlineBinary` rename**: `arraybuffer` → `uint8Array` improves clarity for the base64-decoded path with no behavioural change.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is narrowly scoped to palette LUT parsing and correctly handles both ArrayBuffer and TypedArray inputs without affecting other code paths.

The logic change is straightforward: the old 16-bit formula was broken and the new Uint16Array view is the correct approach. The ArrayBuffer/TypedArray branch is guarded properly, the InlineBinary path stays inside a try-catch, and the retrieveBulkData path is unaffected in normal usage. No regressions are apparent for the 8-bit path or the WADO loaders.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| platform/core/src/utils/metadataProvider/fetchPaletteColorLookupTableData.js | Fixes palette LUT parsing by branching on ArrayBuffer vs TypedArray inputs and replacing a broken 16-bit byte-combination formula with a proper Uint16Array view |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["Improve arrayBufferToPaletteColorLUT fun..."](https://github.com/ohif/viewers/commit/f613ee3166476f58c6faef1d090c52bdaa2923f1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33235989)</sub>

<!-- /greptile_comment -->