### PR TITLE
fix(action-corners): check hideWhenDisabled at both the evaluator and prop levels

### DIFF
--- a/platform/core/src/services/ToolBarService/ToolbarService.ts
+++ b/platform/core/src/services/ToolBarService/ToolbarService.ts
@@ -310,11 +310,13 @@ export default class ToolbarService extends PubSubService {
           typeof props.evaluate === 'function'
             ? props.evaluate({ ...refreshProps, button })
             : undefined;
+        // Check hideWhenDisabled at both evaluateProps level and props level
+        const hideWhenDisabled = evaluateProps?.hideWhenDisabled || props.hideWhenDisabled;
         const updatedProps = {
           ...props,
           ...evaluated,
           disabled: evaluated?.disabled || false,
-          visible: evaluateProps?.hideWhenDisabled && evaluated?.disabled ? false : true,
+          visible: hideWhenDisabled && evaluated?.disabled ? false : true,
           className: evaluated?.className || '',
           isActive: evaluated?.isActive, // isActive will be undefined for buttons without this prop
         };


### PR DESCRIPTION
### Context

This change allows us to define hideWhenDisabled at the prop level in the case of having multiple evaluators
```ts
  {
    id: 'orientationMenu',
    uiType: 'ohif.viewportOrientationMenu',
    props: {
      label: 'Orientation',
      tooltip:
        'Change viewport orientation between axial, sagittal, coronal and acquisition planes',
      evaluate: [
        {
          name: 'evaluate.orientationMenu',
        },
        {
          name: 'evaluate.viewport.supported',
          unsupportedViewportTypes: ['video', 'volume3d'],
        },
      ],
      hideWhenDisabled: true,
    },
  },
  ``