### PR TITLE
feat(hp): add onStageChange callback

### DIFF
--- a/platform/core/src/services/HangingProtocolService/HangingProtocolService.ts
+++ b/platform/core/src/services/HangingProtocolService/HangingProtocolService.ts
@@ -1064,6 +1064,11 @@ export default class HangingProtocolService extends PubSubService {
         throw new Error(`Can't find applicable stage ${protocol.id} ${options?.stageIndex}`);
       }
       this.stageIndex = stage as number;
+
+      if (this.protocol?.callbacks?.onStageChange) {
+        this._commandsManager.run(this.protocol.callbacks.onStageChange);
+      }
+
       this._updateViewports(options);
     } catch (error) {
       console.log(error);

--- a/platform/core/src/types/HangingProtocol.ts
+++ b/platform/core/src/types/HangingProtocol.ts
@@ -293,6 +293,8 @@ export type ProtocolNotifications = {
   // and all viewport data includes a designated display set. This command
   // will run on every stage's initial layout.
   onViewportDataInitialized?: Command[];
+  // This set of commands is executed before the stage change is applied
+  onStageChange?: Command[];
 };
 
 /**


### PR DESCRIPTION
### Context

Adds `onStageChange` callback for hanging protocols, currently we have:
```
onProtocolExit -> leaving HP
onProtocolEnter -> entering HP
onLayoutChange -> grid layout tool (setViewportGridLayout)
onViewportDataInitialized -> data load
```

This adds `onStageChange`

``
onStageChange -> going back/forward in the HP stages
``