### PR TITLE
ui(icons): Adds action and helper icon artwork for segmentation

### DIFF
--- a/platform/ui-next/src/components/Icons/Icons.tsx
+++ b/platform/ui-next/src/components/Icons/Icons.tsx
@@ -170,8 +170,18 @@ import {
   ActionsSmooth,
   ActionsSimplify,
   ActionsCombine,
+  ActionsCombineMerge,
+  ActionsCombineSubtract,
+  ActionsCombineIntersect,
   ActionsSetting,
+  ActionsBidirectional,
+  ActionsInterpolate,
 } from './Sources/SegActions';
+import {
+  HelperCombineSubtract,
+  HelperCombineIntersect,
+  HelperCombineMerge,
+} from './Sources/Helpers';
 import Link from './Sources/Link';
 import IconColorLUT from './Sources/IconColorLUT';
 import CTAAA from '../../../assets/images/CT-AAA.png';
@@ -598,7 +608,15 @@ export const Icons = {
   ActionsSmooth,
   ActionsSimplify,
   ActionsCombine,
+  ActionsCombineMerge,
+  ActionsCombineSubtract,
+  ActionsCombineIntersect,
   ActionsSetting,
+  ActionsBidirectional,
+  ActionsInterpolate,
+  HelperCombineSubtract,
+  HelperCombineIntersect,
+  HelperCombineMerge,
   //
   //
   //
@@ -745,14 +763,22 @@ export const Icons = {
   'old-trash': (props: IconProps) => Trash(props),
   'tool-point': (props: IconProps) => ToolCircle(props),
   'tool-freehand-line': (props: IconProps) => ToolFreehand(props),
+  'actions-smooth': (props: IconProps) => ActionsSmooth(props),
+  'actions-simplify': (props: IconProps) => ActionsSimplify(props),
+  'actions-combine': (props: IconProps) => ActionsCombine(props),
+  'actions-combine-merge': (props: IconProps) => ActionsCombineMerge(props),
+  'actions-combine-subtract': (props: IconProps) => ActionsCombineSubtract(props),
+  'actions-combine-intersect': (props: IconProps) => ActionsCombineIntersect(props),
+  'actions-bidirectional': (props: IconProps) => ActionsBidirectional(props),
+  'actions-interpolate': (props: IconProps) => ActionsInterpolate(props),
+  'actions-setting': (props: IconProps) => ActionsSetting(props),
+  'helper-combine-subtract': (props: IconProps) => HelperCombineSubtract(props),
+  'helper-combine-intersect': (props: IconProps) => HelperCombineIntersect(props),
+  'helper-combine-merge': (props: IconProps) => HelperCombineMerge(props),
   clipboard: (props: IconProps) => Clipboard(props),
   Undo,
   Redo,
   JumpToSlice,
-  'actions-smooth': (props: IconProps) => ActionsSmooth(props),
-  'actions-simplify': (props: IconProps) => ActionsSimplify(props),
-  'actions-combine': (props: IconProps) => ActionsCombine(props),
-  'actions-setting': (props: IconProps) => ActionsSetting(props),
 
   /** Adds an icon to the set of icons */
   addIcon: (name: string, icon) => {

--- a/platform/ui-next/src/components/Icons/Sources/Helpers.tsx
+++ b/platform/ui-next/src/components/Icons/Sources/Helpers.tsx
@@ -1,0 +1,398 @@
+import React from 'react';
+import type { IconProps } from '../types';
+
+export const HelperCombineSubtract = (props: IconProps) => (
+  <svg
+    width="49"
+    height="49"
+    viewBox="0 0 49 49"
+    fill="none"
+    {...props}
+  >
+    <path
+      d="M17.6459 47.0208C17.1265 47.0208 16.6284 46.8145 16.2611 46.4472C15.8939 46.08 15.6875 45.5819 15.6875 45.0625"
+      stroke="white"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M45.0625 47.0208C45.5819 47.0208 46.08 46.8145 46.4473 46.4472C46.8146 46.08 47.0209 45.5819 47.0209 45.0625"
+      stroke="white"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M15.6875 41.1458V39.1875"
+      stroke="white"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M23.5209 47.0208H21.5625"
+      stroke="white"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M29.3959 47.0208H27.4375"
+      stroke="white"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M35.2709 47.0208H33.3125"
+      stroke="white"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M41.1459 47.0208H39.1875"
+      stroke="white"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M41.1459 15.6875H39.1875"
+      stroke="white"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M45.0625 15.6875C45.5819 15.6875 46.08 15.8938 46.4473 16.2611C46.8146 16.6283 47.0209 17.1264 47.0209 17.6458"
+      stroke="white"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M47.0209 21.5625V23.5208"
+      stroke="white"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M47.0209 27.4375V29.3958"
+      stroke="white"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M47.0209 33.3125V35.2708"
+      stroke="white"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M47.0209 39.1875V41.1458"
+      stroke="white"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M3.93787 35.7708C3.28603 35.7708 2.66058 35.5119 2.19958 35.0511C1.73863 34.5901 1.47897 33.9647 1.47888 33.3128L1.47888 3.93781C1.47888 3.28582 1.73856 2.66055 2.19958 2.19952C2.66061 1.7385 3.28588 1.47882 3.93787 1.47882L33.3129 1.47882C33.9647 1.47891 34.5902 1.73857 35.0511 2.19952C35.512 2.66052 35.7709 3.28597 35.7709 3.93781L35.7709 13.7288C35.7709 14.3807 35.512 15.0061 35.0511 15.4671C34.5902 15.9281 33.9647 16.1877 33.3129 16.1878L17.6459 16.1878C17.2591 16.1878 16.8881 16.3411 16.6146 16.6146C16.3411 16.8881 16.1879 17.259 16.1879 17.6458L16.1879 33.3128C16.1878 33.9647 15.9281 34.5901 15.4672 35.0511C15.0062 35.5119 14.3807 35.7708 13.7289 35.7708L3.93787 35.7708Z"
+      fill="#1A3F7E"
+      stroke="white"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M6.53267 16H5.33239L8.80398 6.54545H9.9858L13.4574 16H12.2571L9.43182 8.04119H9.35795L6.53267 16ZM6.97585 12.3068H11.8139V13.3224H6.97585V12.3068Z"
+      fill="white"
+    />
+    <path
+      d="M28.1449 36V26.5455H31.4503C32.1089 26.5455 32.6521 26.6593 33.0799 26.8871C33.5077 27.1117 33.8262 27.4149 34.0355 27.7965C34.2448 28.1751 34.3494 28.5952 34.3494 29.0568C34.3494 29.4631 34.2771 29.7985 34.1325 30.0632C33.9909 30.3279 33.8031 30.5372 33.5692 30.6911C33.3384 30.8449 33.0876 30.9588 32.8168 31.0327V31.125C33.1061 31.1435 33.3969 31.245 33.6893 31.4297C33.9817 31.6143 34.2263 31.879 34.4233 32.2237C34.6203 32.5684 34.7188 32.9901 34.7188 33.4886C34.7188 33.9626 34.611 34.3888 34.3956 34.7674C34.1802 35.146 33.8401 35.446 33.3754 35.6676C32.9106 35.8892 32.3059 36 31.5611 36H28.1449ZM29.2898 34.9844H31.5611C32.3089 34.9844 32.8398 34.8397 33.1538 34.5504C33.4708 34.258 33.6293 33.9041 33.6293 33.4886C33.6293 33.1686 33.5477 32.8731 33.3846 32.6023C33.2215 32.3284 32.9891 32.1098 32.6875 31.9467C32.3859 31.7805 32.0289 31.6974 31.6165 31.6974H29.2898V34.9844ZM29.2898 30.7003H31.4134C31.758 30.7003 32.0689 30.6326 32.3459 30.4972C32.6259 30.3617 32.8475 30.1709 33.0107 29.9247C33.1768 29.6785 33.2599 29.3892 33.2599 29.0568C33.2599 28.6413 33.1153 28.2889 32.826 27.9996C32.5367 27.7073 32.0781 27.5611 31.4503 27.5611H29.2898V30.7003Z"
+      fill="white"
+    />
+  </svg>
+);
+
+export const HelperCombineIntersect = (props: IconProps) => (
+  <svg
+    width="49"
+    height="49"
+    viewBox="0 0 49 49"
+    fill="none"
+    {...props}
+  >
+    <path
+      d="M31.0625 3.9375C31.5598 3.9375 32.0367 4.13504 32.3883 4.48667C32.74 4.83831 32.9375 5.31522 32.9375 5.8125"
+      stroke="white"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M4.8125 3.9375C4.31522 3.9375 3.83831 4.13504 3.48667 4.48667C3.13504 4.83831 2.9375 5.31522 2.9375 5.8125"
+      stroke="white"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M32.9375 9.5625V11.4375"
+      stroke="white"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M25.4375 3.9375H27.3125"
+      stroke="white"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M19.8125 3.9375H21.6875"
+      stroke="white"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M14.1875 3.9375H16.0625"
+      stroke="white"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M8.5625 3.9375H10.4375"
+      stroke="white"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M14.1875 33.9375H16.0625"
+      stroke="white"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M8.5625 33.9375H10.4375"
+      stroke="white"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M4.8125 33.9375C4.31522 33.9375 3.83831 33.74 3.48667 33.3883C3.13504 33.0367 2.9375 32.5598 2.9375 32.0625"
+      stroke="white"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M2.9375 28.3125V26.4375"
+      stroke="white"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M2.9375 22.6875V20.8125"
+      stroke="white"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M2.9375 17.0625V15.1875"
+      stroke="white"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M32.9375 17.0625V15.1875"
+      stroke="white"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M2.9375 11.4375V9.5625"
+      stroke="white"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M17.9375 47.0625C17.4402 47.0625 16.9633 46.865 16.6117 46.5133C16.26 46.1617 16.0625 45.6848 16.0625 45.1875"
+      stroke="white"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M44.1875 47.0625C44.6848 47.0625 45.1617 46.865 45.5133 46.5133C45.865 46.1617 46.0625 45.6848 46.0625 45.1875"
+      stroke="white"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M16.0625 41.4375V39.5625"
+      stroke="white"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M23.5625 47.0625H21.6875"
+      stroke="white"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M29.1875 47.0625H27.3125"
+      stroke="white"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M34.8125 47.0625H32.9375"
+      stroke="white"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M40.4375 47.0625H38.5625"
+      stroke="white"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M34.8125 17.0625H32.9375"
+      stroke="white"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M40.4375 17.0625H38.5625"
+      stroke="white"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M44.1875 17.0625C44.6848 17.0625 45.1617 17.26 45.5133 17.6117C45.865 17.9633 46.0625 18.4402 46.0625 18.9375"
+      stroke="white"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M46.0625 22.6875V24.5625"
+      stroke="white"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M46.0625 28.3125V30.1875"
+      stroke="white"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M46.0625 33.9375V35.8125"
+      stroke="white"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M16.0625 33.9375V35.8125"
+      stroke="white"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M46.0625 39.5625V41.4375"
+      stroke="white"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M16.0625 18.9375C16.0625 18.4402 16.26 17.9633 16.6117 17.6117C16.9633 17.26 17.4402 17.0625 17.9375 17.0625H32.9375V32.0625C32.9375 32.5598 32.74 33.0367 32.3883 33.3883C32.0367 33.74 31.5598 33.9375 31.0625 33.9375H16.0625V18.9375Z"
+      fill="#1A3F7E"
+      stroke="white"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M6.53267 16H5.33239L8.80398 6.54545H9.9858L13.4574 16H12.2571L9.43182 8.04119H9.35795L6.53267 16ZM6.97585 12.3068H11.8139V13.3224H6.97585V12.3068Z"
+      fill="white"
+    />
+    <path
+      d="M36.1449 43V33.5455H39.4503C40.1089 33.5455 40.6521 33.6593 41.0799 33.8871C41.5077 34.1117 41.8262 34.4149 42.0355 34.7965C42.2448 35.1751 42.3494 35.5952 42.3494 36.0568C42.3494 36.4631 42.2771 36.7985 42.1325 37.0632C41.9909 37.3279 41.8031 37.5372 41.5692 37.6911C41.3384 37.8449 41.0876 37.9588 40.8168 38.0327V38.125C41.1061 38.1435 41.3969 38.245 41.6893 38.4297C41.9817 38.6143 42.2263 38.879 42.4233 39.2237C42.6203 39.5684 42.7188 39.9901 42.7188 40.4886C42.7188 40.9626 42.611 41.3888 42.3956 41.7674C42.1802 42.146 41.8401 42.446 41.3754 42.6676C40.9106 42.8892 40.3059 43 39.5611 43H36.1449ZM37.2898 41.9844H39.5611C40.3089 41.9844 40.8398 41.8397 41.1538 41.5504C41.4708 41.258 41.6293 40.9041 41.6293 40.4886C41.6293 40.1686 41.5477 39.8731 41.3846 39.6023C41.2215 39.3284 40.9891 39.1098 40.6875 38.9467C40.3859 38.7805 40.0289 38.6974 39.6165 38.6974H37.2898V41.9844ZM37.2898 37.7003H39.4134C39.758 37.7003 40.0689 37.6326 40.3459 37.4972C40.6259 37.3617 40.8475 37.1709 41.0107 36.9247C41.1768 36.6785 41.2599 36.3892 41.2599 36.0568C41.2599 35.6413 41.1153 35.2889 40.826 34.9996C40.5367 34.7073 40.0781 34.5611 39.4503 34.5611H37.2898V37.7003Z"
+      fill="white"
+    />
+  </svg>
+);
+
+export const HelperCombineMerge = (props: IconProps) => (
+  <svg
+    width="49"
+    height="49"
+    viewBox="0 0 49 49"
+    fill="none"
+    {...props}
+  >
+    <path
+      d="M5.79167 32.5625C5.31649 32.5625 4.86077 32.3737 4.52477 32.0377C4.18876 31.7017 4 31.246 4 30.7708V5.68748C4 5.2123 4.18876 4.75658 4.52477 4.42058C4.86077 4.08458 5.31649 3.89581 5.79167 3.89581H30.875C31.3502 3.89581 31.8059 4.08458 32.1419 4.42058C32.4779 4.75658 32.6667 5.2123 32.6667 5.68748V16.4375H43.4167C43.8918 16.4375 44.3476 16.6262 44.6836 16.9622C45.0196 17.2982 45.2083 17.754 45.2083 18.2291V43.3125C45.2083 43.7877 45.0196 44.2434 44.6836 44.5794C44.3476 44.9154 43.8918 45.1041 43.4167 45.1041H18.3333C17.8582 45.1041 17.4024 44.9154 17.0664 44.5794C16.7304 44.2434 16.5417 43.7877 16.5417 43.3125V32.5625H5.79167Z"
+      fill="#1A3F7E"
+      stroke="white"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M18.3333 16.4375C17.8581 16.4375 17.4024 16.6263 17.0664 16.9623C16.7304 17.2983 16.5416 17.754 16.5416 18.2292"
+      stroke="white"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M16.5416 21.8125V23.6042"
+      stroke="white"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M23.7083 16.4375H21.9166"
+      stroke="white"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M29.0833 16.4375H27.2916"
+      stroke="white"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M21.9167 32.5625H20.125"
+      stroke="white"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M27.2917 32.5625H25.5"
+      stroke="white"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M16.5416 28.9792V27.1875"
+      stroke="white"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M32.6666 20.0208V21.8125"
+      stroke="white"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M30.875 32.5625C31.3502 32.5625 31.8059 32.3737 32.1419 32.0377C32.4779 31.7017 32.6667 31.246 32.6667 30.7708"
+      stroke="white"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M32.6666 27.1875V25.3958"
+      stroke="white"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M7.6368 16H6.43651L9.9081 6.54545H11.0899L14.5615 16H13.3612L10.5359 8.04119H10.4621L7.6368 16ZM8.07998 12.3068H12.918V13.3224H8.07998V12.3068Z"
+      fill="white"
+    />
+    <path
+      d="M36.249 42V32.5455H39.5544C40.213 32.5455 40.7562 32.6593 41.184 32.8871C41.6118 33.1117 41.9304 33.4149 42.1396 33.7965C42.3489 34.1751 42.4536 34.5952 42.4536 35.0568C42.4536 35.4631 42.3812 35.7985 42.2366 36.0632C42.095 36.3279 41.9073 36.5372 41.6734 36.6911C41.4425 36.8449 41.1917 36.9588 40.9209 37.0327V37.125C41.2102 37.1435 41.501 37.245 41.7934 37.4297C42.0858 37.6143 42.3305 37.879 42.5274 38.2237C42.7244 38.5684 42.8229 38.9901 42.8229 39.4886C42.8229 39.9626 42.7152 40.3888 42.4997 40.7674C42.2843 41.146 41.9442 41.446 41.4795 41.6676C41.0148 41.8892 40.41 42 39.6652 42H36.249ZM37.3939 40.9844H39.6652C40.4131 40.9844 40.944 40.8397 41.2579 40.5504C41.5749 40.258 41.7334 39.9041 41.7334 39.4886C41.7334 39.1686 41.6518 38.8731 41.4887 38.6023C41.3256 38.3284 41.0932 38.1098 40.7916 37.9467C40.49 37.7805 40.133 37.6974 39.7206 37.6974H37.3939V40.9844ZM37.3939 36.7003H39.5175C39.8622 36.7003 40.173 36.6326 40.45 36.4972C40.7301 36.3617 40.9517 36.1709 41.1148 35.9247C41.281 35.6785 41.3641 35.3892 41.3641 35.0568C41.3641 34.6413 41.2194 34.2889 40.9301 33.9996C40.6408 33.7073 40.1823 33.5611 39.5544 33.5611H37.3939V36.7003Z"
+      fill="white"
+    />
+  </svg>
+);

--- a/platform/ui-next/src/components/Icons/Sources/SegActions.tsx
+++ b/platform/ui-next/src/components/Icons/Sources/SegActions.tsx
@@ -87,6 +87,375 @@ export const ActionsCombine = (props: IconProps) => (
   </svg>
 );
 
+export const ActionsCombineMerge = (props: IconProps) => (
+  <svg
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    {...props}
+  >
+    <path
+      d="M2.99448 15.9397C2.7656 15.9397 2.54609 15.8488 2.38424 15.687C2.22239 15.5251 2.13147 15.3056 2.13147 15.0767V2.99454C2.13147 2.76566 2.22239 2.54615 2.38424 2.3843C2.54609 2.22246 2.7656 2.13153 2.99448 2.13153H15.0767C15.3056 2.13153 15.5251 2.22246 15.6869 2.3843C15.8488 2.54615 15.9397 2.76566 15.9397 2.99454V8.17262H21.1178C21.3467 8.17262 21.5662 8.26355 21.728 8.4254C21.8899 8.58724 21.9808 8.80675 21.9808 9.03564V21.1178C21.9808 21.3467 21.8899 21.5662 21.728 21.7281C21.5662 21.8899 21.3467 21.9808 21.1178 21.9808H9.03558C8.8067 21.9808 8.58719 21.8899 8.42534 21.7281C8.26349 21.5662 8.17257 21.3467 8.17257 21.1178V15.9397H2.99448Z"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M9.03562 8.17261C8.80674 8.17261 8.58723 8.26353 8.42538 8.42538C8.26353 8.58722 8.17261 8.80674 8.17261 9.03562"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M8.17261 10.7617V11.6247"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M11.6246 8.17261H10.7616"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M14.2136 8.17261H13.3506"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M10.7616 15.9398H9.89856"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M13.3507 15.9398H12.4877"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M8.17261 14.2137V13.3507"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M15.9397 9.89862V10.7616"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M15.0767 15.9397C15.3055 15.9397 15.5251 15.8488 15.6869 15.687C15.8488 15.5251 15.9397 15.3056 15.9397 15.0767"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M15.9397 13.3507V12.4877"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+export const ActionsCombineIntersect = (props: IconProps) => (
+  <svg
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    {...props}
+  >
+    <path
+      d="M15.0767 2.13153C15.3055 2.13153 15.5251 2.22246 15.6869 2.3843C15.8488 2.54615 15.9397 2.76566 15.9397 2.99454"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M2.99448 2.13153C2.7656 2.13153 2.54609 2.22246 2.38424 2.3843C2.22239 2.54615 2.13147 2.76566 2.13147 2.99454"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M15.9397 4.72058V5.58359"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M12.4877 2.13153H13.3507"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M9.89856 2.13153H10.7616"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M7.30957 2.13153H8.17258"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M4.72046 2.13153H5.58347"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M7.30957 15.9398H8.17258"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M4.72046 15.9398H5.58347"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M2.99448 15.9397C2.7656 15.9397 2.54609 15.8488 2.38424 15.687C2.22239 15.5251 2.13147 15.3056 2.13147 15.0767"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M2.13147 13.3507V12.4877"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M2.13147 10.7616V9.89862"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M2.13147 8.17258V7.30957"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M15.9397 8.17258V7.30957"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M2.13147 5.58359V4.72058"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M9.03562 21.9808C8.80674 21.9808 8.58723 21.8899 8.42538 21.728C8.26353 21.5662 8.17261 21.3467 8.17261 21.1178"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M21.1178 21.9808C21.3467 21.9808 21.5662 21.8899 21.728 21.728C21.8899 21.5662 21.9808 21.3467 21.9808 21.1178"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M8.17261 19.3918V18.5287"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M11.6246 21.9808H10.7616"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M14.2136 21.9808H13.3506"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M16.8027 21.9808H15.9397"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M19.3917 21.9808H18.5287"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M16.8027 8.17261H15.9397"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M19.3917 8.17261H18.5287"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M21.1178 8.17261C21.3467 8.17261 21.5662 8.26353 21.728 8.42538C21.8899 8.58722 21.9808 8.80674 21.9808 9.03562"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M21.9808 10.7617V11.6247"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M21.9808 13.3507V14.2137"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M21.9808 15.9398V16.8028"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M8.17261 15.9398V16.8028"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M21.9808 18.5287V19.3918"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M8.17261 9.03562C8.17261 8.80674 8.26353 8.58722 8.42538 8.42538C8.58723 8.26353 8.80674 8.17261 9.03562 8.17261H15.9397V15.0767C15.9397 15.3056 15.8488 15.5251 15.687 15.687C15.5251 15.8488 15.3056 15.9397 15.0767 15.9397H8.17261V9.03562Z"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+export const ActionsCombineSubtract = (props: IconProps) => (
+  <svg
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    {...props}
+  >
+    <path
+      d="M9.03564 21.9808C8.80676 21.9808 8.58725 21.8899 8.4254 21.7281C8.26355 21.5662 8.17263 21.3467 8.17263 21.1178"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M21.1178 21.9808C21.3467 21.9808 21.5662 21.8899 21.7281 21.7281C21.8899 21.5662 21.9808 21.3467 21.9808 21.1178"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M8.17261 19.3918V18.5288"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M11.6246 21.9808H10.7616"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M14.2137 21.9808H13.3507"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M16.8027 21.9808H15.9397"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M19.3918 21.9808H18.5288"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M19.3918 8.17261H18.5288"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M21.1178 8.17263C21.3467 8.17263 21.5662 8.26355 21.7281 8.4254C21.8899 8.58725 21.9808 8.80676 21.9808 9.03564"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M21.9808 10.7617V11.6247"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M21.9808 13.3507V14.2137"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M21.9808 15.9398V16.8028"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M21.9808 18.5288V19.3918"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M16.8027 7.30965C16.8027 7.53853 16.7118 7.75804 16.55 7.91989C16.3881 8.08174 16.1686 8.17266 15.9397 8.17266L9.03561 8.17266C8.80672 8.17266 8.58721 8.26358 8.42536 8.42543C8.26352 8.58728 8.17259 8.80679 8.17259 9.03567L8.17259 15.9398C8.17259 16.1687 8.08167 16.3882 7.91982 16.55C7.75798 16.7119 7.53846 16.8028 7.30958 16.8028H2.99451C2.76562 16.8028 2.54611 16.7119 2.38426 16.55C2.22242 16.3882 2.13149 16.1687 2.13149 15.9398L2.13149 2.99458C2.13149 2.76569 2.22242 2.54618 2.38426 2.38434C2.54611 2.22249 2.76562 2.13157 2.99451 2.13157L15.9397 2.13157C16.1686 2.13157 16.3881 2.22249 16.55 2.38434C16.7118 2.54618 16.8027 2.76569 16.8027 2.99458V7.30965Z"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
 export const ActionsSetting = (props: IconProps) => (
   <svg
     width="28"
@@ -154,6 +523,72 @@ export const ActionsSetting = (props: IconProps) => (
       stroke="currentColor"
       strokeLinecap="round"
       strokeLinejoin="round"
+    />
+  </svg>
+);
+
+export const ActionsInterpolate = (props: IconProps) => (
+  <svg
+    width="28"
+    height="28"
+    viewBox="0 0 28 28"
+    fill="none"
+    {...props}
+  >
+    <path
+      d="M7 14.75H21"
+      stroke="currentColor"
+      strokeWidth="1.2"
+      strokeLinecap="round"
+    />
+    <path
+      d="M10.5 6H17.5"
+      stroke="currentColor"
+      strokeWidth="1.2"
+      strokeLinecap="round"
+    />
+    <path
+      d="M10.5 22.625H17.5"
+      stroke="currentColor"
+      strokeWidth="1.2"
+      strokeLinecap="round"
+    />
+    <path
+      d="M12.25 10.375H15.75"
+      stroke="currentColor"
+      strokeWidth="1.2"
+      strokeLinecap="round"
+    />
+    <path
+      d="M12.25 18.25H15.75"
+      stroke="currentColor"
+      strokeWidth="1.2"
+      strokeLinecap="round"
+    />
+  </svg>
+);
+
+export const ActionsBidirectional = (props: IconProps) => (
+  <svg
+    width="28"
+    height="28"
+    viewBox="0 0 28 28"
+    fill="none"
+    {...props}
+  >
+    <path
+      d="M9.08936 18.1306L20.5415 11.6855"
+      stroke="currentColor"
+      strokeLinecap="round"
+    />
+    <path
+      d="M11.5084 10.8735L16.2583 19.0161"
+      stroke="currentColor"
+      strokeLinecap="round"
+    />
+    <path
+      d="M7.17338 19.6824C5.88735 17.7757 5.7986 15.3546 6.70193 13.094C7.41762 11.3029 8.75605 9.61255 10.6152 8.35855C12.3677 7.17645 14.875 7.89754 16.7071 7.83789C19.2718 7.7544 21.3773 7.1777 22.7218 9.17092C23.9578 11.0034 22.7419 14.1203 21.9481 16.3041C21.2617 18.1926 20.9123 19.4176 18.9619 20.7331C17.2094 21.9152 15.2707 22.5231 13.4385 22.5827C10.8738 22.6662 8.51782 21.6756 7.17338 19.6824Z"
+      stroke="currentColor"
     />
   </svg>
 );


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

Adds new icon art for Segmentation Actions and Helper Artwork

<img width="1290" height="880" alt="Screenshot 2025-07-11 at 3 30 57 PM" src="https://github.com/user-attachments/assets/f9390cd0-f545-41e0-8ef3-dcc0cc4378e4" />

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

#### Segmentation Action Icons
| Icon | Alias key  |
|-----------------|-----------------------|
| `ActionsSetting` | `actions-setting` |
| `ActionsCombine` | `actions-combine` |
| `ActionsSimplify` | `actions-simplify` |
| `ActionsSmooth` | `actions-smooth` |
| `ActionsBidirectional` | `actions-bidirectional` |
| `ActionsInterpolate` | `actions-interpolate` |
| `ActionsCombineSubtract` | `actions-combine-subtract` |
| `ActionsCombineIntersect` | `actions-combine-intersect` |
| `ActionsCombineMerge` | `actions-combine-merge` |


#### Helper Icons
| Icon | Alias key  |
|-----------------|-----------------------|
| `HelperCombineSubtract` | `helper-combine-subtract` |
| `HelperCombineIntersect` | `helper-combine-intersect` |
| `HelperCombineMerge` | `helper-combine-merge` |

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

Icons tested in the Viewer with the current Chrome (macOS)

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] OS: macOS Sequoia 15.5 (24F74), Apple M4 Pro <!--[e.g. Windows 10, macOS 10.15.4]-->
- [x] Node version: v20.19.1 <!--[e.g. 18.16.1]-->
- [x] Browser: 137.0.7151.120 (Official Build) (arm64)
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
