### PR TITLE
fix(panels): Allow for setting the initial and minimum expanded widths of each side panel.

### DIFF
--- a/extensions/default/src/ViewerLayout/ResizablePanelsHook.tsx
+++ b/extensions/default/src/ViewerLayout/ResizablePanelsHook.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useLayoutEffect, useRef } from 'react';
 import { getPanelElement, getPanelGroupElement } from 'react-resizable-panels';
-import { panelGroupDefinition } from './constants/panels';
+import { getPanelGroupDefinition } from './constants/panels';
 
 /**
  * Set the minimum and maximum css style width attributes for the given element.
@@ -30,8 +30,21 @@ const useResizablePanels = (
   rightPanelClosed,
   setRightPanelClosed,
   hasLeftPanels,
-  hasRightPanels
+  hasRightPanels,
+  leftPanelInitialExpandedWidth,
+  rightPanelInitialExpandedWidth,
+  leftPanelMinimumExpandedWidth,
+  rightPanelMinimumExpandedWidth
 ) => {
+  const [panelGroupDefinition] = useState(
+    getPanelGroupDefinition({
+      leftPanelInitialExpandedWidth,
+      rightPanelInitialExpandedWidth,
+      leftPanelMinimumExpandedWidth,
+      rightPanelMinimumExpandedWidth,
+    })
+  );
+
   const [leftPanelExpandedWidth, setLeftPanelExpandedWidth] = useState(
     panelGroupDefinition.left.initialExpandedWidth
   );

--- a/extensions/default/src/ViewerLayout/constants/panels.ts
+++ b/extensions/default/src/ViewerLayout/constants/panels.ts
@@ -3,36 +3,40 @@ const collapsedInsideBorderSize = 4;
 const collapsedOutsideBorderSize = 4;
 const collapsedWidth = 25;
 
-const rightPanelInitialExpandedWidth = 280;
-const leftPanelInitialExpandedWidth = 282;
-
-const panelGroupDefinition = {
-  groupId: 'viewerLayoutResizablePanelGroup',
-  shared: {
-    expandedInsideBorderSize,
-    collapsedInsideBorderSize,
-    collapsedOutsideBorderSize,
-    collapsedWidth,
-  },
-  left: {
-    // id
-    panelId: 'viewerLayoutResizableLeftPanel',
-    // expanded width
-    initialExpandedWidth: leftPanelInitialExpandedWidth,
-    // expanded width + expanded inside border
-    minimumExpandedOffsetWidth: 145 + expandedInsideBorderSize,
-    // initial expanded width
-    initialExpandedOffsetWidth: leftPanelInitialExpandedWidth + expandedInsideBorderSize,
-    // collapsed width + collapsed inside border + collapsed outside border
-    collapsedOffsetWidth: collapsedWidth + collapsedInsideBorderSize + collapsedOutsideBorderSize,
-  },
-  right: {
-    panelId: 'viewerLayoutResizableRightPanel',
-    initialExpandedWidth: rightPanelInitialExpandedWidth,
-    minimumExpandedOffsetWidth: rightPanelInitialExpandedWidth + expandedInsideBorderSize,
-    initialExpandedOffsetWidth: rightPanelInitialExpandedWidth + expandedInsideBorderSize,
-    collapsedOffsetWidth: collapsedWidth + collapsedInsideBorderSize + collapsedOutsideBorderSize,
-  },
+const getPanelGroupDefinition = ({
+  leftPanelInitialExpandedWidth = 282,
+  rightPanelInitialExpandedWidth = 280,
+  leftPanelMinimumExpandedWidth = 145,
+  rightPanelMinimumExpandedWidth = 280,
+}) => {
+  return {
+    groupId: 'viewerLayoutResizablePanelGroup',
+    shared: {
+      expandedInsideBorderSize,
+      collapsedInsideBorderSize,
+      collapsedOutsideBorderSize,
+      collapsedWidth,
+    },
+    left: {
+      // id
+      panelId: 'viewerLayoutResizableLeftPanel',
+      // expanded width
+      initialExpandedWidth: leftPanelInitialExpandedWidth,
+      // expanded width + expanded inside border
+      minimumExpandedOffsetWidth: leftPanelMinimumExpandedWidth + expandedInsideBorderSize,
+      // initial expanded width
+      initialExpandedOffsetWidth: leftPanelInitialExpandedWidth + expandedInsideBorderSize,
+      // collapsed width + collapsed inside border + collapsed outside border
+      collapsedOffsetWidth: collapsedWidth + collapsedInsideBorderSize + collapsedOutsideBorderSize,
+    },
+    right: {
+      panelId: 'viewerLayoutResizableRightPanel',
+      initialExpandedWidth: rightPanelInitialExpandedWidth,
+      minimumExpandedOffsetWidth: rightPanelMinimumExpandedWidth + expandedInsideBorderSize,
+      initialExpandedOffsetWidth: rightPanelInitialExpandedWidth + expandedInsideBorderSize,
+      collapsedOffsetWidth: collapsedWidth + collapsedInsideBorderSize + collapsedOutsideBorderSize,
+    },
+  };
 };
 
-export { panelGroupDefinition };
+export { getPanelGroupDefinition };

--- a/extensions/default/src/ViewerLayout/index.tsx
+++ b/extensions/default/src/ViewerLayout/index.tsx
@@ -24,6 +24,10 @@ function ViewerLayout({
   rightPanelClosed = false,
   leftPanelResizable = false,
   rightPanelResizable = false,
+  leftPanelInitialExpandedWidth,
+  rightPanelInitialExpandedWidth,
+  leftPanelMinimumExpandedWidth,
+  rightPanelMinimumExpandedWidth,
 }: withAppTypes): React.FunctionComponent {
   const [appConfig] = useAppConfig();
 
@@ -54,7 +58,11 @@ function ViewerLayout({
     rightPanelClosed,
     setRightPanelClosed,
     hasLeftPanels,
-    hasRightPanels
+    hasRightPanels,
+    leftPanelInitialExpandedWidth,
+    rightPanelInitialExpandedWidth,
+    leftPanelMinimumExpandedWidth,
+    rightPanelMinimumExpandedWidth
   );
 
   const handleMouseEnter = () => {


### PR DESCRIPTION


<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context
See #5173 

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results
Added props to `ViewerLayout` so that the mode definitions can define the initial and minimum expanded widths.

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing
In a mode add any combination of the following properties...

```
  leftPanelInitialExpandedWidth,
  rightPanelInitialExpandedWidth,
  leftPanelMinimumExpandedWidth,
  rightPanelMinimumExpandedWidth,
```

They should take effect when loading the mode. Of course because the side panels are resizable, the properties marked as 'initial' likely only be applied on first load.

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] OS: Windows 11<!--[e.g. Windows 10, macOS 10.15.4]-->
- [x] Node version: 20.9.0<!--[e.g. 18.16.1]-->
- [x] Browser: Chrome 138.0.7204.101
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
