### PR TITLE
fix(black-viewports): MPR viewports were turning black if their parent stack had it's properties reset

### DIFF
--- a/extensions/cornerstone/src/services/ViewportService/CornerstoneViewportService.ts
+++ b/extensions/cornerstone/src/services/ViewportService/CornerstoneViewportService.ts
@@ -345,6 +345,11 @@ class CornerstoneViewportService extends PubSubService implements IViewportServi
         delete properties?.voiRange;
         delete properties?.VOILUTFunction;
       }
+      if (properties?.colormap) {
+        if (properties.colormap?.opacity?.length === 0) {
+          delete properties.colormap.opacity;
+        }
+      }
       return properties;
     };
 
@@ -1080,8 +1085,8 @@ class CornerstoneViewportService extends PubSubService implements IViewportServi
       const { dimensions, spacing } = imageVolume;
       const slabThickness = Math.sqrt(
         Math.pow(dimensions[0] * spacing[0], 2) +
-          Math.pow(dimensions[1] * spacing[1], 2) +
-          Math.pow(dimensions[2] * spacing[2], 2)
+        Math.pow(dimensions[1] * spacing[1], 2) +
+        Math.pow(dimensions[2] * spacing[2], 2)
       );
 
       return slabThickness;


### PR DESCRIPTION
fixes https://github.com/OHIF/Viewers/issues/5147 
fixes https://github.com/OHIF/Viewers/issues/5059

### Context

Sometimes when properties are reset on a stack, a default colormap is set of Grayscale, however an empty opacity array is also set, which breaks the viewports

`{name: 'Grayscale', opacity: []}`

This adds a check for empty opacity arrays and removes them before setting the lut presentation