### PR TITLE
fix: issue introduced from PR 5022

### DIFF
--- a/extensions/default/src/utils/validations/checkSingleFrames.ts
+++ b/extensions/default/src/utils/validations/checkSingleFrames.ts
@@ -1,9 +1,10 @@
 import areAllImageDimensionsEqual from './areAllImageDimensionsEqual';
 import areAllImageComponentsEqual from './areAllImageComponentsEqual';
-import areAllImageOrientationsEqual from './areAllImageOrientationsEqual';
 import areAllImagePositionsEqual from './areAllImagePositionsEqual';
 import areAllImageSpacingEqual from './areAllImageSpacingEqual';
-import { DisplaySetMessage, DisplaySetMessageList } from '@ohif/core';
+import { DisplaySetMessage, DisplaySetMessageList, utils } from '@ohif/core';
+
+const { areAllImageOrientationsEqual } = utils;
 
 /**
  * Runs various checks in a single frame series

--- a/platform/core/src/utils/areAllImageOrientationsEqual.ts
+++ b/platform/core/src/utils/areAllImageOrientationsEqual.ts
@@ -1,5 +1,5 @@
-import toNumber from '@ohif/core/src/utils/toNumber';
-import { _isSameOrientation } from '@ohif/core/src/utils/isDisplaySetReconstructable';
+import toNumber from './toNumber';
+import { _isSameOrientation } from './isDisplaySetReconstructable';
 
 /**
  * Check is the series has frames with different orientations

--- a/platform/core/src/utils/index.ts
+++ b/platform/core/src/utils/index.ts
@@ -44,6 +44,7 @@ import { sopClassDictionary } from './sopClassDictionary';
 import * as MeasurementFilters from './measurementFilters';
 import getClosestOrientationFromIOP from './getClosestOrientationFromIOP';
 import calculateScanAxisNormal from './calculateScanAxisNormal';
+import areAllImageOrientationsEqual from './areAllImageOrientationsEqual';
 // Commented out unused functionality.
 // Need to implement new mechanism for derived displaySets using the displaySetManager.
 
@@ -93,6 +94,7 @@ const utils = {
   MeasurementFilters,
   getClosestOrientationFromIOP,
   calculateScanAxisNormal,
+  areAllImageOrientationsEqual,
 };
 
 export {

--- a/platform/core/src/utils/sortStudy.ts
+++ b/platform/core/src/utils/sortStudy.ts
@@ -1,6 +1,7 @@
 import { vec3 } from 'gl-matrix';
 import isLowPriorityModality from './isLowPriorityModality';
 import calculateScanAxisNormal from './calculateScanAxisNormal';
+import areAllImageOrientationsEqual from './areAllImageOrientationsEqual';
 
 const compareSeriesDateTime = (a, b) => {
   const seriesDateA = Date.parse(`${a.seriesDate ?? a.SeriesDate} ${a.seriesTime ?? a.SeriesTime}`);
@@ -145,6 +146,11 @@ function isValidForPositionSort(images): boolean {
   if (!referenceImagePositionPatient || !imageOrientationPatient) {
     return false;
   }
+
+  if (!areAllImageOrientationsEqual(images)) {
+    return false;
+  }
+
   return true;
 }
 


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

- Fix for the issue mentioned by @IbrahimCSAE in #5022 

> FYI. This has broken the sort on some series, they became completely out of order. I can't share the data but the only information I can share is that it was a sagittal series with an axial cover slice.
 
- This PR has been incorporated by [FlyWheel.io](https://flywheel.io/).

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results
The issue is fixed by validating whether the `areAllImageOrientationsEqual` before sorting slices with spatial position

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

1. Launch viewer with data /viewer?StudyInstanceUIDs=1.3.6.1.4.1.14519.5.2.1.99.1071.26968527900428638961173806140069&SeriesInstanceUID=1.3.6.1.4.1.14519.5.2.1.99.1071.19276989507392553891297154495191 & /viewer?StudyInstanceUIDs=1.3.6.1.4.1.14519.5.2.1.99.1071.21255249241959598781018667405790&SeriesInstanceUID=1.3.6.1.4.1.14519.5.2.1.99.1071.18655460124733602726552772434272
2. Verify that slices are in order



<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] OS: <!--[e.g. Windows 10, macOS 10.15.4]-->  Windows 11
- [x] Node version: <!--[e.g. 18.16.1]--> 18.19.0
- [x] Browser: Chrome 131.0.6778.265
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
