### PR TITLE
Handle 200 status response and add default error handling

### DIFF
--- a/extensions/default/src/DicomWebDataSource/dcm4cheeReject.js
+++ b/extensions/default/src/DicomWebDataSource/dcm4cheeReject.js
@@ -34,6 +34,7 @@ export default function (wadoRoot, getAuthrorizationHeader) {
                 reject('Your dataSource does not support reject functionality');
               default:
                 reject(`Unexpected status code: ${xhr.status}`);
+                break;
             }
           }
         };

--- a/extensions/default/src/DicomWebDataSource/dcm4cheeReject.js
+++ b/extensions/default/src/DicomWebDataSource/dcm4cheeReject.js
@@ -25,12 +25,15 @@ export default function (wadoRoot, getAuthrorizationHeader) {
           //Call a function when the state changes.
           if (xhr.readyState == 4) {
             switch (xhr.status) {
+              case 200:
               case 204:
                 resolve(xhr.responseText);
 
                 break;
               case 404:
                 reject('Your dataSource does not support reject functionality');
+              default:
+                reject(`Unexpected status code: ${xhr.status}`);
             }
           }
         };


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

Fixes [#5226](https://github.com/OHIF/Viewers/issues/5226)

The `dataSource.reject.series` method currently only treats HTTP 204 (No Content) as a successful response. However, the DCM4CHEE server returns HTTP 200 (OK) on success. As a result, the promise is not resolved, leading to an infinite loading state in the UI.

This PR adds support for HTTP 200 as a valid success response and includes a `default` case to handle unexpected status codes gracefully.

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

- Add handling for HTTP 200 response to properly resolve the `reject` request.
- Add `default` case to `switch` to reject on unexpected HTTP status codes.
- Fix missing UI response after clicking deleting.

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

- Open a study with available series.
- Trigger a reject operation on a series.
- Confirm that the rejection completes successfully when the backend responds with HTTP 200.

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] OS: Windows 10
- [x] Node version: 24.0.2
- [x] Browser:
  Chrome 138.0.7204.101

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
