### PR TITLE
fix: prevent failure in DICOM loader for wadouri type

### DIFF
--- a/extensions/cornerstone/src/utils/dicomLoaderService.js
+++ b/extensions/cornerstone/src/utils/dicomLoaderService.js
@@ -120,7 +120,7 @@ class DicomLoaderService {
     const imageInstance = getImageInstance(dataset);
 
     if (imageInstance) {
-      const imageId = getImageInstanceId(imageInstance);
+      let imageId = getImageInstanceId(imageInstance);
       let getDicomDataMethod = fetchIt;
       const loaderType = getImageLoaderType(imageId);
 


### PR DESCRIPTION
### Context

Fixes an issue in the DICOM loader service where `wadouri` image types failed due to incorrect handling of `imageId` reassignment, resulting in runtime errors.

### Changes & Results

- Refactored `getDataByImageType` to correctly parse and handle `wadouri` imageId.

### Checklist

#### PR

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

- [ ] The documentation page has been updated as necessary for any public API
  additions or removals.

