### PR TITLE
test(SegmentationPanel): add test for jump to center of segments from PACS and basic add, rename, delete from panel

### DIFF
--- a/tests/SegmentationPanel.spec.ts
+++ b/tests/SegmentationPanel.spec.ts
@@ -1,0 +1,97 @@
+import { test, expect } from 'playwright-test-coverage';
+import { visitStudy } from './utils';
+
+test.beforeEach(async ({ page }) => {
+  // Using same one as JumpToMeasurementMPR.spec.ts
+  const studyInstanceUID = '1.3.6.1.4.1.14519.5.2.1.256467663913010332776401703474716742458';
+  const mode = 'segmentation'; // To also test add/remove
+  await visitStudy(page, studyInstanceUID, mode, 2000);
+});
+
+test('checks basic add, rename, delete segments from panel', async ({ page }) => {
+  // Segmentation Panel should already be open
+  const segmentationPanel = page.getByTestId('panelSegmentationWithTools-btn');
+  await expect(segmentationPanel).toBeVisible();
+
+  // Add segmentation
+  const addSegmentationBtn = page.getByTestId('addSegmentation');
+  await addSegmentationBtn.click();
+
+  // Expect new segmentation and blank segment named "Segment 1"
+  await expect(page.getByTestId('data-row')).toHaveCount(1);
+  await expect(page.getByTestId('data-row')).toContainText('Segment 1');
+
+  // Rename
+  const segment1Dropdown = page
+    .getByTestId('data-row')
+    .first()
+    .getByRole('button', { name: 'Actions' });
+  await segment1Dropdown.click();
+
+  const renameButton = page.getByRole('menuitem', { name: 'Rename' });
+  await expect(renameButton).toBeVisible();
+  await renameButton.click();
+
+  const renameDialog = page.getByRole('dialog', { name: 'Edit Segment Label' });
+  await expect(renameDialog).toBeVisible();
+
+  const renameInput = page.getByRole('textbox', { name: 'Enter new label' });
+  await renameInput.fill('Segment One');
+
+  await page.getByTestId('input-dialog-save-button').click();
+
+  await expect(page.getByTestId('data-row')).toContainText('Segment One');
+  await expect(page.getByTestId('data-row')).not.toContainText('Segment 1');
+
+  // Delete
+  await segment1Dropdown.click();
+  const deleteButton = page.getByRole('menuitem', { name: 'Delete' });
+  await expect(deleteButton).toBeVisible();
+  await deleteButton.click();
+
+  await expect(page.getByTestId('data-row')).toHaveCount(0);
+});
+
+test('checks saved segmentations loads and jumps to slices', async ({ page }) => {
+  const viewportInfoBottomRight = page.getByTestId('viewport-overlay-bottom-right');
+
+  // Image loads on slice 1, confirm on slice 1
+  await expect(viewportInfoBottomRight).toContainText('1/', { timeout: 10000 });
+
+  // Add Segmentations
+  const segmentationsThumbnail = page
+    .getByTestId('study-browser-thumbnail-no-image')
+    .getByRole('button', { name: 'Segmentation' });
+  await segmentationsThumbnail.dblclick();
+
+  await page.waitForTimeout(3000);
+
+  // Confirm open segmentation
+  const viewportNotification = page.getByTestId('viewport-notification');
+  await expect(viewportNotification).toBeVisible();
+  await page.getByTestId('yes-hydrate-btn').click();
+
+  // Segmentation Panel should already be open
+  const segmentationPanel = page.getByTestId('panelSegmentationWithTools-btn');
+  await expect(segmentationPanel).toBeVisible();
+
+  // Confirm spleen jumps to slice 17
+  // First iteration repeat to account for segmentation loading delays
+  const spleenRow = page.getByTestId('data-row').filter({ hasText: 'Spleen' });
+  await expect(async () => {
+    await spleenRow.click();
+    await expect(viewportInfoBottomRight).toContainText('17/');
+  }).toPass({
+    timeout: 10000,
+  });
+
+  // Esophagus - 5
+  const esophagusRow = page.getByTestId('data-row').filter({ hasText: 'Esophagus' });
+  await esophagusRow.click();
+  await expect(viewportInfoBottomRight).toContainText('5/');
+
+  // Pancreas - 22
+  const pancreasRow = page.getByTestId('data-row').filter({ hasText: 'Pancreas' });
+  await pancreasRow.click();
+  await expect(viewportInfoBottomRight).toContainText('22/');
+});


### PR DESCRIPTION
-test segmentation from PACS jumps to center when clicked on segmentation panel

<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

Create test for 
1. Basic add, rename, and delete
2. Jump to center slice index when segment loaded from PACS (note that it seems this only works for segments loaded from PACS and not new segments or newly modified segments)

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] OS: <!--[e.g. Windows 10, macOS 10.15.4]-->
- [] Node version: <!--[e.g. 18.16.1]-->
- [] Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
