### PR TITLE
fix(multiframes): Corrected combining frame instances for multiframes.

### DIFF
--- a/platform/core/src/utils/combineFrameInstance.ts
+++ b/platform/core/src/utils/combineFrameInstance.ts
@@ -26,7 +26,7 @@ const combineFrameInstance = (frame, instance) => {
   instance.ImageType = dicomSplit(ImageType);
   const frameNumber = Number.parseInt(frame || 1);
 
-  if (PerFrameFunctionalGroupsSequence && SharedFunctionalGroupsSequence) {
+  if (!instance.GridFrameOffsetVector) {
     // this is to fix NM multiframe datasets with position and orientation
     // information inside DetectorInformationSequence
     if (!instance.ImageOrientationPatient && instance.DetectorInformationSequence) {
@@ -102,49 +102,45 @@ const combineFrameInstance = (frame, instance) => {
   }
 
   // For RTDOSE datasets
-  if (instance.GridFrameOffsetVector) {
-    if (!instance._parentInstance) {
-      Object.defineProperty(instance, '_parentInstance', {
-        value: { ...instance },
-      });
-    }
-
-    const sharedInstance = createCombinedValue(
-      instance._parentInstance,
-      SharedFunctionalGroupsSequence?.[0],
-      '_shared'
-    );
-
-    const newInstance = createCombinedValue(
-      sharedInstance,
-      PerFrameFunctionalGroupsSequence?.[frameNumber - 1],
-      frameNumber
-    );
-
-    const origin = newInstance.ImagePositionPatient?.map(Number);
-    const orientation = newInstance.ImageOrientationPatient?.map(Number);
-    const offset = Number(instance.GridFrameOffsetVector[frameNumber - 1]);
-
-    if (origin && orientation && !Number.isNaN(offset)) {
-      const row = vec3.fromValues(orientation[0], orientation[1], orientation[2]);
-      const col = vec3.fromValues(orientation[3], orientation[4], orientation[5]);
-      const normal = vec3.cross(vec3.create(), row, col);
-
-      const position = vec3.scaleAndAdd(vec3.create(), vec3.fromValues(...origin), normal, offset);
-      newInstance.ImagePositionPatient = [position[0], position[1], position[2]];
-    }
-
-    Object.defineProperty(newInstance, 'frameNumber', {
-      value: frameNumber,
-      writable: true,
-      enumerable: true,
-      configurable: true,
+  if (!instance._parentInstance) {
+    Object.defineProperty(instance, '_parentInstance', {
+      value: { ...instance },
     });
-
-    return newInstance;
   }
 
-  return instance;
+  const sharedInstance = createCombinedValue(
+    instance._parentInstance,
+    SharedFunctionalGroupsSequence?.[0],
+    '_shared'
+  );
+
+  const newInstance = createCombinedValue(
+    sharedInstance,
+    PerFrameFunctionalGroupsSequence?.[frameNumber - 1],
+    frameNumber
+  );
+
+  const origin = newInstance.ImagePositionPatient?.map(Number);
+  const orientation = newInstance.ImageOrientationPatient?.map(Number);
+  const offset = Number(instance.GridFrameOffsetVector[frameNumber - 1]);
+
+  if (origin && orientation && !Number.isNaN(offset)) {
+    const row = vec3.fromValues(orientation[0], orientation[1], orientation[2]);
+    const col = vec3.fromValues(orientation[3], orientation[4], orientation[5]);
+    const normal = vec3.cross(vec3.create(), row, col);
+
+    const position = vec3.scaleAndAdd(vec3.create(), vec3.fromValues(...origin), normal, offset);
+    newInstance.ImagePositionPatient = [position[0], position[1], position[2]];
+  }
+
+  Object.defineProperty(newInstance, 'frameNumber', {
+    value: frameNumber,
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  });
+
+  return newInstance;
 };
 
 /**


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context
It was discovered that some NM series contained NO RTDOSE, PerFrameFunctionalGroupsSequence, SharedFunctionalGroupsSequence. Thus any fusion view (via HP or overlay) were NOT aligning the NM multiframes correctly with the underlaid/fused series.

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results
Now accounting for such NM series.

Also making sure not to break RTDOSE series.

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing
Overlay an NM series over a CT. They should align.

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] OS: Windows 11<!--[e.g. Windows 10, macOS 10.15.4]-->
- [x] Node version: 20.9.0<!--[e.g. 18.16.1]-->
- [x] Browser: Chrome 138.0.7204.158
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
