### PR TITLE
fix(colorbar): Allow for `AdvancedRenderingControls` to be placed at the top or bottom of the viewport.

### DIFF
--- a/extensions/cornerstone/src/components/AdvancedRenderingControls/AdvancedRenderingControls.tsx
+++ b/extensions/cornerstone/src/components/AdvancedRenderingControls/AdvancedRenderingControls.tsx
@@ -1,6 +1,12 @@
 import { useToolbar, useViewportMousePosition } from '@ohif/core/src/hooks';
 import React, { useState, useEffect, useRef } from 'react';
 import { useViewportRendering } from '../../hooks';
+import { ButtonLocation } from '@ohif/core/src/services/ToolBarService/ToolbarService';
+
+const mouseNearControlsRanges = {
+  [ButtonLocation.TopMiddle]: { minX: 0, minY: 0, maxX: 1, maxY: 0.1 },
+  [ButtonLocation.BottomMiddle]: { minX: 0, minY: 0.9, maxX: 1, maxY: 1 },
+};
 
 function AdvancedRenderingControls({
   viewportId,
@@ -24,7 +30,7 @@ function AdvancedRenderingControls({
   });
 
   const mousePosition = useViewportMousePosition(viewportId);
-  const [isAtBottom, setIsAtBottom] = useState(false);
+  const [isMouseNearControls, setIsMouseNearControls] = useState(false);
   const [showAllIcons, setShowAllIcons] = useState(true);
   const firstMountRef = useRef(true);
   const { hasColorbar } = useViewportRendering(viewportId);
@@ -43,10 +49,11 @@ function AdvancedRenderingControls({
 
   useEffect(() => {
     if (!showAllIcons && mousePosition.isInViewport) {
-      if (mousePosition.isInBottomPercentage(10)) {
-        setIsAtBottom(true);
+      const mouseHoverLocation = mouseNearControlsRanges[location];
+      if (mousePosition.isWithinNormalizedBox(mouseHoverLocation)) {
+        setIsMouseNearControls(true);
       } else {
-        setIsAtBottom(false);
+        setIsMouseNearControls(false);
       }
     }
   }, [mousePosition, showAllIcons]);
@@ -97,7 +104,7 @@ function AdvancedRenderingControls({
 
         // Always show all icons on first mount for 3 seconds
         // After that, always show Colorbar, show others only when mouse is at bottom
-        const shouldBeVisible = showAllIcons || id === 'Colorbar' || isAtBottom;
+        const shouldBeVisible = showAllIcons || id === 'Colorbar' || isMouseNearControls;
 
         return (
           <div

--- a/extensions/cornerstone/src/components/ViewportColorbar/ViewportColorbar.tsx
+++ b/extensions/cornerstone/src/components/ViewportColorbar/ViewportColorbar.tsx
@@ -27,6 +27,9 @@ type ColorbarProps = {
   numColorbars: number;
 };
 
+export const isHorizontal = (position: ColorbarPositionType): boolean =>
+  position === 'top' || position === 'bottom';
+
 /**
  * ViewportColorbar Component
  * A React wrapper for the cornerstone ViewportColorbar that adds a close button
@@ -143,8 +146,9 @@ const ViewportColorbar = memo(function ViewportColorbar({
         display: 'flex',
         alignItems: 'center',
         pointerEvents: 'auto',
-        minWidth: position === 'bottom' ? width / 2.5 : '17px',
-        minHeight: position === 'bottom' ? '20px' : numColorbars === 1 ? height / 3 : height / 4,
+        minWidth: isHorizontal(position) ? width / 2.5 : '17px',
+        minHeight: isHorizontal(position) ? '20px' : numColorbars === 1 ? height / 3 : height / 4,
+        height: '1px', // sometimes flex items with min-height need a starting point for its height calculation
         ...positionStylesFromConfig,
       }}
     ></div>

--- a/extensions/cornerstone/src/components/ViewportColorbar/ViewportColorbarsContainer.tsx
+++ b/extensions/cornerstone/src/components/ViewportColorbar/ViewportColorbarsContainer.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState, useMemo, memo, useCallback } from 'react';
 import { useSystem } from '@ohif/core';
 import { ColorbarCustomization } from '../../types/Colorbar';
 import type { ColorMapPreset } from '../../types/Colormap';
-import ViewportColorbar from './ViewportColorbar';
+import ViewportColorbar, { isHorizontal } from './ViewportColorbar';
 import useViewportRendering from '../../hooks/useViewportRendering';
 import { useViewportDisplaySets } from '../../hooks/useViewportDisplaySets';
 type ViewportColorbarsContainerProps = {
@@ -74,10 +74,8 @@ const ViewportColorbarsContainer = memo(function ViewportColorbarsContainer({
     return null;
   }
 
-  const isBottom = position === 'bottom';
-
   const isSingleViewport = viewportDisplaySets.length === 1;
-  const showFullList = isSingleViewport || !isBottom;
+  const showFullList = isSingleViewport || !isHorizontal(position);
 
   const colorbarsToUse = showFullList
     ? colorbars

--- a/platform/core/src/hooks/useViewportMousePosition.ts
+++ b/platform/core/src/hooks/useViewportMousePosition.ts
@@ -2,24 +2,35 @@ import { useState, useEffect } from 'react';
 import { useViewportRef } from './useViewportRef';
 import { useViewportSize } from './useViewportSize';
 
+interface NormalizedBox {
+  minX: number;
+  minY: number;
+  maxX: number;
+  maxY: number;
+}
+
 interface MousePosition {
   x: number;
   y: number;
   isInViewport: boolean;
+  relativeX: number;
   relativeY: number; // Position as percentage from top (0-1)
   isInBottomPercentage: (percentage: number) => boolean;
+  isWithinNormalizedBox?: (normalizedBox: NormalizedBox) => boolean;
 }
 
 function useViewportMousePosition(viewportId: string): MousePosition {
   const viewportRef = useViewportRef(viewportId);
-  const { height, clientRect } = useViewportSize(viewportId);
+  const { width, height, clientRect } = useViewportSize(viewportId);
 
   const [mousePosition, setMousePosition] = useState<MousePosition>({
     x: 0,
     y: 0,
     isInViewport: false,
     relativeY: 0,
+    relativeX: 0,
     isInBottomPercentage: (percentage: number) => false,
+    isWithinNormalizedBox: (normalizedBox: NormalizedBox) => false,
   });
 
   useEffect(() => {
@@ -38,18 +49,35 @@ function useViewportMousePosition(viewportId: string): MousePosition {
 
       const isInViewport = x >= 0 && x <= clientRect.width && y >= 0 && y <= clientRect.height;
 
+      const relativeX = Math.max(0, Math.min(1, x / width));
       const relativeY = Math.max(0, Math.min(1, y / height));
 
       const isInBottomPercentage = (percentage: number) => {
-        return relativeY >= 1 - percentage / 100;
+        return isWithinNormalizedBox({
+          minX: 0,
+          minY: 1 - percentage / 100,
+          maxX: 1,
+          maxY: 1,
+        });
+      };
+
+      const isWithinNormalizedBox = (normalizedBox: NormalizedBox) => {
+        return (
+          relativeX >= normalizedBox.minX &&
+          relativeX <= normalizedBox.maxX &&
+          relativeY >= normalizedBox.minY &&
+          relativeY <= normalizedBox.maxY
+        );
       };
 
       setMousePosition({
         x,
         y,
         isInViewport,
+        relativeX,
         relativeY,
         isInBottomPercentage,
+        isWithinNormalizedBox,
       });
     };
 
@@ -58,7 +86,7 @@ function useViewportMousePosition(viewportId: string): MousePosition {
     return () => {
       document.removeEventListener('mousemove', handleMouseMove);
     };
-  }, [viewportRef, height, clientRect]);
+  }, [viewportRef, height, clientRect, width]);
 
   return mousePosition;
 }

--- a/platform/core/src/hooks/useViewportMousePosition.ts
+++ b/platform/core/src/hooks/useViewportMousePosition.ts
@@ -15,7 +15,6 @@ interface MousePosition {
   isInViewport: boolean;
   relativeX: number;
   relativeY: number; // Position as percentage from top (0-1)
-  isInBottomPercentage: (percentage: number) => boolean;
   isWithinNormalizedBox?: (normalizedBox: NormalizedBox) => boolean;
 }
 
@@ -29,7 +28,6 @@ function useViewportMousePosition(viewportId: string): MousePosition {
     isInViewport: false,
     relativeY: 0,
     relativeX: 0,
-    isInBottomPercentage: (percentage: number) => false,
     isWithinNormalizedBox: (normalizedBox: NormalizedBox) => false,
   });
 
@@ -52,15 +50,6 @@ function useViewportMousePosition(viewportId: string): MousePosition {
       const relativeX = Math.max(0, Math.min(1, x / width));
       const relativeY = Math.max(0, Math.min(1, y / height));
 
-      const isInBottomPercentage = (percentage: number) => {
-        return isWithinNormalizedBox({
-          minX: 0,
-          minY: 1 - percentage / 100,
-          maxX: 1,
-          maxY: 1,
-        });
-      };
-
       const isWithinNormalizedBox = (normalizedBox: NormalizedBox) => {
         return (
           relativeX >= normalizedBox.minX &&
@@ -76,7 +65,6 @@ function useViewportMousePosition(viewportId: string): MousePosition {
         isInViewport,
         relativeX,
         relativeY,
-        isInBottomPercentage,
         isWithinNormalizedBox,
       });
     };

--- a/tests/SEGHydration.spec.ts
+++ b/tests/SEGHydration.spec.ts
@@ -10,6 +10,8 @@ test.beforeEach(async ({ page }) => {
 test('should hydrate SEG reports correctly', async ({ page }) => {
   await page.getByTestId('side-panel-header-right').click();
   await page.getByTestId('study-browser-thumbnail-no-image').dblclick();
+
+  await page.waitForTimeout(5000);
   await checkForScreenshot(page, page, screenShotPaths.segHydration.segPreHydration);
 
   await page.evaluate(() => {
@@ -32,5 +34,7 @@ test('should hydrate SEG reports correctly', async ({ page }) => {
   });
 
   await page.getByTestId('yes-hydrate-btn').click();
+
+  await page.waitForTimeout(5000);
   await checkForScreenshot(page, page, screenShotPaths.segHydration.segPostHydration);
 });

--- a/tests/SEGHydrationFromMPR.spec.ts
+++ b/tests/SEGHydrationFromMPR.spec.ts
@@ -18,10 +18,12 @@ test('should properly display MPR for MR', async ({ page }) => {
 
   await page.getByTestId('study-browser-thumbnail-no-image').dblclick();
 
+  await page.waitForTimeout(5000);
   await checkForScreenshot(page, page, screenShotPaths.segHydrationFromMPR.mprAfterSEG);
 
   await page.getByTestId('yes-hydrate-btn').click();
 
+  await page.waitForTimeout(5000);
   await checkForScreenshot(page, page, screenShotPaths.segHydrationFromMPR.mprAfterSegHydrated);
 
   await page.getByTestId('Layout').click();

--- a/tests/SEGHydrationFromMPR.spec.ts
+++ b/tests/SEGHydrationFromMPR.spec.ts
@@ -13,6 +13,7 @@ test('should properly display MPR for MR', async ({ page }) => {
   await page.getByTestId('Layout').click();
   await page.getByTestId('MPR').click();
 
+  await page.waitForTimeout(5000);
   await checkForScreenshot(page, page, screenShotPaths.segHydrationFromMPR.mprBeforeSEG);
 
   await page.getByTestId('study-browser-thumbnail-no-image').dblclick();
@@ -26,6 +27,7 @@ test('should properly display MPR for MR', async ({ page }) => {
   await page.getByTestId('Layout').click();
   await page.getByTestId('Axial Primary').click();
 
+  await page.waitForTimeout(5000);
   await checkForScreenshot(
     page,
     page,


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context
Prior to this PR, the `AdvancedRenderingControls`  were only working and looking properly at the bottom of a viewport.

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results
`ViewportMousePosition` now has a utility for determining if the mouse pointer is in a normalized area/range of the viewport. This is useful particularly for the `AdvancedRenderingControls` that are to be hidden and shown based on the relative mouse pointer location.

A `isHorizontal` utility function was added for the `ViewportColorbar` to determine, based on its position, whether it is horizontal or not (i.e. vertical).  This function is used in several locations to set the proper styling for the `ViewportColorbar` and to determine if the full set of colorbars should be shown or not.

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing
In a mode, add the `AdvancedRenderingControls` to either the top or bottom middle of the viewport action menu. Here is a snippet of code from a mode's `onModeEnter` method that sets the `AdvancedRenderingControls` in the top middle.

```
...
      toolbarService.updateSection(toolbarService.sections.viewportActionMenu.topMiddle, [
        'AdvancedRenderingControls',
      ]);

      toolbarService.updateSection('AdvancedRenderingControls', [
        'windowLevelMenuEmbedded',
        'voiManualControlMenu',
        'Colorbar',
        'opacityMenu',
        'thresholdMenu',
      ]);
...
```

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] OS: Windows 11<!--[e.g. Windows 10, macOS 10.15.4]-->
- [x] Node version: 20.9.0<!--[e.g. 18.16.1]-->
- [x] Browser: Chrome 138.0.7204.169
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
