### PR TITLE
make segmentation stats calculation customizable

### DIFF
--- a/extensions/cornerstone/src/utils/setUpSegmentationEventHandlers.ts
+++ b/extensions/cornerstone/src/utils/setUpSegmentationEventHandlers.ts
@@ -6,12 +6,20 @@ import {
 export const setUpSegmentationEventHandlers = ({ servicesManager, commandsManager }) => {
   const { segmentationService, customizationService, displaySetService } = servicesManager.services;
 
-  const { unsubscribe: unsubscribeSegmentationDataModifiedHandler } =
-    setupSegmentationDataModifiedHandler({
-      segmentationService,
-      customizationService,
-      commandsManager,
-    });
+  const updateSegmentationStats = customizationService.getCustomization('panelSegmentation.updateSegmentationStats');
+  console.debug(updateSegmentationStats)
+  let unsubscribeSegmentationDataModifiedHandler = () => {};
+  if(updateSegmentationStats) {
+    const { unsubscribe } =
+      setupSegmentationDataModifiedHandler({
+        segmentationService,
+        customizationService,
+        commandsManager,
+      });
+      unsubscribeSegmentationDataModifiedHandler = unsubscribe;
+  }
+
+
 
   const { unsubscribe: unsubscribeSegmentationModifiedHandler } = setupSegmentationModifiedHandler({
     segmentationService,


### PR DESCRIPTION

### Context

see issue : https://github.com/OHIF/Viewers/issues/5301

### Changes & Results

Computation coast of labelmap statistics can be avoided if the project is ready to handle statistics calculation on labelmap by custom code (or even do not need calculation at all for example for labeling purpose for deep learning datasets)

### Testing

set 'panelSegmentation.updateSegmentationStats': false to disabled stats computation

### Checklist

#### PR

#### Code



#### Public Documentation Updates

It would need to add this doc : 
`panelSegmentation.updateSegmentationStats`              | Control labelmap statistics refresh on each labelmap update (default true)                       |

Where is the index of all customization attribute ?

#### Tested Environment

Linux
Node 20
Chrome Latest

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
