### PR TITLE
fix: load 3dsr

### DIFF
--- a/extensions/cornerstone-dicom-sr/src/components/OHIFCornerstoneSRMeasurementViewport.tsx
+++ b/extensions/cornerstone-dicom-sr/src/components/OHIFCornerstoneSRMeasurementViewport.tsx
@@ -86,7 +86,7 @@ function OHIFCornerstoneSRMeasurementViewport(props) {
         const { presentationIds } = viewportOptions;
         const measurement = srDisplaySet.measurements[newMeasurementSelected];
         setPositionPresentation(presentationIds.positionPresentationId, {
-          viewReference: {
+          viewReference: measurement.viewReference || {
             referencedImageId: measurement.imageId,
           },
         });

--- a/extensions/cornerstone-dicom-sr/src/getSopClassHandlerModule.ts
+++ b/extensions/cornerstone-dicom-sr/src/getSopClassHandlerModule.ts
@@ -54,7 +54,7 @@ const validateSameStudyUID = (uid: string, instances): void => {
  * @param instances is a list of instances from THIS series that are not
  *     in this DICOM SR Display Set already.
  */
-function addInstances(instances: InstanceMetadata[], displaySetService: DisplaySetService) {
+function addInstances(instances: InstanceMetadata[], _displaySetService: DisplaySetService) {
   this.instances.push(...instances);
   utils.sortStudyInstances(this.instances);
   // The last instance is the newest one, so is the one most interesting.

--- a/extensions/cornerstone-dicom-sr/src/getSopClassHandlerModule.ts
+++ b/extensions/cornerstone-dicom-sr/src/getSopClassHandlerModule.ts
@@ -35,6 +35,7 @@ const sopClassUids = [
   sopClassDictionary.BasicTextSR,
   sopClassDictionary.EnhancedSR,
   sopClassDictionary.ComprehensiveSR,
+  sopClassDictionary.Comprehensive3DSR,
 ];
 
 const validateSameStudyUID = (uid: string, instances): void => {

--- a/extensions/cornerstone-dicom-sr/src/getSopClassHandlerModule.ts
+++ b/extensions/cornerstone-dicom-sr/src/getSopClassHandlerModule.ts
@@ -289,6 +289,8 @@ function _checkIfCanAddMeasurementsToDisplaySet(
       is3DMeasurement &&
       _measurementBelongsToDisplaySet({ measurement, displaySet: newDisplaySet })
     ) {
+      _measurementBelongsToDisplaySet({ measurement, displaySet: newDisplaySet })
+
       addSRAnnotation(measurement, null, null);
       measurement.loaded = true;
       measurement.displaySetInstanceUID = newDisplaySet.displaySetInstanceUID;

--- a/extensions/cornerstone-dicom-sr/src/utils/addSRAnnotation.ts
+++ b/extensions/cornerstone-dicom-sr/src/utils/addSRAnnotation.ts
@@ -21,6 +21,7 @@ export default function addSRAnnotation(measurement, imageId, frameNumber) {
 
   /** TODO: Read the tool name from the DICOM SR identification type in the future. */
   let frameOfReferenceUID = null;
+  let planeRestriction = null;
 
   if (imageId) {
     const imagePlaneModule = metaData.get('imagePlaneModule', imageId);
@@ -37,7 +38,19 @@ export default function addSRAnnotation(measurement, imageId, frameNumber) {
 
     // get the ReferencedFrameOfReferenceUID from the measurement
     frameOfReferenceUID = measurement.coords[0].ReferencedFrameOfReferenceSequence;
+
+    planeRestriction = {
+      FrameOfReferenceUID: frameOfReferenceUID,
+      point: graphicTypePoints[0][0],
+    };
   }
+
+  // Store the view reference for use in initial navigation
+  measurement.viewReference = {
+    planeRestriction,
+    FrameOfReferenceUID: frameOfReferenceUID,
+    referencedImageId: imageId,
+  };
 
   const SRAnnotation: Types.Annotation = {
     annotationUID: TrackingUniqueIdentifier,
@@ -46,6 +59,7 @@ export default function addSRAnnotation(measurement, imageId, frameNumber) {
     invalidated: false,
     metadata: {
       toolName,
+      planeRestriction,
       valueType,
       graphicType,
       FrameOfReferenceUID: frameOfReferenceUID,

--- a/extensions/cornerstone-dicom-sr/src/utils/addSRAnnotation.ts
+++ b/extensions/cornerstone-dicom-sr/src/utils/addSRAnnotation.ts
@@ -1,11 +1,8 @@
 import { Types, annotation } from '@cornerstonejs/tools';
 import { metaData } from '@cornerstonejs/core';
-import { adaptersSR } from '@cornerstonejs/adapters';
 
 import getRenderableData from './getRenderableData';
 import toolNames from '../tools/toolNames';
-
-const { MeasurementReport } = adaptersSR.Cornerstone3D;
 
 export default function addSRAnnotation(measurement, imageId, frameNumber) {
   let toolName = toolNames.DICOMSRDisplay;
@@ -28,13 +25,6 @@ export default function addSRAnnotation(measurement, imageId, frameNumber) {
   }
 
   if (valueType === 'SCOORD3D') {
-    const adapter = MeasurementReport.getAdapterForTrackingIdentifier(
-      measurement.TrackingIdentifier
-    );
-    if (!adapter) {
-      toolName = toolNames.SRSCOORD3DPoint;
-    }
-
     // get the ReferencedFrameOfReferenceUID from the measurement
     frameOfReferenceUID = measurement.coords[0].ReferencedFrameOfReferenceSequence;
   }

--- a/extensions/cornerstone-dicom-sr/src/utils/addSRAnnotation.ts
+++ b/extensions/cornerstone-dicom-sr/src/utils/addSRAnnotation.ts
@@ -1,8 +1,11 @@
 import { Types, annotation } from '@cornerstonejs/tools';
 import { metaData } from '@cornerstonejs/core';
+import { adaptersSR } from '@cornerstonejs/adapters';
 
 import getRenderableData from './getRenderableData';
 import toolNames from '../tools/toolNames';
+
+const { MeasurementReport } = adaptersSR.Cornerstone3D;
 
 export default function addSRAnnotation(measurement, imageId, frameNumber) {
   let toolName = toolNames.DICOMSRDisplay;
@@ -25,6 +28,13 @@ export default function addSRAnnotation(measurement, imageId, frameNumber) {
   }
 
   if (valueType === 'SCOORD3D') {
+    const adapter = MeasurementReport.getAdapterForTrackingIdentifier(
+      measurement.TrackingIdentifier
+    );
+    if (!adapter) {
+      toolName = toolNames.SRSCOORD3DPoint;
+    }
+
     // get the ReferencedFrameOfReferenceUID from the measurement
     frameOfReferenceUID = measurement.coords[0].ReferencedFrameOfReferenceSequence;
   }

--- a/modes/longitudinal/src/initToolGroups.js
+++ b/modes/longitudinal/src/initToolGroups.js
@@ -87,9 +87,6 @@ function initDefaultToolGroup(extensionManager, toolGroupService, commandsManage
     enabled: [
       { toolName: toolNames.ImageOverlayViewer },
       { toolName: toolNames.ReferenceLines },
-      {
-        toolName: SRToolNames.SRSCOORD3DPoint,
-      },
     ],
     disabled: [
       {

--- a/modes/usAnnotation/src/initToolGroups.js
+++ b/modes/usAnnotation/src/initToolGroups.js
@@ -88,9 +88,6 @@ function initDefaultToolGroup(extensionManager, toolGroupService, commandsManage
     enabled: [
       { toolName: toolNames.ImageOverlayViewer },
       { toolName: toolNames.ReferenceLines },
-      {
-        toolName: SRToolNames.SRSCOORD3DPoint,
-      },
     ],
     disabled: [
       {


### PR DESCRIPTION
### Context

The 3d sr loading got broken due to removing a sop class uid from a list of supported classes.
Additionally, this PR adds the view reference to the unloaded SOP class to help with navigation.

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

Use the two point example SR from  https://github.com/OHIF/Viewers/issues/5082
Hydrate the SR, and you should see two lesion annotations, displayed as probe instances.
The points are not visible until after hydration - there is an issue with needing an image id to navigate to in the SR display set,
AND with needing an image id to be visible in the stack viewport.  This isn't an issue after rehydration.

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] OS: <!--[e.g. Windows 10, macOS 10.15.4]-->
- [] Node version: <!--[e.g. 18.16.1]-->
- [] Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
