### PR TITLE
feat(ErrorBoundary): Fixing console errors and Improving error logging for better developer experience

### DIFF
--- a/platform/ui-next/src/components/Button/Button.tsx
+++ b/platform/ui-next/src/components/Button/Button.tsx
@@ -39,13 +39,13 @@ export interface ButtonProps
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, asChild = false, ...props }, forwardRef) => {
+  ({ className, variant, size, asChild = false, dataCY, ...props }, forwardRef) => {
     const Comp = asChild ? Slot : 'button';
-    const dataCY = props.dataCY || `${props.name}-btn`;
+    const testId = dataCY || `${props.name}-btn`;
 
     return (
       <Comp
-        data-cy={dataCY}
+        data-cy={testId}
         className={cn(buttonVariants({ variant, size }), className)}
         ref={forwardRef}
         {...props}

--- a/platform/ui-next/src/components/Errorboundary/ErrorBoundary.tsx
+++ b/platform/ui-next/src/components/Errorboundary/ErrorBoundary.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { ErrorBoundary as ReactErrorBoundary, FallbackProps } from 'react-error-boundary';
 import { useTranslation } from 'react-i18next';
-import { Dialog, DialogContent } from '../Dialog/Dialog';
+import { Dialog, DialogContent, DialogTitle } from '../Dialog/Dialog';
 import { ScrollArea } from '../ScrollArea/ScrollArea';
 import { Button } from '../Button/Button';
 import { useNotification } from '../../contextProviders';
@@ -181,6 +181,7 @@ const DefaultFallback = ({
       open={showDetails}
       onOpenChange={setShowDetails}
     >
+      <DialogTitle className="invisible">{errorTitle}</DialogTitle>
       <DialogContent
         className="bg-muted max-w-3xl overflow-hidden border-0 p-0"
         onInteractOutside={e => e.preventDefault()}

--- a/platform/ui-next/src/components/Errorboundary/ErrorBoundary.tsx
+++ b/platform/ui-next/src/components/Errorboundary/ErrorBoundary.tsx
@@ -263,7 +263,6 @@ const ErrorBoundary = ({
     let errorTimeout: NodeJS.Timeout;
 
     const handleError = (event: ErrorEvent) => {
-      event.preventDefault();
       clearTimeout(errorTimeout);
       errorTimeout = setTimeout(() => {
         setError(event.error);


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

I was having a bad experience while trying to find the source of errors I was facing, not being able to see the errors at the console, and being misguided by errors in the console that had no relation with the issue itself. The changes on this PR solved both of this problems.

### Changes & Results

- a0f9bc8203a2d029df4ad20e4e7aa825f38af1c5 - This fix removed the following error to be shown in the console while rendering the error dialog, which was misguiding me while searching for the actual error.

**Previous:**
<img width="1902" height="659" alt="image" src="https://github.com/user-attachments/assets/1a63dba6-2fb1-4888-be1f-ee900af94765" />

**After:**
(No error)

- 01e5c43f607bb002e5019f0a3e4b82fdf16db338 - This fix removed the following error to be shown while opening the error dialog after clicking the "Show details" button, also was misguiding since it is not related to the issue itself.

**Previous:**
<img width="1899" height="91" alt="image" src="https://github.com/user-attachments/assets/dc2b2639-f803-481e-97ce-28adcd5d27d9" />

**After:**
(No error)


- d5b7a04e944dfd59d9d39f3145c290c4e56ed223 - This removes the prevent default behavior that was making the error that generated the error screen itself, to not be printed to the console.

**Previous:**
(No error)

**After (example):**
<img width="1896" height="940" alt="image" src="https://github.com/user-attachments/assets/4eec798e-126b-47ad-8eb0-5e69dd86b22e" />

> Note that there are two huge wins on having this error being displayed at the console here. 
The first one one of them is the usage of the code source maps, I couldn't find a way to use a JavaScript API to display the mapped files in the Dialog UI without a huge change. But, by having the error in the console, the browser automatically uses the source maps and we can see the original file and line where the error happened, in this example is "ToolbarService.ts:664:1". Previously I would have just the Dialog UI file, that says that the file where the error happened is "http://localhost:3000/static/js/index.js:18727:40", which is not of much help since it points to the "compiled" file, and not the original one.
The second one is the integration with the browser's DevTools, with the error in the console I can click on the file and go directly to the file in DevTools, putting a breakpoint on it to further investigate what was the issue, allowing me to go through the error stack in real time. 

### Testing

Intentionally create a issue that will throw an unhandled error in OHIF, e.g. add a not registered tool at modes/longitudinal/src/index.ts:133 into the `toolbarService.updateSection` second parameter array, such as:
```ts
toolbarService.updateSection('MeasurementTools', [
    'Length',
    'Bidirectional',
    'ArrowAnnotate',
    'NotRegistered', // <--- will cause error
    'EllipticalROI',
    'RectangleROI',
    'CircleROI',
    'PlanarFreehandROI',
    'SplineROI',
    'LivewireContour',
]);
```

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] OS: Windows 11 Home 24H2 + WSL Ubuntu 22.04.4 LTS 
- [x] Node version: v20.9.0
- [x] Browser: Microsoft Edge 139.0.3405.119

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
