### PR TITLE
fix(cornerstone-dicom-rt): adding caching usage to cornerstone-dicom-rt SOP Class Handler

### DIFF
--- a/extensions/cornerstone-dicom-rt/src/getSopClassHandlerModule.ts
+++ b/extensions/cornerstone-dicom-rt/src/getSopClassHandlerModule.ts
@@ -4,7 +4,9 @@ import i18n from '@ohif/i18n';
 import { SOPClassHandlerId } from './id';
 import loadRTStruct from './loadRTStruct';
 
-const sopClassUids = ['1.2.840.10008.5.1.4.1.1.481.3'];
+const { sopClassDictionary } = utils;
+
+const sopClassUids = [sopClassDictionary.RTStructureSetStorage];
 
 const loadPromises = {};
 

--- a/extensions/cornerstone-dicom-rt/src/loadRTStruct.js
+++ b/extensions/cornerstone-dicom-rt/src/loadRTStruct.js
@@ -140,11 +140,9 @@ export default async function loadRTStruct(extensionManager, rtStructDisplaySet,
     const ContourSequenceArray = _toArray(ContourSequence);
 
     const contourPoints = [];
-    for (let c = 0; c < ContourSequenceArray.length; c++) {
+    for (const ContourSequenceItem of ContourSequenceArray) {
       const { ContourData, NumberOfContourPoints, ContourGeometricType, ContourImageSequence } =
-        ContourSequenceArray[c];
-
-      let isSupported = false;
+        ContourSequenceItem;
 
       const points = [];
       for (let p = 0; p < NumberOfContourPoints * 3; p += 3) {
@@ -155,22 +153,18 @@ export default async function loadRTStruct(extensionManager, rtStructDisplaySet,
         });
       }
 
-      switch (ContourGeometricType) {
-        case 'CLOSED_PLANAR':
-        case 'OPEN_PLANAR':
-        case 'POINT':
-          isSupported = true;
-
-          break;
-        default:
-          continue;
-      }
+      const supportedContourTypesMap = new Map([
+        ['CLOSED_PLANAR', false],
+        ['OPEN_NONPLANAR', false],
+        ['OPEN_PLANAR', false],
+        ['POINT', true],
+      ]);
 
       contourPoints.push({
         numberOfPoints: NumberOfContourPoints,
         points,
         type: ContourGeometricType,
-        isSupported,
+        isSupported: supportedContourTypesMap.get(ContourGeometricType) ?? false,
       });
 
       if (ContourImageSequence?.ReferencedSOPInstanceUID) {
@@ -209,6 +203,7 @@ function _setROIContourMetadata(
     ROIDescription: StructureSetROI.ROIDescription,
     contourPoints,
     visible: true,
+    colorArray: [],
   };
 
   _setROIContourDataColor(ROIContour, ROIContourData);

--- a/extensions/cornerstone-dicom-rt/src/loadRTStruct.js
+++ b/extensions/cornerstone-dicom-rt/src/loadRTStruct.js
@@ -137,8 +137,6 @@ export default async function loadRTStruct(extensionManager, rtStructDisplaySet,
       continue;
     }
 
-    const isSupported = false;
-
     const ContourSequenceArray = _toArray(ContourSequence);
 
     const contourPoints = [];
@@ -187,8 +185,7 @@ export default async function loadRTStruct(extensionManager, rtStructDisplaySet,
       StructureSetROISequence,
       RTROIObservationsSequence,
       ROIContour,
-      contourPoints,
-      isSupported
+      contourPoints
     );
   }
   return structureSet;
@@ -199,8 +196,7 @@ function _setROIContourMetadata(
   StructureSetROISequence,
   RTROIObservationsSequence,
   ROIContour,
-  contourPoints,
-  isSupported
+  contourPoints
 ) {
   const StructureSetROI = StructureSetROISequence.find(
     structureSetROI => structureSetROI.ROINumber === ROIContour.ReferencedROINumber
@@ -211,7 +207,6 @@ function _setROIContourMetadata(
     ROIName: StructureSetROI.ROIName,
     ROIGenerationAlgorithm: StructureSetROI.ROIGenerationAlgorithm,
     ROIDescription: StructureSetROI.ROIDescription,
-    isSupported,
     contourPoints,
     visible: true,
   };

--- a/extensions/cornerstone/src/services/SegmentationService/SegmentationService.ts
+++ b/extensions/cornerstone/src/services/SegmentationService/SegmentationService.ts
@@ -580,6 +580,13 @@ class SegmentationService extends PubSubService {
       ) || null;
 
     rtDisplaySet.firstSegmentedSliceImageId = firstSegmentedSliceImageId;
+
+    if (!structureSet.ROIContours?.length) {
+      throw new Error(
+        'The structureSet does not contain any ROIContours. Please ensure the structureSet is loaded first.'
+      );
+    }
+
     // Map ROI contours to RT Struct Data
     const allRTStructData = mapROIContoursToRTStructData(structureSet, rtDisplaySetUID);
 
@@ -601,12 +608,6 @@ class SegmentationService extends PubSubService {
         label: rtDisplaySet.SeriesDescription,
       },
     };
-
-    if (!structureSet.ROIContours?.length) {
-      throw new Error(
-        'The structureSet does not contain any ROIContours. Please ensure the structureSet is loaded first.'
-      );
-    }
 
     const segments: { [segmentIndex: string]: cstTypes.Segment } = {};
     let segmentsCachedStats = {};

--- a/extensions/cornerstone/src/services/SegmentationService/SegmentationService.ts
+++ b/extensions/cornerstone/src/services/SegmentationService/SegmentationService.ts
@@ -574,7 +574,9 @@ class SegmentationService extends PubSubService {
     // find the first image id that contains a referenced SOP instance UID
     const firstSegmentedSliceImageId =
       referencedImageIds?.find(imageId =>
-        referencedImageIdsWithGeometry.some(referencedId => imageId.includes(referencedId))
+        referencedImageIdsWithGeometry.some(referencedId =>
+          imageId.includes(referencedId as string)
+        )
       ) || null;
 
     rtDisplaySet.firstSegmentedSliceImageId = firstSegmentedSliceImageId;


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

While investigating the RT Struct SOP Class Handler I noticed that the DisplaySets were being loaded over again if they already were loaded previously and could live in a cache. There was a "TODO" marker to make the feature available, so I investigated it and added an implementation that I could verify that was preventing new loading calls to be done, by early exiting the `_load` function if the RTStruct and Segmentation are already loaded.

### Changes & Results

Made the commits atomic and well commented so they document themselves, except by the one responsible for the main reason for the PR itself, that is documented below:

4d01f40e75f6607a3ec85e54cbfe195af8d07dde: The old implementation would use the `_segmentationExistsInCache` function to validate if the display set needed to be loaded again, but it was missing implementation, and always returned false, which was causing it to always load again, even if the display set was already loaded.

So I begin with the investigation to understand what actually meant this function, and why not just rely on the `isLoaded` flag of the display set. The true is that the `load` function of this RTStruct display set, allows the user to create or not a segmentation depending on the `createSegmentation` flag, therefore you could have your RTStruct in a "partially loaded state", where you would have called the `loadRTStruct` function for your display set, but not the `createSegmentationForRTDisplaySet` one. This state was characterized by having `isLoaded` flag set to true, and the segmentation not available in cache. 

The first approach I thought was to remove the `isLoaded` of true only by loading the RTStruct, but since the user of the handler could load the display set without loading the segmentations, this could be misleading. So the approach that I choose was to subscribe to SEGMENTATION_LOADING_COMPLETE, and add the `displaySetInstanceUID` to a Set data structure so I could keep track of the ones that had their Segmentation loaded, being it through the SOP Class Handler or independently. 

If the displaySet was on a loading/isLoaded state, had its loadPromise registered and has its SEGs cached, there is no nead to load the diaplay set again, therefore the cache is used.

#### Results 1
To assert the feature, one thing that could be done is to load a RT Struct, load a normal series (e.g. CT) and then load the same RT Struct again.

> Note: for the results screenshots, the load function is called twice due to a default behavior of React on dev environment of calling useEffects twice to assure consistency.

**Before the changes**
- Setup
<img width="834" height="252" alt="image" src="https://github.com/user-attachments/assets/c007a301-d21a-425d-b486-9f4df265df76" />

- Results
<img width="488" height="109" alt="image" src="https://github.com/user-attachments/assets/d09d2355-1ac4-4208-add7-a030885f040f" />

**After the changes**
- Setup
<img width="842" height="267" alt="image" src="https://github.com/user-attachments/assets/5ad0d56b-164d-4a2f-902f-add1cbc4f14f" />

- Results
<img width="948" height="121" alt="image" src="https://github.com/user-attachments/assets/2a7b8978-bba8-4cb3-bdf2-9e284cd24983" />


#### Results 2
Another setup that I created to validate was to verify if it was possible to first load only the RT Struct and then the segmentations.

- Results
<img width="464" height="230" alt="image" src="https://github.com/user-attachments/assets/378f056f-6f51-44ae-894d-b3a83f01da41" />


<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing
It is possible to do the setup described above, or put breakpoints to validate the code workflow. The OHIF standard database has some studies with RT Structs, such as `StudyInstanceUIDs=1.3.6.1.4.1.14519.5.2.1.5099.8010.217836670708542506360829799868`, or you can open your own RT Struct study as I've done with one from IDC to validate it.


<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] OS: Windows 11 Home 24H2 + WSL Ubuntu 22.04.4 LTS
- [x] Node version: v20.9.0
- [x] Browser: Microsoft Edge 139.0.3405.119

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
