### PR TITLE
feat(DICOM Upload): Allow configuring maximum concurrent uploads

### DIFF
--- a/platform/app/public/config/default.js
+++ b/platform/app/public/config/default.js
@@ -24,6 +24,8 @@ window.config = {
     // Prefetch number is dependent on the http protocol. For http 2 or
     // above, the number of requests can be go a lot higher.
     prefetch: 25,
+    // Maximum number of concurrent DICOM uploads
+    upload: 20,
   },
   // filterQueryParam: false,
   // Defines multi-monitor layouts

--- a/platform/app/public/config/default_16bit.js
+++ b/platform/app/public/config/default_16bit.js
@@ -23,6 +23,8 @@ window.config = {
     // Prefetch number is dependent on the http protocol. For http 2 or
     // above, the number of requests can be go a lot higher.
     prefetch: 25,
+    // Maximum number of concurrent DICOM uploads
+    upload: 3,
   },
   // filterQueryParam: false,
   dataSources: [

--- a/platform/app/public/config/docker-nginx-orthanc-keycloak.js
+++ b/platform/app/public/config/docker-nginx-orthanc-keycloak.js
@@ -15,6 +15,8 @@ window.config = {
     interaction: 100,
     thumbnail: 75,
     prefetch: 25,
+    // Maximum number of concurrent DICOM uploads
+    upload: 3,
   },
   defaultDataSourceName: 'dicomweb',
   dataSources: [

--- a/platform/app/public/config/kheops.js
+++ b/platform/app/public/config/kheops.js
@@ -19,6 +19,8 @@ window.config = {
   maxNumRequests: {
     interaction: 100,
     thumbnail: 75,
+    // Maximum number of concurrent DICOM uploads
+    upload: 3,
     // Prefetch number is dependent on the http protocol. For http 2 or
     // above, the number of requests can be go a lot higher.
     prefetch: 25,

--- a/platform/core/src/types/AppTypes.ts
+++ b/platform/core/src/types/AppTypes.ts
@@ -103,6 +103,7 @@ declare global {
       maxNumRequests?: {
         interaction?: number;
         prefetch?: number;
+        upload?: number;
         thumbnail?: number;
         compute?: number;
       };

--- a/platform/docs/docs/configuration/configurationFiles.md
+++ b/platform/docs/docs/configuration/configurationFiles.md
@@ -132,7 +132,8 @@ Here are a list of some options available:
 - `requestTransferSyntaxUID` : Request a specific Transfer syntax from dicom web server ex: 1.2.840.10008.1.2.4.80  (applied only if acceptHeader is not set)
 - `omitQuotationForMultipartRequest`: Some servers (e.g., .NET) require the `multipart/related` request to be sent without quotation marks. Defaults to `false`. If your server doesn't require this, then setting this flag to `true` might improve performance (by removing the need for preflight requests). Also note that
 if auth headers are used, a preflight request is required.
-- `maxNumRequests`: The maximum number of requests to allow in parallel. It is an object with keys of `interaction`, `thumbnail`, and `prefetch`. You can specify a specific number for each type.
+- `maxNumRequests`: The maximum number of requests to allow in parallel. It is an object with keys of `interaction`, `thumbnail`, `prefetch`, and `upload`. You can specify a specific number for each type.
+  - `upload`: Maximum number of concurrent DICOM file uploads when using the DICOM upload plugin (default: 3)
 - `modesConfiguration`: Allows overriding modes configuration.
   - Example config:
   ```js


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->

### Context

Add configurable concurrency control for DICOM uploads to prevent server overload and improve upload performance. Previously, all uploads started simultaneously regardless of network capacity.

### Changes & Results

- Add `maxNumRequests.upload` configuration option (default: 3)
- Implement lazy `DicomFileUploader` instantiation - XHR objects only created when upload starts
- Add upload queue management with configurable concurrency limiting
- Update components to handle queued vs active upload states

**Result:** Better server resource management and configurable upload performance optimization.

### Testing

1. Set `maxNumRequests.upload: 2` in config
2. Upload 5+ DICOM files 
3. Verify only 2 uploads run simultaneously
4. Check network tab - XHR requests created only when uploads start

#### Before
Last uploaded files have long running requests that timeout on many DICOMWeb implementations
<img width="1920" height="430" alt="Screenshot 2025-09-10 at 20 34 37" src="https://github.com/user-attachments/assets/094202f0-92e1-4af7-a080-56cafcd50959" />

#### After
Last uploaded files are only launched when prior requests have completed

<img width="1920" height="414" alt="Screenshot 2025-09-10 at 20 15 14" src="https://github.com/user-attachments/assets/2cc6db76-0f2c-4e8d-8806-4cf8d116fbce" />


### Checklist

#### PR
- [x] My Pull Request title is descriptive, accurate and follows the semantic-release format and guidelines.

#### Code
- [x] My code has been well-documented (function documentation, inline comments, etc.)

#### Public Documentation Updates
- [x] The documentation page has been updated as necessary for any public API additions or removals.

#### Tested Environment
- [x] OS: macOS 14.3.0
- [x] Node version: 22.14.0
- [x] Browser: Chrome

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->