### PR TITLE
feat(segmentation): Separate segmentation utilities from the segmentation tools

### DIFF
--- a/extensions/cornerstone-dicom-seg/src/getToolbarModule.ts
+++ b/extensions/cornerstone-dicom-seg/src/getToolbarModule.ts
@@ -31,37 +31,6 @@ export function getToolbarModule({ servicesManager }: withAppTypes) {
           return {
             disabled: true,
             disabledText: `No ${segmentationRepresentationType} segmentations available`,
-            visible: customizationService.getCustomization('panelSegmentation.isMultiTab'),
-          };
-        }
-      },
-    },
-    {
-      name: 'evaluate.cornerstone.isActiveSegmentationOfType',
-      evaluate: ({ viewportId, segmentationRepresentationType }) => {
-        const activeSegmentation = segmentationService.getActiveSegmentation(viewportId);
-        if (!activeSegmentation || !Object.keys(activeSegmentation.segments).length) {
-          return {
-            disabled: true,
-            disabledText: 'Add segment to enable this tool',
-          };
-        }
-
-        const activeRepresentations = segmentationService.getSegmentationRepresentations(
-          viewportId,
-          {
-            segmentationId: activeSegmentation.segmentationId,
-            type: segmentationRepresentationType,
-          }
-        );
-        if (!activeRepresentations?.length) {
-          return {
-            disabled: true,
-            disabledText: `Active segmentation is not a ${segmentationRepresentationType} segmentation`,
-            // Set the visible flag to false for single tab mode so that only the tools and utilities for
-            // the active segmentation representation type are shown. This is not needed for multi-tab mode because
-            // the tools and utilities are already segregated by by type in each tab.
-            visible: customizationService.getCustomization('panelSegmentation.isMultiTab'),
           };
         }
       },

--- a/extensions/cornerstone/src/commandsModule.ts
+++ b/extensions/cornerstone/src/commandsModule.ts
@@ -2203,6 +2203,20 @@ function commandsModule({
         deleting,
       });
     },
+    activateSelectedSegmentationOfType: ({ segmentationRepresentationType }) => {
+      const { segmentationService, viewportGridService } = servicesManager.services;
+      const activeViewportId = viewportGridService.getActiveViewportId();
+      const segmentationId = segmentationService.getSelectedSegmentation({
+        viewportId: activeViewportId,
+        segmentationRepresentationType,
+      });
+
+      if (!segmentationId) {
+        return;
+      }
+
+      segmentationService.setActiveSegmentation(activeViewportId, segmentationId);
+    },
   };
 
   const definitions = {
@@ -2502,6 +2516,7 @@ function commandsModule({
     toggleSegmentLabel: actions.toggleSegmentLabel,
     jumpToMeasurementViewport: actions.jumpToMeasurementViewport,
     initializeSegmentLabelTool: actions.initializeSegmentLabelTool,
+    activateSelectedSegmentationOfType: actions.activateSelectedSegmentationOfType,
   };
 
   return {

--- a/extensions/cornerstone/src/components/SegmentationUtilityButton.tsx
+++ b/extensions/cornerstone/src/components/SegmentationUtilityButton.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+import { Button } from '@ohif/ui-next';
+
+interface SegmentationUtilityButtonProps {
+  onInteraction: (details: { itemId: string; commands?: Record<string, unknown> }) => void;
+  disabled: boolean;
+  id: string;
+  commands: Record<string, unknown>;
+}
+
+function SegmentationUtilityButton(props: SegmentationUtilityButtonProps) {
+  const { onInteraction, disabled, id: itemId, commands } = props;
+
+  return (
+    <Button
+      onClick={() => {
+        if (!disabled) {
+          onInteraction?.({ itemId, commands });
+        }
+      }}
+      {...props}
+    />
+  );
+}
+
+export default SegmentationUtilityButton;

--- a/extensions/cornerstone/src/getPanelModule.tsx
+++ b/extensions/cornerstone/src/getPanelModule.tsx
@@ -8,10 +8,9 @@ import { SegmentationRepresentations } from '@cornerstonejs/tools/enums';
 import i18n from '@ohif/i18n';
 
 const getPanelModule = ({ commandsManager, servicesManager, extensionManager }: withAppTypes) => {
-  const selectedSegmentationIdByViewportAndType: Map<string, Map<string, string>> = new Map();
   const { toolbarService } = servicesManager.services;
 
-  const toolbarMap = {
+  const toolSectionMap = {
     Segmentation: toolbarService.sections.segmentationToolbox,
     [SegmentationRepresentations.Labelmap]: toolbarService.sections.labelMapSegmentationToolbox,
     [SegmentationRepresentations.Contour]: toolbarService.sections.contourSegmentationToolbox,
@@ -27,7 +26,6 @@ const getPanelModule = ({ commandsManager, servicesManager, extensionManager }: 
           ...props?.configuration,
         }}
         segmentationRepresentationType={props?.segmentationRepresentationType}
-        selectedSegmentationIdByViewportAndType={selectedSegmentationIdByViewportAndType}
       />
     );
   };
@@ -42,7 +40,6 @@ const getPanelModule = ({ commandsManager, servicesManager, extensionManager }: 
           ...props?.configuration,
         }}
         segmentationRepresentationType={props?.segmentationRepresentationType}
-        selectedSegmentationIdByViewportAndType={selectedSegmentationIdByViewportAndType}
       />
     );
   };
@@ -55,7 +52,7 @@ const getPanelModule = ({ commandsManager, servicesManager, extensionManager }: 
     return (
       <>
         <Toolbox
-          buttonSectionId={toolbarMap[props.segmentationRepresentationType ?? 'Segmentation']}
+          buttonSectionId={toolSectionMap[props.segmentationRepresentationType ?? 'Segmentation']}
           title={tValue}
         />
         <PanelSegmentation
@@ -66,7 +63,6 @@ const getPanelModule = ({ commandsManager, servicesManager, extensionManager }: 
             ...props?.configuration,
           }}
           segmentationRepresentationType={props?.segmentationRepresentationType}
-          selectedSegmentationIdByViewportAndType={selectedSegmentationIdByViewportAndType}
         />
       </>
     );
@@ -120,7 +116,7 @@ const getPanelModule = ({ commandsManager, servicesManager, extensionManager }: 
     },
     {
       name: 'panelSegmentationWithToolsContour',
-      iconName: 'tab-segmentation',
+      iconName: 'tab-contours',
       iconLabel: 'Segmentation',
       label: i18n.t('SegmentationTable:Contour'),
       component: props =>

--- a/extensions/cornerstone/src/panels/PanelSegmentation.tsx
+++ b/extensions/cornerstone/src/panels/PanelSegmentation.tsx
@@ -1,29 +1,33 @@
 import React from 'react';
-import { SegmentationTable } from '@ohif/ui-next';
+import { Button, IconPresentationProvider, SegmentationTable, ToolButton } from '@ohif/ui-next';
 import { useActiveViewportSegmentationRepresentations } from '../hooks/useActiveViewportSegmentationRepresentations';
 import { metaData, cache } from '@cornerstonejs/core';
 import { useSystem } from '@ohif/core/src';
 import { SegmentationRepresentations } from '@cornerstonejs/tools/enums';
+import { Toolbar } from '@ohif/extension-default';
+import SegmentationUtilityButton from '../components/SegmentationUtilityButton';
 
 type PanelSegmentationProps = {
   children?: React.ReactNode;
 
   // The representation type for this segmentation panel. Undefined means all types.
   segmentationRepresentationType?: SegmentationRepresentations;
-
-  // A map of viewportId -> (map of representation type -> segmentationId)
-  // It keeps track of the last selected segmentationId for each representation type in each viewport.
-  selectedSegmentationIdByViewportAndType: Map<string, Map<string, string>>;
 } & withAppTypes;
 
 export default function PanelSegmentation({
   children,
   segmentationRepresentationType,
-  selectedSegmentationIdByViewportAndType,
 }: PanelSegmentationProps) {
   const { commandsManager, servicesManager } = useSystem();
-  const { customizationService, displaySetService, viewportGridService } = servicesManager.services;
+  const { customizationService, displaySetService, viewportGridService, segmentationService } =
+    servicesManager.services;
   const { activeViewportId } = viewportGridService.getState();
+
+  const utilitiesSectionMap = {
+    Segmentation: 'SegmentationUtilities',
+    [SegmentationRepresentations.Labelmap]: 'LabelMapUtilities',
+    [SegmentationRepresentations.Contour]: 'ContourUtilities',
+  };
 
   const { segmentationsWithRepresentations, disabled } =
     useActiveViewportSegmentationRepresentations();
@@ -168,28 +172,13 @@ export default function PanelSegmentation({
     };
   });
 
-  // Update the map of last selected segmentation IDs for the active viewport id.
-  const activeSegmentationInfo = segmentationsWithRepresentations.find(
-    info => info.representation?.active
-  );
-
-  if (activeSegmentationInfo) {
-    const typeToSegmentationIdMap =
-      selectedSegmentationIdByViewportAndType.get(activeViewportId) ?? new Map<string, string>();
-
-    typeToSegmentationIdMap.set(
-      activeSegmentationInfo.representation.type,
-      activeSegmentationInfo.segmentation.segmentationId
-    );
-
-    selectedSegmentationIdByViewportAndType.set(activeViewportId, typeToSegmentationIdMap);
-  }
-
   const selectedSegmentationIdForType = segmentationRepresentationType
-    ? selectedSegmentationIdByViewportAndType
-        .get(activeViewportId)
-        ?.get(segmentationRepresentationType)
-    : activeSegmentationInfo?.segmentation?.segmentationId;
+    ? segmentationService.getSelectedSegmentation({
+        viewportId: activeViewportId,
+        segmentationRepresentationType,
+      })
+    : segmentationsWithRepresentations.find(info => info.representation?.active)?.segmentation
+        ?.segmentationId;
 
   // Common props for SegmentationTable
   const tableProps = {
@@ -205,6 +194,25 @@ export default function PanelSegmentation({
     segmentationRepresentationType,
     selectedSegmentationIdForType,
     ...handlers,
+  };
+
+  const renderUtilitiesToolbar = () => {
+    return (
+      <IconPresentationProvider
+        size="large"
+        IconContainer={SegmentationUtilityButton}
+        containerProps={{
+          variant: 'ghost',
+          className: 'w-7 h-7',
+        }}
+      >
+        <div className="flex gap-[3px] bg-transparent">
+          <Toolbar
+            buttonSection={utilitiesSectionMap[segmentationRepresentationType ?? 'Segmentation']}
+          />
+        </div>
+      </IconPresentationProvider>
+    );
   };
 
   const renderSegments = () => {
@@ -223,6 +231,7 @@ export default function PanelSegmentation({
     if (tableProps.mode === 'collapsed') {
       return (
         <SegmentationTable.Collapsed>
+          {renderUtilitiesToolbar()}
           <SegmentationTable.Collapsed.Header>
             <SegmentationTable.Collapsed.DropdownMenu>
               <CustomDropdownMenuContent />
@@ -241,6 +250,7 @@ export default function PanelSegmentation({
     return (
       <>
         <SegmentationTable.Expanded>
+          {renderUtilitiesToolbar()}
           <SegmentationTable.Expanded.Header>
             <SegmentationTable.Expanded.DropdownMenu>
               <CustomDropdownMenuContent />

--- a/extensions/cornerstone/src/utils/setUpSegmentationEventHandlers.ts
+++ b/extensions/cornerstone/src/utils/setUpSegmentationEventHandlers.ts
@@ -1,10 +1,17 @@
 import {
   setupSegmentationDataModifiedHandler,
   setupSegmentationModifiedHandler,
+  setupAutoTabSwitchHandler,
 } from './segmentationHandlers';
 
 export const setUpSegmentationEventHandlers = ({ servicesManager, commandsManager }) => {
-  const { segmentationService, customizationService, displaySetService } = servicesManager.services;
+  const {
+    segmentationService,
+    customizationService,
+    displaySetService,
+    viewportGridService,
+    panelService,
+  } = servicesManager.services;
 
   const { unsubscribe: unsubscribeSegmentationDataModifiedHandler } =
     setupSegmentationDataModifiedHandler({
@@ -50,10 +57,17 @@ export const setUpSegmentationEventHandlers = ({ servicesManager, commandsManage
     }
   );
 
+  const { unsubscribeAutoTabSwitchEvents } = setupAutoTabSwitchHandler({
+    segmentationService,
+    viewportGridService,
+    panelService,
+  });
+
   const unsubscriptions = [
     unsubscribeSegmentationDataModifiedHandler,
     unsubscribeSegmentationModifiedHandler,
     unsubscribeSegmentationCreated,
+    ...unsubscribeAutoTabSwitchEvents,
   ];
 
   return { unsubscriptions };

--- a/modes/segmentation/src/index.tsx
+++ b/modes/segmentation/src/index.tsx
@@ -118,7 +118,7 @@ function modeFactory({ modeConfiguration }) {
         'TagBrowser',
       ]);
 
-      const commonSegmentationUtilities = ['SegmentLabelTool'];
+      const commonSegmentationTools = ['SegmentLabelTool'];
 
       // Placeholder for near future.
       const contourUtilities = [];
@@ -134,43 +134,33 @@ function modeFactory({ modeConfiguration }) {
 
       const labelMapTools = ['BrushTools', 'MarkerLabelmap', 'RegionSegmentPlus', 'Shapes'];
 
-      const allSegmentationUtilities = [
-        ...contourUtilities,
-        ...labelMapUtilities,
-        ...commonSegmentationUtilities,
-      ];
-
-      const allSegmentationTools = [...contourTools, ...labelMapTools];
-
       // We cannot simply create two sections - utilities and tools - that combine the utilities and tools for both
       // segmentation types and add them to each tab because switching to a tab does not activate its selected segmentation
       // and thus the utilities/tools of the other tab might be incorrectly displayed.
       toolbarService.updateSection(toolbarService.sections.segmentationToolbox, [
-        'SegmentationUtilities',
         'SegmentationTools',
       ]);
       toolbarService.updateSection(toolbarService.sections.labelMapSegmentationToolbox, [
-        'LabelMapUtilities',
         'LabelMapTools',
       ]);
       toolbarService.updateSection(toolbarService.sections.contourSegmentationToolbox, [
-        'ContourUtilities',
         'ContourTools',
       ]);
 
-      toolbarService.updateSection('SegmentationUtilities', allSegmentationUtilities);
-      toolbarService.updateSection('LabelMapUtilities', [
-        ...labelMapUtilities,
-        ...commonSegmentationUtilities,
+      toolbarService.updateSection('SegmentationTools', [
+        ...contourTools,
+        ...labelMapTools,
+        ...commonSegmentationTools,
       ]);
-      toolbarService.updateSection('ContourUtilities', [
-        ...contourUtilities,
-        ...commonSegmentationUtilities,
-      ]);
+      toolbarService.updateSection('LabelMapTools', [...labelMapTools, ...commonSegmentationTools]);
+      toolbarService.updateSection('ContourTools', [...contourTools, ...commonSegmentationTools]);
 
-      toolbarService.updateSection('SegmentationTools', allSegmentationTools);
-      toolbarService.updateSection('LabelMapTools', labelMapTools);
-      toolbarService.updateSection('ContourTools', contourTools);
+      toolbarService.updateSection('SegmentationUtilities', [
+        ...contourUtilities,
+        ...labelMapUtilities,
+      ]);
+      toolbarService.updateSection('LabelMapUtilities', labelMapUtilities);
+      toolbarService.updateSection('ContourUtilities', contourUtilities);
 
       toolbarService.updateSection('BrushTools', ['Brush', 'Eraser', 'Threshold']);
     },

--- a/modes/segmentation/src/toolbarButtons.ts
+++ b/modes/segmentation/src/toolbarButtons.ts
@@ -437,10 +437,16 @@ const toolbarButtons: Button[] = [
           disabledText: 'Create new segmentation to enable this tool.',
         },
         {
-          name: 'evaluate.cornerstone.isActiveSegmentationOfType',
+          name: 'evaluate.cornerstone.hasSegmentationOfType',
           segmentationRepresentationType: SegmentationRepresentations.Labelmap,
         },
       ],
+      commands: {
+        commandName: 'activateSelectedSegmentationOfType',
+        commandOptions: {
+          segmentationRepresentationType: SegmentationRepresentations.Labelmap,
+        },
+      },
       options: [
         {
           name: 'Radius (mm)',
@@ -450,10 +456,12 @@ const toolbarButtons: Button[] = [
           max: 99.5,
           step: 0.5,
           value: 25,
-          commands: {
-            commandName: 'setBrushSize',
-            commandOptions: { toolNames: ['CircularBrush', 'SphereBrush'] },
-          },
+          commands: [
+            {
+              commandName: 'setBrushSize',
+              commandOptions: { toolNames: ['CircularBrush', 'SphereBrush'] },
+            },
+          ],
         },
         {
           name: 'Shape',
@@ -464,14 +472,14 @@ const toolbarButtons: Button[] = [
             { value: 'CircularBrush', label: 'Circle' },
             { value: 'SphereBrush', label: 'Sphere' },
           ],
-          commands: 'setToolActiveToolbar',
+          commands: ['setToolActiveToolbar'],
         },
       ],
     },
   },
   {
     id: 'InterpolateLabelmap',
-    uiType: 'ohif.toolBoxButton',
+    uiType: 'ohif.toolButton',
     props: {
       icon: 'icon-tool-interpolation',
       label: 'Interpolate Labelmap',
@@ -482,7 +490,7 @@ const toolbarButtons: Button[] = [
           name: 'evaluate.cornerstone.segmentation',
         },
         {
-          name: 'evaluate.cornerstone.isActiveSegmentationOfType',
+          name: 'evaluate.cornerstone.hasSegmentationOfType',
           segmentationRepresentationType: SegmentationRepresentations.Labelmap,
         },
         {
@@ -490,12 +498,20 @@ const toolbarButtons: Button[] = [
           disabledText: 'The current viewport cannot handle interpolation.',
         },
       ],
-      commands: 'interpolateLabelmap',
+      commands: [
+        {
+          commandName: 'activateSelectedSegmentationOfType',
+          commandOptions: {
+            segmentationRepresentationType: SegmentationRepresentations.Labelmap,
+          },
+        },
+        'interpolateLabelmap',
+      ],
     },
   },
   {
     id: 'SegmentBidirectional',
-    uiType: 'ohif.toolBoxButton',
+    uiType: 'ohif.toolButton',
     props: {
       icon: 'icon-tool-bidirectional-segment',
       label: 'Segment Bidirectional',
@@ -507,11 +523,19 @@ const toolbarButtons: Button[] = [
           disabledText: 'Create new segmentation to enable this tool.',
         },
         {
-          name: 'evaluate.cornerstone.isActiveSegmentationOfType',
+          name: 'evaluate.cornerstone.hasSegmentationOfType',
           segmentationRepresentationType: SegmentationRepresentations.Labelmap,
         },
       ],
-      commands: 'runSegmentBidirectional',
+      commands: [
+        {
+          commandName: 'activateSelectedSegmentationOfType',
+          commandOptions: {
+            segmentationRepresentationType: SegmentationRepresentations.Labelmap,
+          },
+        },
+        'runSegmentBidirectional',
+      ],
     },
   },
   {
@@ -529,16 +553,24 @@ const toolbarButtons: Button[] = [
           disabledText: 'Create new segmentation to enable this tool.',
         },
         {
-          name: 'evaluate.cornerstone.isActiveSegmentationOfType',
+          name: 'evaluate.cornerstone.hasSegmentationOfType',
           segmentationRepresentationType: SegmentationRepresentations.Labelmap,
         },
       ],
-      commands: 'setToolActiveToolbar',
+      commands: [
+        {
+          commandName: 'activateSelectedSegmentationOfType',
+          commandOptions: {
+            segmentationRepresentationType: SegmentationRepresentations.Labelmap,
+          },
+        },
+        'setToolActiveToolbar',
+      ],
     },
   },
   {
     id: 'LabelmapSlicePropagation',
-    uiType: 'ohif.toolBoxButton',
+    uiType: 'ohif.toolButton',
     props: {
       icon: 'icon-labelmap-slice-propagation',
       label: 'Labelmap Assist',
@@ -557,7 +589,15 @@ const toolbarButtons: Button[] = [
         ),
         [ViewportGridService.EVENTS.VIEWPORTS_READY]: callbacks('LabelmapSlicePropagation'),
       },
-      commands: 'toggleEnabledDisabledToolbar',
+      commands: [
+        {
+          commandName: 'activateSelectedSegmentationOfType',
+          commandOptions: {
+            segmentationRepresentationType: SegmentationRepresentations.Labelmap,
+          },
+        },
+        'toggleEnabledDisabledToolbar',
+      ],
     },
   },
   {
@@ -574,11 +614,19 @@ const toolbarButtons: Button[] = [
           toolNames: ['MarkerLabelmap', 'MarkerInclude', 'MarkerExclude'],
         },
         {
-          name: 'evaluate.cornerstone.isActiveSegmentationOfType',
+          name: 'evaluate.cornerstone.hasSegmentationOfType',
           segmentationRepresentationType: SegmentationRepresentations.Labelmap,
         },
       ],
-      commands: 'setToolActiveToolbar',
+      commands: [
+        {
+          commandName: 'activateSelectedSegmentationOfType',
+          commandOptions: {
+            segmentationRepresentationType: SegmentationRepresentations.Labelmap,
+          },
+        },
+        'setToolActiveToolbar',
+      ],
       listeners: {
         [ViewportGridService.EVENTS.ACTIVE_VIEWPORT_ID_CHANGED]: callbacks('MarkerLabelmap'),
         [ViewportGridService.EVENTS.VIEWPORTS_READY]: callbacks('MarkerLabelmap'),
@@ -627,7 +675,7 @@ const toolbarButtons: Button[] = [
           toolNames: ['CircularEraser', 'SphereEraser'],
         },
         {
-          name: 'evaluate.cornerstone.isActiveSegmentationOfType',
+          name: 'evaluate.cornerstone.hasSegmentationOfType',
           segmentationRepresentationType: SegmentationRepresentations.Labelmap,
         },
       ],
@@ -657,6 +705,12 @@ const toolbarButtons: Button[] = [
           commands: 'setToolActiveToolbar',
         },
       ],
+      commands: {
+        commandName: 'activateSelectedSegmentationOfType',
+        commandOptions: {
+          segmentationRepresentationType: SegmentationRepresentations.Labelmap,
+        },
+      },
     },
   },
   {
@@ -676,10 +730,17 @@ const toolbarButtons: Button[] = [
           ],
         },
         {
-          name: 'evaluate.cornerstone.isActiveSegmentationOfType',
+          name: 'evaluate.cornerstone.hasSegmentationOfType',
           segmentationRepresentationType: SegmentationRepresentations.Labelmap,
         },
       ],
+      commands: {
+        commandName: 'activateSelectedSegmentationOfType',
+        commandOptions: {
+          segmentationRepresentationType: SegmentationRepresentations.Labelmap,
+        },
+      },
+
       options: [
         {
           name: 'Radius (mm)',
@@ -795,10 +856,16 @@ const toolbarButtons: Button[] = [
           disabledText: 'Create new segmentation to enable shapes tool.',
         },
         {
-          name: 'evaluate.cornerstone.isActiveSegmentationOfType',
+          name: 'evaluate.cornerstone.hasSegmentationOfType',
           segmentationRepresentationType: SegmentationRepresentations.Labelmap,
         },
       ],
+      commands: {
+        commandName: 'activateSelectedSegmentationOfType',
+        commandOptions: {
+          segmentationRepresentationType: SegmentationRepresentations.Labelmap,
+        },
+      },
       options: [
         {
           name: 'Shape',

--- a/platform/ui-next/src/components/Icons/Icons.tsx
+++ b/platform/ui-next/src/components/Icons/Icons.tsx
@@ -228,6 +228,7 @@ import ArrowRight from './Sources/ArrowRight';
 import ChevronLeft from './Sources/ChevronLeft';
 import StatusAlert from './Sources/StatusAlert';
 import Undo from './Sources/Undo';
+import TabContours from './Sources/TabContours';
 //
 //
 type IconProps = React.HTMLAttributes<SVGElement>;
@@ -674,6 +675,7 @@ export const Icons = {
   'status-tracked': (props: IconProps) => StatusTracking(props),
   'status-untracked': (props: IconProps) => StatusUntracked(props),
   'status-locked': (props: IconProps) => StatusLocked(props),
+  'tab-contours': (props: IconProps) => TabContours(props),
   'tab-segmentation': (props: IconProps) => TabSegmentation(props),
   'tab-studies': (props: IconProps) => TabStudies(props),
   'tab-linear': (props: IconProps) => TabLinear(props),

--- a/platform/ui-next/src/components/Icons/Sources/TabContours.tsx
+++ b/platform/ui-next/src/components/Icons/Sources/TabContours.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import type { IconProps } from '../types';
+
+export const TabContours = (props: IconProps) => (
+  <svg
+    width="22"
+    height="22"
+    viewBox="0 0 22 22"
+    fill="none"
+  >
+    <path
+      d="M11.9168 1.5H10.2502C10.02 1.5 9.8335 1.68655 9.8335 1.91667V3.58333C9.8335 3.81345 10.02 4 10.2502 4H11.9168C12.1469 4 12.3335 3.81345 12.3335 3.58333V1.91667C12.3335 1.68655 12.1469 1.5 11.9168 1.5Z"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M11.9168 18.1667H10.2502C10.02 18.1667 9.8335 18.3532 9.8335 18.5833V20.25C9.8335 20.4801 10.02 20.6667 10.2502 20.6667H11.9168C12.1469 20.6667 12.3335 20.4801 12.3335 20.25V18.5833C12.3335 18.3532 12.1469 18.1667 11.9168 18.1667Z"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M20.2503 9.83333H18.5837C18.3535 9.83333 18.167 10.0199 18.167 10.25V11.9167C18.167 12.1468 18.3535 12.3333 18.5837 12.3333H20.2503C20.4804 12.3333 20.667 12.1468 20.667 11.9167V10.25C20.667 10.0199 20.4804 9.83333 20.2503 9.83333Z"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M3.58333 9.83333H1.91667C1.68655 9.83333 1.5 10.0199 1.5 10.25V11.9167C1.5 12.1468 1.68655 12.3333 1.91667 12.3333H3.58333C3.81345 12.3333 4 12.1468 4 11.9167V10.25C4 10.0199 3.81345 9.83333 3.58333 9.83333Z"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M2.84277 9.83332C3.11056 8.0751 3.93334 6.44851 5.19101 5.191C6.44867 3.93349 8.07536 3.1109 9.83361 2.84332"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M9.83361 19.3242C8.07524 19.0565 6.44846 18.2338 5.19078 16.9762C3.93311 15.7185 3.1104 14.0917 2.84277 12.3333"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M19.3243 12.3333C19.0568 14.0916 18.2341 15.7184 16.9764 16.9759C15.7187 18.2335 14.0918 19.056 12.3335 19.3233"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M12.3335 2.84332C14.0917 3.1109 15.7184 3.93349 16.9761 5.191C18.2338 6.44851 19.0565 8.0751 19.3243 9.83332"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+export default TabContours;


### PR DESCRIPTION

<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context
In the new separation of contour and label map design, the utilities for each segmentation type are to go in the segmentation list as such...

<img width="808" height="346" alt="image" src="https://github.com/user-attachments/assets/340aff51-3485-415c-896d-6feaf45f33f8" />

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results
Moved the segmentation utilities to the segmentation list section.

Styled the segmentation utility buttons as per design.

The segmentation utilities and tools for a specific representation type are now enabled if there is a segmentation of the corresponding type loaded for the viewport.

Clicking a segmentation tool or utility button will activate the last selected segmentation of the corresponding type.

The SegmentationService now keeps track of the last selected segmentation of a specific representation type for a viewport.

Added the tab-contours icon.

Auto switch tabs whenever the first segmentation is added/loaded into a viewport.

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing
The utilities should be moved for label maps and styled correcty. Note there are no contour utilities yet.
<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] OS: Windows 11<!--[e.g. Windows 10, macOS 10.15.4]-->
- [x] Node version: 20.9.0<!--[e.g. 18.16.1]-->
- [x] Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
