### PR TITLE
fix(ToolSettings): Added Switch component to ToolSettings. In general, we should use Switch instead of Checkbox.

### DIFF
--- a/extensions/cornerstone/src/commandsModule.ts
+++ b/extensions/cornerstone/src/commandsModule.ts
@@ -54,6 +54,7 @@ import { getCenterExtent } from './utils/getCenterExtent';
 import { EasingFunctionEnum } from './utils/transitions';
 import { createSegmentationForViewport } from './utils/createSegmentationForViewport';
 import { utilities as segmentationUtilities } from '@cornerstonejs/tools/segmentation';
+import i18n from '@ohif/i18n';
 
 const { add, intersect, subtract, copy } = cstUtils.contourSegmentation;
 

--- a/extensions/cornerstone/src/services/SegmentationService/SegmentationService.test.ts
+++ b/extensions/cornerstone/src/services/SegmentationService/SegmentationService.test.ts
@@ -1970,7 +1970,7 @@ describe('SegmentationService', () => {
 
       service.addSegment(segmentationId, config);
 
-      expect(cstSegmentation.state.getSegmentation).toHaveBeenCalledTimes(1);
+      expect(cstSegmentation.state.getSegmentation).toHaveBeenCalledTimes(2);
       expect(cstSegmentation.state.getSegmentation).toHaveBeenCalledWith(segmentationId);
 
       expect(cstSegmentation.updateSegmentations).toHaveBeenCalledTimes(1);

--- a/modes/segmentation/src/toolbarButtons.ts
+++ b/modes/segmentation/src/toolbarButtons.ts
@@ -470,7 +470,7 @@ const toolbarButtons: Button[] = [
       options: [
         {
           name: 'Interpolate Contours',
-          type: 'checkbox',
+          type: 'switch',
           id: 'planarFreehandInterpolateContours',
           value: false,
           commands: {
@@ -523,7 +523,7 @@ const toolbarButtons: Button[] = [
       options: [
         {
           name: 'Interpolate Contours',
-          type: 'checkbox',
+          type: 'switch',
           id: 'livewireInterpolateContours',
           value: false,
           commands: {
@@ -591,7 +591,7 @@ const toolbarButtons: Button[] = [
         },
         {
           name: 'Simplified Spline',
-          type: 'checkbox',
+          type: 'switch',
           id: 'simplifiedSpline',
           value: true,
           commands: {
@@ -600,7 +600,7 @@ const toolbarButtons: Button[] = [
         },
         {
           name: 'Interpolate Contours',
-          type: 'checkbox',
+          type: 'switch',
           id: 'splineInterpolateContours',
           value: false,
           commands: {
@@ -640,7 +640,7 @@ const toolbarButtons: Button[] = [
       options: [
         {
           name: 'Dynamic Cursor Size',
-          type: 'checkbox',
+          type: 'switch',
           id: 'dynamicCursorSize',
           value: true,
           commands: {

--- a/platform/ui-next/src/components/OHIFToolSettings/ToolSettings.tsx
+++ b/platform/ui-next/src/components/OHIFToolSettings/ToolSettings.tsx
@@ -6,6 +6,7 @@ import { Button } from '../Button';
 import { Checkbox } from '../Checkbox/Checkbox';
 import { Label } from '../Label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../Select';
+import { Switch } from '../Switch';
 
 const SETTING_TYPES = {
   RANGE: 'range',
@@ -14,6 +15,7 @@ const SETTING_TYPES = {
   DOUBLE_RANGE: 'double-range',
   BUTTON: 'button',
   CHECKBOX: 'checkbox',
+  SWITCH: 'switch',
   SELECT: 'select',
 };
 
@@ -47,6 +49,8 @@ function ToolSettings({ options }) {
             return renderButtonSetting(option);
           case SETTING_TYPES.CHECKBOX:
             return renderCheckboxSetting(option);
+          case SETTING_TYPES.SWITCH:
+            return renderSwitchSetting(option);
           case SETTING_TYPES.SELECT:
             return renderSelectSetting(option);
           default:
@@ -130,6 +134,29 @@ const renderCheckboxSetting = option => {
       className="flex items-center gap-2"
     >
       <Checkbox
+        id={option.id}
+        checked={option.value}
+        onCheckedChange={checked => {
+          option.onChange?.(checked);
+        }}
+      />
+      <Label
+        htmlFor={option.id}
+        className="cursor-pointer"
+      >
+        {option.name}
+      </Label>
+    </div>
+  );
+};
+
+const renderSwitchSetting = option => {
+  return (
+    <div
+      key={option.id}
+      className="flex items-center gap-2"
+    >
+      <Switch
         id={option.id}
         checked={option.value}
         onCheckedChange={checked => {


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context
@dan-rukas pointed out that for tool settings we were using checkbox components, however the OHIF standard should be to use a switch component.

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results
Changed to using a switch component instead of a checkbox.
<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing
All of the contour tool options should use a switch component. Use this [link](https://multi-tab-seg.netlify.app/) to test.

<img width="315" height="380" alt="image" src="https://github.com/user-attachments/assets/5d689bfc-75bb-4f1d-87b0-99b91d50be34" />

<img width="324" height="426" alt="image" src="https://github.com/user-attachments/assets/c650a44a-6790-4e8e-a378-d3858c812451" />

<img width="306" height="430" alt="image" src="https://github.com/user-attachments/assets/485acde0-7ffe-4f12-b315-c2475120e052" />

<img width="326" height="377" alt="image" src="https://github.com/user-attachments/assets/8373a59d-3dc1-4e1a-bee2-a6437e410558" />

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] OS: Windows 11<!--[e.g. Windows 10, macOS 10.15.4]-->
- [x] Node version: 23.9.0<!--[e.g. 18.16.1]-->
- [x] Browser: Chrome 140.0.7339.208
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
