### PR TITLE
Fix segmentation display and drawing in viewport switching

### DIFF
--- a/extensions/cornerstone/src/services/ViewportService/CornerstoneViewportService.ts
+++ b/extensions/cornerstone/src/services/ViewportService/CornerstoneViewportService.ts
@@ -1336,9 +1336,21 @@ class CornerstoneViewportService extends PubSubService implements IViewportServi
       const { segmentationId, type, hydrated } = presentationItem;
 
       if (hydrated) {
+        // Check if we need to convert the representation type based on viewport type
+        // Surface representations are only supported on VOLUME_3D viewports
+        // For Stack and Orthographic viewports, we need to use Labelmap instead
+        let representationType = type;
+        if (
+          type === csToolsEnums.SegmentationRepresentations.Surface &&
+          !(viewport instanceof VolumeViewport3D)
+        ) {
+          // Convert Surface to Labelmap for non-3D viewports
+          representationType = csToolsEnums.SegmentationRepresentations.Labelmap;
+        }
+
         segmentationService.addSegmentationRepresentation(viewport.id, {
           segmentationId,
-          type,
+          type: representationType,
         });
       }
     });


### PR DESCRIPTION
Convert Surface segmentation representation to Labelmap when switching from 3D to 2D/volume viewports to ensure visibility and editability.

Segmentations are stored as Surface representations in 3D viewports. Previously, when returning to a 2D or volume viewport, the system attempted to restore the incompatible Surface representation, leading to the segmentation disappearing and brush tools failing. This change ensures the correct Labelmap representation is used for non-3D viewports.

---
Linear Issue: [OHI-2216](https://linear.app/ohif/issue/OHI-2216)

<a href="https://cursor.com/background-agent?bcId=bc-969425d6-b0a7-43dc-b51d-32f5d2ba1722"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-969425d6-b0a7-43dc-b51d-32f5d2ba1722"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

