### PR TITLE
Fix viewport ready event firing logic

### DIFF
--- a/platform/ui-next/src/contextProviders/ViewportGridProvider.tsx
+++ b/platform/ui-next/src/contextProviders/ViewportGridProvider.tsx
@@ -404,8 +404,17 @@ export function ViewportGridProvider({ children, service }: ViewportGridProvider
 
   const getGridViewportsReady = useCallback(() => {
     const { viewports } = viewportGridState;
-    const readyViewports = Array.from(viewports.values()).filter(viewport => viewport.isReady);
-    return readyViewports.length === viewports.size;
+    // Filter viewports that have display sets (i.e., have content to display)
+    const viewportsWithContent = Array.from(viewports.values()).filter(
+      viewport => viewport.displaySetInstanceUIDs && viewport.displaySetInstanceUIDs.length > 0
+    );
+    // If there are no viewports with content, return false
+    if (viewportsWithContent.length === 0) {
+      return false;
+    }
+    // Check if all viewports with content are ready
+    const readyViewports = viewportsWithContent.filter(viewport => viewport.isReady);
+    return readyViewports.length === viewportsWithContent.length;
   }, [viewportGridState]);
 
   const setLayout = useCallback(


### PR DESCRIPTION
Update `getGridViewportsReady` to correctly fire `VIEWPORTS_READY` when all content-bearing viewports are ready, resolving OHI-2065.

Previously, the `VIEWPORTS_READY` event would only fire if *all* viewport slots were ready, including empty ones. This prevented the event from firing in layouts with fewer series than slots, or when new empty viewports were added. The fix ensures the event fires based on the readiness of viewports that actually contain display sets.

---
Linear Issue: [OHI-2065](https://linear.app/ohif/issue/OHI-2065)

<a href="https://cursor.com/background-agent?bcId=bc-3084ce55-f67e-47c3-9eb8-4168c61bd7ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3084ce55-f67e-47c3-9eb8-4168c61bd7ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

