### PR TITLE
fix(Segmentation): [Bug #5420] Segmentation color resets after using toggleOneUp

### DIFF
--- a/extensions/cornerstone/src/services/SegmentationService/SegmentationService.test.ts
+++ b/extensions/cornerstone/src/services/SegmentationService/SegmentationService.test.ts
@@ -2032,7 +2032,7 @@ describe('SegmentationService', () => {
         .mockReturnValue(undefined);
       jest.spyOn(cstSegmentation.config.color, 'setSegmentIndexColor').mockReturnValue(undefined);
       jest
-        .spyOn(cstSegmentation.state, 'getSegmentationRepresentationsBySegmentationId')
+        .spyOn(cstSegmentation.state, 'getSegmentationRepresentations')
         .mockReturnValue([{ colorLUTIndex: 1 }]);
 
       service.addSegment(segmentationId, config);
@@ -2202,18 +2202,17 @@ describe('SegmentationService', () => {
 
     it('should set the color of the segment', () => {
       jest
-        .spyOn(cstSegmentation.state, 'getSegmentationRepresentationsBySegmentationId')
+        .spyOn(cstSegmentation.state, 'getSegmentationRepresentations')
         .mockReturnValue([{ colorLUTIndex: 1 }]);
       jest.spyOn(cstSegmentation.config.color, 'setSegmentIndexColor').mockReturnValue(undefined);
 
       service.setSegmentColor(viewportId, segmentationId, segmentIndex, color);
 
-      expect(
-        cstSegmentation.state.getSegmentationRepresentationsBySegmentationId
-      ).toHaveBeenCalledTimes(1);
-      expect(
-        cstSegmentation.state.getSegmentationRepresentationsBySegmentationId
-      ).toHaveBeenCalledWith(segmentationId);
+      expect(cstSegmentation.state.getSegmentationRepresentations).toHaveBeenCalledTimes(1);
+      expect(cstSegmentation.state.getSegmentationRepresentations).toHaveBeenCalledWith(
+        viewportId,
+        { segmentationId }
+      );
 
       expect(cstSegmentation.config.color.setSegmentIndexColor).toHaveBeenCalledTimes(1);
       expect(cstSegmentation.config.color.setSegmentIndexColor).toHaveBeenCalledWith(
@@ -2226,7 +2225,7 @@ describe('SegmentationService', () => {
 
     it('should set the color of the segment with the colorLUTIndex', async () => {
       jest
-        .spyOn(cstSegmentation.state, 'getSegmentationRepresentationsBySegmentationId')
+        .spyOn(cstSegmentation.state, 'getSegmentationRepresentations')
         .mockReturnValue([{ colorLUTIndex: 1 }]);
       jest.spyOn(cstSegmentation.config.color, 'setSegmentIndexColor').mockReturnValue(undefined);
 

--- a/extensions/cornerstone/src/services/SegmentationService/SegmentationService.test.ts
+++ b/extensions/cornerstone/src/services/SegmentationService/SegmentationService.test.ts
@@ -2031,6 +2031,9 @@ describe('SegmentationService', () => {
         .spyOn(cstSegmentation.segmentLocking, 'setSegmentIndexLocked')
         .mockReturnValue(undefined);
       jest.spyOn(cstSegmentation.config.color, 'setSegmentIndexColor').mockReturnValue(undefined);
+      jest
+        .spyOn(cstSegmentation.state, 'getSegmentationRepresentationsBySegmentationId')
+        .mockReturnValue([{ colorLUTIndex: 1 }]);
 
       service.addSegment(segmentationId, config);
 
@@ -2192,15 +2195,25 @@ describe('SegmentationService', () => {
   });
 
   describe('setSegmentColor', () => {
-    it('should set the color of the segment', () => {
-      const viewportId = 'viewportId';
-      const segmentationId = 'segmentationId';
-      const segmentIndex = 1;
-      const color = [255, 0, 0, 255] as csTypes.Color;
+    const viewportId = 'viewportId';
+    const segmentationId = 'segmentationId';
+    const segmentIndex = 1;
+    const color = [255, 0, 0, 255] as csTypes.Color;
 
+    it('should set the color of the segment', () => {
+      jest
+        .spyOn(cstSegmentation.state, 'getSegmentationRepresentationsBySegmentationId')
+        .mockReturnValue([{ colorLUTIndex: 1 }]);
       jest.spyOn(cstSegmentation.config.color, 'setSegmentIndexColor').mockReturnValue(undefined);
 
       service.setSegmentColor(viewportId, segmentationId, segmentIndex, color);
+
+      expect(
+        cstSegmentation.state.getSegmentationRepresentationsBySegmentationId
+      ).toHaveBeenCalledTimes(1);
+      expect(
+        cstSegmentation.state.getSegmentationRepresentationsBySegmentationId
+      ).toHaveBeenCalledWith(segmentationId);
 
       expect(cstSegmentation.config.color.setSegmentIndexColor).toHaveBeenCalledTimes(1);
       expect(cstSegmentation.config.color.setSegmentIndexColor).toHaveBeenCalledWith(
@@ -2209,6 +2222,43 @@ describe('SegmentationService', () => {
         segmentIndex,
         color
       );
+    });
+
+    it('should set the color of the segment with the colorLUTIndex', async () => {
+      jest
+        .spyOn(cstSegmentation.state, 'getSegmentationRepresentationsBySegmentationId')
+        .mockReturnValue([{ colorLUTIndex: 1 }]);
+      jest.spyOn(cstSegmentation.config.color, 'setSegmentIndexColor').mockReturnValue(undefined);
+
+      service.setSegmentColor(viewportId, segmentationId, segmentIndex, color);
+
+      jest
+        .spyOn(cstSegmentation.state, 'getSegmentation')
+        .mockReturnValue(mockCornerstoneSegmentation as cstTypes.Segmentation);
+      jest
+        .spyOn(serviceManagerMock.services.cornerstoneViewportService, 'getCornerstoneViewport')
+        // only needed interfaces for the addSegmentationRepresentation call
+        .mockReturnValue(mockCornerstoneStackViewport as unknown as csTypes.IStackViewport);
+      jest
+        .spyOn(cstSegmentation.state, 'updateLabelmapSegmentationImageReferences')
+        .mockReturnValue('labelmapImageId');
+      jest.spyOn(cstSegmentation, 'addSegmentationRepresentations').mockReturnValueOnce(undefined);
+
+      await service.addSegmentationRepresentation(viewportId, {
+        segmentationId: segmentationId,
+        type: csToolsEnums.SegmentationRepresentations.Labelmap,
+        config: { active: true },
+        suppressEvents: true,
+      });
+
+      expect(cstSegmentation.addSegmentationRepresentations).toHaveBeenCalledTimes(1);
+      expect(cstSegmentation.addSegmentationRepresentations).toHaveBeenCalledWith(viewportId, [
+        {
+          type: csToolsEnums.SegmentationRepresentations.Labelmap,
+          segmentationId: segmentationId,
+          config: { colorLUTOrIndex: 1, active: true },
+        },
+      ]);
     });
   });
 

--- a/extensions/cornerstone/src/services/SegmentationService/SegmentationService.ts
+++ b/extensions/cornerstone/src/services/SegmentationService/SegmentationService.ts
@@ -983,6 +983,10 @@ class SegmentationService extends PubSubService {
     segmentIndex: number,
     color: csTypes.Color
   ): void {
+    const segmentationRepresentations = this.getRepresentationsForSegmentation(segmentationId);
+    const { colorLUTIndex } = segmentationRepresentations[0];
+    this._segmentationIdToColorLUTIndexMap.set(segmentationId, colorLUTIndex);
+
     cstSegmentation.config.color.setSegmentIndexColor(
       viewportId,
       segmentationId,

--- a/extensions/cornerstone/src/services/SegmentationService/SegmentationService.ts
+++ b/extensions/cornerstone/src/services/SegmentationService/SegmentationService.ts
@@ -983,7 +983,9 @@ class SegmentationService extends PubSubService {
     segmentIndex: number,
     color: csTypes.Color
   ): void {
-    const segmentationRepresentations = this.getRepresentationsForSegmentation(segmentationId);
+    const segmentationRepresentations = this.getSegmentationRepresentations(viewportId, {
+      segmentationId,
+    });
     const { colorLUTIndex } = segmentationRepresentations[0];
     this._segmentationIdToColorLUTIndexMap.set(segmentationId, colorLUTIndex);
 


### PR DESCRIPTION
### Context

This PR has the intention to close issue #5420 that reported a bug while dealing with custom colors for created segmentation after interacting with the expansion and retraction of viewports. Please refer to #5420 for reproducibility. 

### Changes & Results

This PR has two small commits, the 3b773b776eb8d039c047abf3bc8fd5615e5ccbce fix the issue itself, the reason for that is at the commit body.
> There was a bug when you added a custom segmentation, changed its color
and then expanded a second viewport, when you retract the viewport back,
this caused the other viewport with the created segmentation with a
custom color, to have it's color set to the default segmentation color.
Therefore, there was a need to add this custom color to the
_segmentationIdToColorLUTIndexMap, thar wasn't being done as it is for
createSegmentationForRTDisplaySet and createSegmentationForSEGDisplaySet

The other commit simply adds unit tests to validate the functioning of this feature added 54fc685d78bf6d4f25e4df17ca188e1cefa6d3fe.

#### Results

**Previous**
- Refer to the video at #5420 

**After**

https://github.com/user-attachments/assets/283511c9-6551-4406-b5ba-1d713ac83a31

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

For testing, please follow the reproduction steps at #5420 and validate that it can't be reproduced after the changes.

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] OS: Windows 11 Home 24H2 + WSL Ubuntu 22.04.4 LTS
- [x] Node version: v20.9.0
- [x] Browser: Microsoft Edge 139.0.3405.119

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
