### PR TITLE
fix(segmentation): Fixed contour spline interpolation.

### DIFF
--- a/extensions/cornerstone/src/commandsModule.ts
+++ b/extensions/cornerstone/src/commandsModule.ts
@@ -2248,16 +2248,28 @@ function commandsModule({
         updateCursorSize: isDynamicCursorSize ? 'dynamic' : '',
       };
     },
-    setInterpolationToolConfiguration: ({ value: interpolateContours }) => {
+    setInterpolationToolConfiguration: ({ value: interpolateContours, toolNames }) => {
       const viewportId = viewportGridService.getActiveViewportId();
       const toolGroup = toolGroupService.getToolGroupForViewport(viewportId);
+
+      // Set the interpolation configuration for the active tool.
       const activeTool = toolGroupService.getActiveToolForViewport(viewportId);
-      toolGroup.setToolConfiguration(activeTool, {
+      const interpolationConfig = {
         interpolation: {
           enabled: interpolateContours,
           showInterpolationPolyline: true,
         },
-      });
+      };
+      toolGroup.setToolConfiguration(activeTool, interpolationConfig);
+
+      // Now set the interpolation configuration for the other tools specified.
+      if (toolNames) {
+        Object.values(toolGroup.getToolInstances()).forEach(toolInstance => {
+          if (toolNames?.includes(toolInstance.toolName)) {
+            toolGroup.setToolConfiguration(toolInstance.toolName, interpolationConfig);
+          }
+        });
+      }
     },
     setSimplifiedSplineForSplineContourSegmentationTool: ({ value: simplifiedSpline }) => {
       const viewportId = viewportGridService.getActiveViewportId();

--- a/modes/segmentation/src/toolbarButtons.ts
+++ b/modes/segmentation/src/toolbarButtons.ts
@@ -591,6 +591,9 @@ const toolbarButtons: Button[] = [
           value: false,
           commands: {
             commandName: 'setInterpolationToolConfiguration',
+            commandOptions: {
+              toolNames: ['CatmullRomSplineROI', 'LinearSplineROI', 'BSplineROI'],
+            },
           },
         },
       ],


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context
Interpolate b-spline contours only works for non-simplified Catmull Rom Splines

#### Steps to reproduce

1. Launch OHIF
2. Add a contour segmentation
3. From the contour side panel activate the Spline Contour Segmentation tool
4. Turn on interpolate contours
5. leave/turn on simplified splines
6. Add two simplified catmull rom splines on two non neighbouring images. Alternatively add two simplified or non-simplified b-splines or linear splines on two non neighbouring images.

#### Actual Result

No interpolation occurs on the images between the images where the contours were applied.

#### Expected Result

Interpolation occurs on the images between the images where the contours were applied.
<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results
Upgraded CS3D version that has most of the fixes.
Now when interpolation is enabled for a tool, an optional list of tools can be specified to also be interpolated. This ensures all spline tools have interpolation turned on and not just the active (spline) tool.
<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing
Visit https://multi-tab-seg.netlify.app/ and follow the steps to reproduce verifying that the expected result occurs.

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] OS: Windows 11<!--[e.g. Windows 10, macOS 10.15.4]-->
- [x] Node version: 23.9.0<!--[e.g. 18.16.1]-->
- [x] Browser: Chrome 141.0.7390.66
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
