### PR TITLE
fix(rendering): Fix palette color LUT conversion causing black images

### DIFF
--- a/platform/core/src/utils/metadataProvider/fetchPaletteColorLookupTableData.js
+++ b/platform/core/src/utils/metadataProvider/fetchPaletteColorLookupTableData.js
@@ -30,18 +30,15 @@ function _getPaletteColor(paletteColorLookupTableData, lutDescriptor) {
   }
 
   const arrayBufferToPaletteColorLUT = arraybuffer => {
+    // Handle both ArrayBuffer and TypedArray inputs
+    const buffer = arraybuffer.buffer || arraybuffer;
+    const data = bits === 16 ? new Uint16Array(buffer) : new Uint8Array(buffer);
     const lut = [];
 
-    if (bits === 16) {
-      let j = 0;
-      for (let i = 0; i < numLutEntries; i++) {
-        lut[i] = (arraybuffer[j++] + arraybuffer[j++]) << 8;
-      }
-    } else {
-      for (let i = 0; i < numLutEntries; i++) {
-        lut[i] = arraybuffer[i];
-      }
+    for (let i = 0; i < numLutEntries; i++) {
+      lut[i] = data[i];
     }
+
     return lut;
   };
 
@@ -51,10 +48,10 @@ function _getPaletteColor(paletteColorLookupTableData, lutDescriptor) {
 
   if (paletteColorLookupTableData.InlineBinary) {
     try {
-      const arraybuffer = Uint8Array.from(atob(paletteColorLookupTableData.InlineBinary), c =>
+      const uint8Array = Uint8Array.from(atob(paletteColorLookupTableData.InlineBinary), c =>
         c.charCodeAt(0)
       );
-      return (paletteColorLookupTableData.palette = arrayBufferToPaletteColorLUT(arraybuffer));
+      return (paletteColorLookupTableData.palette = arrayBufferToPaletteColorLUT(uint8Array));
     } catch (e) {
       console.log("Couldn't decode", paletteColorLookupTableData.InlineBinary, e);
       return undefined;


### PR DESCRIPTION
## Problem
Palette color images were rendering completely black due to incorrect ArrayBuffer handling in `fetchPaletteColorLookupTableData.js`.

## Root Cause
The code tried to access ArrayBuffer directly with array indexing (`arraybuffer[i]`), which doesn't work. ArrayBuffers need typed array views for data access.

## Fix
- Create proper typed array views (`Uint16Array` for 16-bit, `Uint8Array` for 8-bit) before reading palette data
- Handle both ArrayBuffer and TypedArray inputs in the conversion function
- Remove incorrect bit-shifting logic that was adding bytes instead of properly combining them


<img width="4128" height="1596" alt="CleanShot 2025-10-20 at 13 01 21@2x" src="https://github.com/user-attachments/assets/7fb264da-64b4-4741-9786-fc311e238b01" />

