### PR TITLE
fix(segmentation): When synchronizing a segmentation representation, use the type of the source viewport segmentation to determine the type of the target viewport segmentations

### DIFF
--- a/extensions/cornerstone/src/services/SyncGroupService/createHydrateSegmentationSynchronizer.ts
+++ b/extensions/cornerstone/src/services/SyncGroupService/createHydrateSegmentationSynchronizer.ts
@@ -43,7 +43,7 @@ const segmentationRepresentationModifiedCallback = async (
 ) => {
   const event = sourceEvent as ToolsTypes.EventTypes.SegmentationRepresentationModifiedEventType;
 
-  const { segmentationId } = event.detail;
+  const { segmentationId, type: segmentationRepresentationType } = event.detail;
   const { segmentationService } = servicesManager.services;
 
   const targetViewportId = targetViewport.viewportId;
@@ -69,7 +69,8 @@ const segmentationRepresentationModifiedCallback = async (
   const type: Enums.SegmentationRepresentations =
     viewport.type === CoreEnums.ViewportType.VOLUME_3D
       ? Enums.SegmentationRepresentations.Surface
-      : Enums.SegmentationRepresentations.Labelmap;
+      : ((segmentationRepresentationType as Enums.SegmentationRepresentations) ??
+        Enums.SegmentationRepresentations.Labelmap);
 
   await segmentationService.addSegmentationRepresentation(targetViewportId, {
     segmentationId,


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context
https://app.betterbugs.io/session/68f0c36525d81be940202fc1

When a display set/series containing contours is swapped out of view and then (later) back into view, its contours no longer appear.

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results
Most of the changes to fix the problem reported were taken care of in CS3D (see PR https://github.com/cornerstonejs/cornerstone3D/pull/2446). However this PR here handles the case for volume viewports. Prior to the changes in this PR, OHIF was not synchronizing the segmentation representation among related volume viewports (e.g. MPR). It was defaulting the type of the segmentation representation to LABELMAP, but instead should have used the source representation type instead.

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing
1. View a study with at least two series that can be viewed in MPR. 
2. View a series in MPR.
3. Add a contour segmentation.
4. Add various contour segment annotations to it.
5. Replace the series with another MPR capable series.
6. Swap in the first series back in.
7. The contour annotations should display as before.

N.B. A similar test should be done for label map segmentations.
<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] OS: Windows 11<!--[e.g. Windows 10, macOS 10.15.4]-->
- [x] Node version: 23.9.0<!--[e.g. 18.16.1]-->
- [x] Browser: Chrome 142.0.7444.60
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
