### PR TITLE
feat(image-orientation-patient): add additional validation of the image orientation patient value before accepting it in the MetadataProvider

### DIFF
--- a/platform/core/src/classes/MetadataProvider.ts
+++ b/platform/core/src/classes/MetadataProvider.ts
@@ -552,7 +552,12 @@ const WADO_IMAGE_LOADER = {
     }
 
     // Additional validation (1. Must exist, 2.Must be an array, 3.Must be 6 values, 4. Must not be an invalid array (all 0s))
-    if (ImageOrientationPatient && Array.isArray(ImageOrientationPatient) && ImageOrientationPatient.length === 6 && ImageOrientationPatient.some(val => parseFloat(val) !== 0)) {
+    if (
+      ImageOrientationPatient &&
+      Array.isArray(ImageOrientationPatient) &&
+      ImageOrientationPatient.length === 6 &&
+      ImageOrientationPatient.some(val => parseFloat(val) !== 0)
+    ) {
       rowCosines = toNumber(ImageOrientationPatient.slice(0, 3));
       columnCosines = toNumber(ImageOrientationPatient.slice(3, 6));
       imageOrientationPatient = toNumber(ImageOrientationPatient);


### PR DESCRIPTION
### Description

This PR adds additional validation to the ImageOrientationPatient value before accepting it, and it doesn't pass all conditions its rejected and the fallback is used.

Example file:  [clean_dicom.dcm.zip](https://github.com/user-attachments/files/23570110/clean_dicom.dcm.zip)

This is an image with an invalid/illegal image orientation patient value [0,0,0,0,0,0], An all-zero orientation means both the row-direction and column-direction vectors are (0,0,0). Geometrically, this yields no defined image plane which leads to impossible display of the image. This PR adds a fallback incase of such scenarios so images can be displayed correctly.

Before / After:

<img width="1451" height="743" alt="CleanShot 2025-11-16 at 13 34 14" src="https://github.com/user-attachments/assets/25b2666c-e3d7-452f-ab89-a31eda7f6ab7" />

<img width="1455" height="736" alt="CleanShot 2025-11-16 at 13 35 08" src="https://github.com/user-attachments/assets/717ebe8f-add0-45c2-8b1b-b1e6a20ef9e8" />

