### PR TITLE
fix(seg-viewport): add guard for missing reference display set handler to prevent viewport crash (#5596)

### DIFF
--- a/extensions/cornerstone-dicom-seg/src/viewports/OHIFCornerstoneSEGViewport.tsx
+++ b/extensions/cornerstone-dicom-seg/src/viewports/OHIFCornerstoneSEGViewport.tsx
@@ -60,15 +60,26 @@ function OHIFCornerstoneSEGViewport(props: withAppTypes) {
   // In such cases, we attempt to handle this scenario gracefully by
   // invoking a custom handler. Ideally, if a user tries to launch a series that isn't viewable,
   // (eg.: we can prompt them with an explanation and provide a link to the full study).
+
+  // Additional guard: If no customization handler is registered for missing
+  // referenced display sets, skip SEG rendering to avoid a viewport crash.
   if (!referencedDisplaySetInstanceUID) {
     const missingReferenceDisplaySetHandler = customizationService.getCustomization(
       'missingReferenceDisplaySetHandler'
     );
-    const { handled } = missingReferenceDisplaySetHandler();
-    if (handled) {
+    if (typeof missingReferenceDisplaySetHandler === 'function') {
+      const { handled } = missingReferenceDisplaySetHandler();
+      if (handled) {
+        return;
+      }
+    } else {
+      console.log(
+        "No customization 'missingReferenceDisplaySetHandler' registered. Skipping SEG rendering."
+      );
       return;
     }
   }
+
   const referencedDisplaySet = displaySetService.getDisplaySetByUID(
     referencedDisplaySetInstanceUID
   );


### PR DESCRIPTION

<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

Fixes #5596

When navigating between display sets using hotkeys (such as PageDown), the SEG viewport may encounter a case where referencedDisplaySetInstanceUID is undefined. And this happens when navigation goes past the last available display set.

In this situation, the SEG viewport tries to call the optional customization hook "missingReferenceDisplaySetHandler", but if no customization is registered, the viewport crashes with:

`TypeError: missingReferenceDisplaySetHandler is not a function`

### Changes & Results

Added a type check (typeof === 'function') before executing missingReferenceDisplaySetHandler.

When the customization is missing, the SEG viewport now skips SEG rendering, and avoids the runtime error.

Before:
Pressing PageDown past the last display set caused a crash.

https://github.com/user-attachments/assets/f95137ca-9a3a-4780-a23b-8967ac36812e


After:
- The SEG viewport no longer crashes.
- A console log is shown when no customization handler is registered.
- SEG rendering is skipped safely in this scenario.

https://github.com/user-attachments/assets/92348c36-c6bf-4db5-b56d-4daf91fd3eb7


<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

Steps to reproduce & verify:

1. Load a study with multiple display sets (e.g. CT series + SEG).
2. Click on "Add segmentation".
3. Press Page Down repeatedly and navigate through all display sets.

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] OS: macOS 10.15.4 <!--[e.g. Windows 10, macOS 10.15.4]-->
- [x] Node version: v22.12.0 <!--[e.g. 18.16.1]-->
- [x] Browser: Chrome 83.0.4103.116
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
