### PR TITLE
studyExpandRow now supports selecting single or multiple sequences for review

### DIFF
--- a/extensions/default/src/DicomWebDataSource/retrieveStudyMetadata.js
+++ b/extensions/default/src/DicomWebDataSource/retrieveStudyMetadata.js
@@ -41,9 +41,13 @@ export function retrieveStudyMetadata(
   const promiseId = `${dicomWebConfig.name}:${StudyInstanceUID}`;
 
   // Already waiting on result? Return cached promise
-  if (StudyMetaDataPromises.has(promiseId)) {
-    return StudyMetaDataPromises.get(promiseId);
-  }
+
+  // Temporarily commented out to prevent promise reuse on duplicate requests,
+  // which causes data inconsistency
+
+  // if (StudyMetaDataPromises.has(promiseId)) {
+  //   return StudyMetaDataPromises.get(promiseId);
+  // }
 
   let promise;
 

--- a/platform/ui/src/components/StudyListExpandedRow/StudyListExpandedRow.tsx
+++ b/platform/ui/src/components/StudyListExpandedRow/StudyListExpandedRow.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 
 import Table from '../Table';
@@ -6,24 +6,60 @@ import TableHead from '../TableHead';
 import TableBody from '../TableBody';
 import TableRow from '../TableRow';
 import TableCell from '../TableCell';
+import { Checkbox } from '@ohif/ui-next';
 
-const StudyListExpandedRow = ({ seriesTableColumns, seriesTableDataSource, children }) => {
+const StudyListExpandedRow = ({ seriesTableColumns, seriesTableDataSource, children, selectedRows: propSelectedRows, onSelectionChange  }) => {
+  const [selectedRows, setSelectedRows] = useState(propSelectedRows || []);
+
+  useEffect(() => {
+    setSelectedRows(propSelectedRows || []);
+  }, [propSelectedRows]);
+
+  const handleSelectAll = (newChecked) => {
+    const newSelected = newChecked ? seriesTableDataSource.map((_, index) => index) : [];
+    setSelectedRows(newSelected);
+    onSelectionChange && onSelectionChange(newSelected);
+  };
+
+  const handleSelectRow = (index, newChecked) => {
+    const newSelected = newChecked ? [...selectedRows, index] : selectedRows.filter(i => i !== index);
+    setSelectedRows(newSelected);
+    onSelectionChange && onSelectionChange(newSelected);
+  };
+
   return (
     <div className="w-full bg-black py-4 pl-12 pr-2">
       <div className="block">{children}</div>
       <div className="mt-4">
         <Table>
           <TableHead>
-            <TableRow>
+            <TableRow
+              className="hover:bg-gray-700 cursor-pointer"
+              onClick={() => handleSelectAll(!(selectedRows.length === seriesTableDataSource.length && seriesTableDataSource.length > 0))}
+            >
+              <TableCell className='flex items-center' cellsNum={1}>
+                <Checkbox
+                  checked={selectedRows.length === seriesTableDataSource.length && seriesTableDataSource.length > 0}
+                  onCheckedChange={handleSelectAll}
+                />
+              </TableCell>
               {Object.keys(seriesTableColumns).map(columnKey => {
-                return <TableCell key={columnKey}>{seriesTableColumns[columnKey]}</TableCell>;
+                return <TableCell key={columnKey} cellsNum={1}>{seriesTableColumns[columnKey]}</TableCell>;
               })}
             </TableRow>
           </TableHead>
 
           <TableBody>
             {seriesTableDataSource.map((row, i) => (
-              <TableRow key={i}>
+              <TableRow key={i} 
+                className="hover:bg-gray-700 cursor-pointer"
+                onClick={() => handleSelectRow(i, !selectedRows.includes(i))}
+              >
+                <TableCell cellsNum={1} className='flex items-center'>
+                  <Checkbox
+                    checked={selectedRows.includes(i)}
+                  />
+                </TableCell>
                 {Object.keys(row).map(cellKey => {
                   const content = row[cellKey];
                   return (

--- a/platform/ui/src/components/TableRow/TableRow.tsx
+++ b/platform/ui/src/components/TableRow/TableRow.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
-const TableRow = ({ children, className = '', isTableHead = false, style = {} }) => {
+const TableRow = ({ children, className = '', isTableHead = false, style = {}, onClick }) => {
   const childrens = React.Children.map(children, child => {
     const isValidReactElement = React.isValidElement(child);
 
@@ -15,6 +15,7 @@ const TableRow = ({ children, className = '', isTableHead = false, style = {} })
     <div
       className={classnames('flex w-full', className)}
       style={style}
+      onClick={onClick}
     >
       {childrens}
     </div>
@@ -43,6 +44,7 @@ TableRow.propTypes = {
   },
   className: PropTypes.string,
   style: PropTypes.object,
+  onClick: PropTypes.func
 };
 
 export default TableRow;


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context
<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->
When only a specific series needs to be retrieved from the study, I can use a link similar to http://localhost:3000/viewer?StudyInstanceUIDs=xxx&SeriesInstanceUIDs=xxx. This presupposes that you know the corresponding studyUid and SeriesInstanceUIDs. Now we can use a more convenient interaction like this:
![viewer](https://github.com/user-attachments/assets/0f3e66e2-982c-4307-9f6f-9c6df4eedb44)

### Changes & Results

Here, the caching has been temporarily commented out to prevent reusing Promises in repeated requests, as this can lead to data inconsistency. If this issue can be resolved, the caching can be uncommented
<img width="517" height="118" alt="image" src="https://github.com/user-attachments/assets/e7131cf1-2488-431b-81c6-ebe7316590f1" />

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

<!-- https://docs.ohif.org/ -->
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]-->

<!-- prettier-ignore-start -->

<!-- prettier-ignore-end -->
