### PR TITLE
feat(ExtensionManager): add ability to save current frame index with no annotation present

### DIFF
--- a/extensions/usAnnotation/src/getCommandsModule.ts
+++ b/extensions/usAnnotation/src/getCommandsModule.ts
@@ -242,6 +242,14 @@ function commandsModule({
           }
         });
 
+        if (annotations.length === 0) {
+          const currentFrameIndex = viewportImageIds.indexOf(imageId);
+          frame_annotations[currentFrameIndex] = {
+            pleura_lines: [],
+            b_lines: [],
+          };
+        }
+
         const instance = getInstanceByImageId(servicesManager.services, imageId);
         const json = {
           SOPInstanceUID: instance.SOPInstanceUID,
@@ -279,14 +287,6 @@ function commandsModule({
       downloadBlob(blob, {
         filename: `ultrasound_annotations_${new Date().toISOString().slice(0, 10)}.json`,
       });
-
-      // Append to the document, click to download, and remove
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-
-      // Clean up by revoking the URL
-      URL.revokeObjectURL(url);
     },
   };
 


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

Using the `usAnnotation` extension, clinicians often first perform a rough assessment of a particular ultrasound clip by visually identifying the frame with the maximum number of B-lines. Later, the clinician or a fellow may add in pleural line and B-line annotations. However, in the current extension, the user cannot save an annotation JSON file without adding the pleural lines and B-lines.

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

Therefore, we added the ability to save out a JSON annotation file, even if no pleural lines or B-lines are present in the frame. The JSON file will contain an entry with the current frame number, and an empty list for both the pleural lines and B-lines. 

A sample resulting JSON file is as follows: 
```
{
  "SOPInstanceUID": "1.2.840.113663.1500.1.248223208.3.1.20110323.110042.375",
  "GrayscaleConversion": false,
  "mask_type": "fan",
  "angle1": 47.37832997335552,
  "angle2": 132.7093899573615,
  "center_rows_px": 419.9508448540707,
  "center_cols_px": 94.38658474142345,
  "radius1": 26.654419138056458,
  "radius2": 469.68489213060354,
  "AnnotationLabels": [],
  "frame_annotations": {
    "24": {
      "pleura_lines": [],
      "b_lines": []
    }
  }
}
```

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

This change can be tested by: 
- searching for US images 
- selecting a study (e.g cardiac)
- scrolling to a particular frame
- clicking the download JSON button in the "Annotated Frames" section 

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] OS: <!--[e.g. Windows 10, macOS 10.15.4]--> macOS 14.7.3
- [x] Node version: <!--[e.g. 18.16.1]--> 25.5.0
- [x] Browser: 
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]--> Chrome 142.0.7444.60
<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
