### PR TITLE
test

### DIFF
--- a/extensions/cornerstone/src/utils/dicomLoaderService.js
+++ b/extensions/cornerstone/src/utils/dicomLoaderService.js
@@ -3,14 +3,6 @@ import dicomImageLoader from '@cornerstonejs/dicom-image-loader';
 import { api } from 'dicomweb-client';
 import { DICOMWeb, errorHandler } from '@ohif/core';
 
-const getImageId = imageObj => {
-  if (!imageObj) {
-    return;
-  }
-
-  return typeof imageObj.getImageId === 'function' ? imageObj.getImageId() : imageObj.url;
-};
-
 const findImageIdOnStudies = (studies, displaySetInstanceUID) => {
   const study = studies.find(study => {
     const displaySet = study.displaySets.some(


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] OS: <!--[e.g. Windows 10, macOS 10.15.4]-->
- [] Node version: <!--[e.g. 18.16.1]-->
- [] Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Removes the `getImageId` helper from a core DICOM loading utility, but `dicomLoaderService.js` still calls `getImageId`, which is likely to cause runtime failures when resolving image IDs and retrieving DICOM data.
> 
> **Overview**
> Removes the local `getImageId` helper from `extensions/cornerstone/src/utils/dicomLoaderService.js`, changing how image IDs are expected to be resolved.
> 
> **Note:** the file still calls `getImageId` (e.g., in `findImageIdOnStudies` and `getImageInstanceId`) without defining or importing it, which likely breaks DICOM retrieval at runtime.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e4c4df01eb1cca746a13dfdb700510ad6492e3d0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR removes the `getImageId` helper function from `dicomLoaderService.js` without removing its usages, causing critical runtime errors.

- **Critical Issue**: Function `getImageId` deleted but still called on lines 17 and 36
- **Impact**: Any code path invoking `findImageIdOnStudies` or `getImageInstanceId` will throw `ReferenceError: getImageId is not defined`
- **Affected flows**: Local DICOM data loading and image instance ID retrieval

<h3>Confidence Score: 0/5</h3>

- This PR is not safe to merge - it contains critical bugs that will cause runtime errors
- Score of 0 reflects that the removed function is still referenced in 2 locations, which will cause immediate ReferenceError exceptions when those code paths execute
- extensions/cornerstone/src/utils/dicomLoaderService.js requires immediate attention to restore the deleted function or inline its logic

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| extensions/cornerstone/src/utils/dicomLoaderService.js | Removed `getImageId` helper function but left 2 call sites, causing ReferenceError |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant DicomLoaderService
    participant findImageIdOnStudies
    participant getImageInstanceId
    participant getImageId
    
    Client->>DicomLoaderService: findDicomDataPromise(dataset, studies)
    DicomLoaderService->>DicomLoaderService: getLocalData(dataset, studies)
    DicomLoaderService->>getImageInstanceId: getImageInstanceId(instance)
    getImageInstanceId->>getImageId: getImageId(imageInstance)
    Note over getImageId: ❌ DELETED FUNCTION<br/>Still called on line 36
    getImageId-->>getImageInstanceId: ReferenceError
    
    DicomLoaderService->>findImageIdOnStudies: findImageIdOnStudies(studies, displaySetInstanceUID)
    findImageIdOnStudies->>getImageId: getImageId(instance)
    Note over getImageId: ❌ DELETED FUNCTION<br/>Still called on line 17
    getImageId-->>findImageIdOnStudies: ReferenceError
```

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->