### PR TITLE
[WIP] fix: Allow loading the linked dicom image loader

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "ohif-monorepo-root",
@@ -52,7 +53,7 @@
     },
     "addOns/externals/devDependencies": {
       "name": "@externals/devDependencies",
-      "version": "3.13.0-beta.4",
+      "version": "3.13.0-beta.7",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "@kitware/vtk.js": "34.15.1",
@@ -137,14 +138,14 @@
     },
     "addOns/externals/dicom-microscopy-viewer": {
       "name": "@externals/dicom-microscopy-viewer",
-      "version": "3.13.0-beta.4",
+      "version": "3.13.0-beta.7",
       "dependencies": {
         "dicom-microscopy-viewer": "0.48.17",
       },
     },
     "extensions/cornerstone": {
       "name": "@ohif/extension-cornerstone",
-      "version": "3.13.0-beta.4",
+      "version": "3.13.0-beta.7",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "@cornerstonejs/adapters": "4.15.29",
@@ -171,8 +172,8 @@
         "@cornerstonejs/codec-openjpeg": "1.3.0",
         "@cornerstonejs/codec-openjph": "2.4.7",
         "@cornerstonejs/dicom-image-loader": "4.15.29",
-        "@ohif/core": "3.13.0-beta.4",
-        "@ohif/ui": "3.13.0-beta.4",
+        "@ohif/core": "3.13.0-beta.7",
+        "@ohif/ui": "3.13.0-beta.7",
         "dcmjs": "0.49.4",
         "dicom-parser": "1.8.21",
         "hammerjs": "2.0.8",
@@ -184,7 +185,7 @@
     },
     "extensions/cornerstone-dicom-pmap": {
       "name": "@ohif/extension-cornerstone-dicom-pmap",
-      "version": "3.13.0-beta.4",
+      "version": "3.13.0-beta.7",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "@cornerstonejs/adapters": "4.15.29",
@@ -192,10 +193,10 @@
         "@kitware/vtk.js": "34.15.1",
       },
       "peerDependencies": {
-        "@ohif/core": "3.13.0-beta.4",
-        "@ohif/extension-cornerstone": "3.13.0-beta.4",
-        "@ohif/extension-default": "3.13.0-beta.4",
-        "@ohif/i18n": "3.13.0-beta.4",
+        "@ohif/core": "3.13.0-beta.7",
+        "@ohif/extension-cornerstone": "3.13.0-beta.7",
+        "@ohif/extension-default": "3.13.0-beta.7",
+        "@ohif/i18n": "3.13.0-beta.7",
         "prop-types": "15.8.1",
         "react": "18.3.1",
         "react-dom": "18.3.1",
@@ -206,15 +207,15 @@
     },
     "extensions/cornerstone-dicom-rt": {
       "name": "@ohif/extension-cornerstone-dicom-rt",
-      "version": "3.13.0-beta.4",
+      "version": "3.13.0-beta.7",
       "dependencies": {
         "@babel/runtime": "7.28.2",
       },
       "peerDependencies": {
-        "@ohif/core": "3.13.0-beta.4",
-        "@ohif/extension-cornerstone": "3.13.0-beta.4",
-        "@ohif/extension-default": "3.13.0-beta.4",
-        "@ohif/i18n": "3.13.0-beta.4",
+        "@ohif/core": "3.13.0-beta.7",
+        "@ohif/extension-cornerstone": "3.13.0-beta.7",
+        "@ohif/extension-default": "3.13.0-beta.7",
+        "@ohif/i18n": "3.13.0-beta.7",
         "prop-types": "15.8.1",
         "react": "18.3.1",
         "react-dom": "18.3.1",
@@ -225,7 +226,7 @@
     },
     "extensions/cornerstone-dicom-seg": {
       "name": "@ohif/extension-cornerstone-dicom-seg",
-      "version": "3.13.0-beta.4",
+      "version": "3.13.0-beta.7",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "@cornerstonejs/adapters": "4.15.29",
@@ -233,10 +234,10 @@
         "@kitware/vtk.js": "34.15.1",
       },
       "peerDependencies": {
-        "@ohif/core": "3.13.0-beta.4",
-        "@ohif/extension-cornerstone": "3.13.0-beta.4",
-        "@ohif/extension-default": "3.13.0-beta.4",
-        "@ohif/i18n": "3.13.0-beta.4",
+        "@ohif/core": "3.13.0-beta.7",
+        "@ohif/extension-cornerstone": "3.13.0-beta.7",
+        "@ohif/extension-default": "3.13.0-beta.7",
+        "@ohif/i18n": "3.13.0-beta.7",
         "prop-types": "15.8.1",
         "react": "18.3.1",
         "react-dom": "18.3.1",
@@ -247,7 +248,7 @@
     },
     "extensions/cornerstone-dicom-sr": {
       "name": "@ohif/extension-cornerstone-dicom-sr",
-      "version": "3.13.0-beta.4",
+      "version": "3.13.0-beta.7",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "@cornerstonejs/adapters": "4.15.29",
@@ -256,10 +257,10 @@
         "classnames": "2.5.1",
       },
       "peerDependencies": {
-        "@ohif/core": "3.13.0-beta.4",
-        "@ohif/extension-cornerstone": "3.13.0-beta.4",
-        "@ohif/extension-measurement-tracking": "3.13.0-beta.4",
-        "@ohif/ui": "3.13.0-beta.4",
+        "@ohif/core": "3.13.0-beta.7",
+        "@ohif/extension-cornerstone": "3.13.0-beta.7",
+        "@ohif/extension-measurement-tracking": "3.13.0-beta.7",
+        "@ohif/ui": "3.13.0-beta.7",
         "dcmjs": "0.49.4",
         "dicom-parser": "1.8.21",
         "hammerjs": "2.0.8",
@@ -269,7 +270,7 @@
     },
     "extensions/cornerstone-dynamic-volume": {
       "name": "@ohif/extension-cornerstone-dynamic-volume",
-      "version": "3.13.0-beta.4",
+      "version": "3.13.0-beta.7",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "@cornerstonejs/core": "4.15.29",
@@ -277,11 +278,11 @@
         "classnames": "2.5.1",
       },
       "peerDependencies": {
-        "@ohif/core": "3.13.0-beta.4",
-        "@ohif/extension-cornerstone": "3.13.0-beta.4",
-        "@ohif/extension-default": "3.13.0-beta.4",
-        "@ohif/i18n": "3.13.0-beta.4",
-        "@ohif/ui": "3.13.0-beta.4",
+        "@ohif/core": "3.13.0-beta.7",
+        "@ohif/extension-cornerstone": "3.13.0-beta.7",
+        "@ohif/extension-default": "3.13.0-beta.7",
+        "@ohif/i18n": "3.13.0-beta.7",
+        "@ohif/ui": "3.13.0-beta.7",
         "dcmjs": "0.49.4",
         "dicom-parser": "1.8.21",
         "hammerjs": "2.0.8",
@@ -291,7 +292,7 @@
     },
     "extensions/default": {
       "name": "@ohif/extension-default",
-      "version": "3.13.0-beta.4",
+      "version": "3.13.0-beta.7",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "@cornerstonejs/calculate-suv": "1.1.0",
@@ -300,8 +301,8 @@
         "react-color": "2.19.3",
       },
       "peerDependencies": {
-        "@ohif/core": "3.13.0-beta.4",
-        "@ohif/i18n": "3.13.0-beta.4",
+        "@ohif/core": "3.13.0-beta.7",
+        "@ohif/i18n": "3.13.0-beta.7",
         "dcmjs": "0.49.4",
         "dicomweb-client": "0.10.4",
         "prop-types": "15.8.1",
@@ -315,7 +316,7 @@
     },
     "extensions/dicom-microscopy": {
       "name": "@ohif/extension-dicom-microscopy",
-      "version": "3.13.0-beta.4",
+      "version": "3.13.0-beta.7",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "@cornerstonejs/codec-charls": "1.2.3",
@@ -326,10 +327,10 @@
         "mathjs": "12.4.3",
       },
       "peerDependencies": {
-        "@ohif/core": "3.13.0-beta.4",
-        "@ohif/extension-default": "3.13.0-beta.4",
-        "@ohif/i18n": "3.13.0-beta.4",
-        "@ohif/ui": "3.13.0-beta.4",
+        "@ohif/core": "3.13.0-beta.7",
+        "@ohif/extension-default": "3.13.0-beta.7",
+        "@ohif/i18n": "3.13.0-beta.7",
+        "@ohif/ui": "3.13.0-beta.7",
         "prop-types": "15.8.1",
         "react": "18.3.1",
         "react-dom": "18.3.1",
@@ -340,14 +341,14 @@
     },
     "extensions/dicom-pdf": {
       "name": "@ohif/extension-dicom-pdf",
-      "version": "3.13.0-beta.4",
+      "version": "3.13.0-beta.7",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "classnames": "2.5.1",
       },
       "peerDependencies": {
-        "@ohif/core": "3.13.0-beta.4",
-        "@ohif/ui": "3.13.0-beta.4",
+        "@ohif/core": "3.13.0-beta.7",
+        "@ohif/ui": "3.13.0-beta.7",
         "dcmjs": "0.49.4",
         "dicom-parser": "1.8.21",
         "hammerjs": "2.0.8",
@@ -357,14 +358,14 @@
     },
     "extensions/dicom-video": {
       "name": "@ohif/extension-dicom-video",
-      "version": "3.13.0-beta.4",
+      "version": "3.13.0-beta.7",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "classnames": "2.5.1",
       },
       "peerDependencies": {
-        "@ohif/core": "3.13.0-beta.4",
-        "@ohif/ui": "3.13.0-beta.4",
+        "@ohif/core": "3.13.0-beta.7",
+        "@ohif/ui": "3.13.0-beta.7",
         "dcmjs": "0.49.4",
         "dicom-parser": "1.8.21",
         "hammerjs": "2.0.8",
@@ -374,20 +375,20 @@
     },
     "extensions/measurement-tracking": {
       "name": "@ohif/extension-measurement-tracking",
-      "version": "3.13.0-beta.4",
+      "version": "3.13.0-beta.7",
       "dependencies": {
         "@babel/runtime": "7.28.2",
-        "@ohif/ui": "3.13.0-beta.4",
+        "@ohif/ui": "3.13.0-beta.7",
         "@xstate/react": "3.2.2",
         "xstate": "4.38.3",
       },
       "peerDependencies": {
         "@cornerstonejs/core": "4.15.29",
         "@cornerstonejs/tools": "4.15.29",
-        "@ohif/core": "3.13.0-beta.4",
-        "@ohif/extension-cornerstone-dicom-sr": "3.13.0-beta.4",
-        "@ohif/extension-default": "3.13.0-beta.4",
-        "@ohif/ui": "3.13.0-beta.4",
+        "@ohif/core": "3.13.0-beta.7",
+        "@ohif/extension-cornerstone-dicom-sr": "3.13.0-beta.7",
+        "@ohif/extension-default": "3.13.0-beta.7",
+        "@ohif/ui": "3.13.0-beta.7",
         "classnames": "2.5.1",
         "dcmjs": "0.49.4",
         "lodash.debounce": "4.0.8",
@@ -400,14 +401,14 @@
     },
     "extensions/test-extension": {
       "name": "@ohif/extension-test",
-      "version": "3.13.0-beta.4",
+      "version": "3.13.0-beta.7",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "classnames": "2.5.1",
       },
       "peerDependencies": {
-        "@ohif/core": "3.13.0-beta.4",
-        "@ohif/ui": "3.13.0-beta.4",
+        "@ohif/core": "3.13.0-beta.7",
+        "@ohif/ui": "3.13.0-beta.7",
         "dcmjs": "0.49.4",
         "dicom-parser": "1.8.21",
         "hammerjs": "2.0.8",
@@ -417,14 +418,14 @@
     },
     "extensions/tmtv": {
       "name": "@ohif/extension-tmtv",
-      "version": "3.13.0-beta.4",
+      "version": "3.13.0-beta.7",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "classnames": "2.5.1",
       },
       "peerDependencies": {
-        "@ohif/core": "3.13.0-beta.4",
-        "@ohif/ui": "3.13.0-beta.4",
+        "@ohif/core": "3.13.0-beta.7",
+        "@ohif/ui": "3.13.0-beta.7",
         "dcmjs": "0.49.4",
         "dicom-parser": "1.8.21",
         "hammerjs": "2.0.8",
@@ -434,16 +435,16 @@
     },
     "extensions/usAnnotation": {
       "name": "@ohif/extension-ultrasound-pleura-bline",
-      "version": "3.13.0-beta.4",
+      "version": "3.13.0-beta.7",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "@cornerstonejs/core": "4.15.29",
         "@cornerstonejs/tools": "4.15.29",
-        "@ohif/core": "3.13.0-beta.4",
-        "@ohif/extension-cornerstone": "3.13.0-beta.4",
-        "@ohif/extension-default": "3.13.0-beta.4",
-        "@ohif/i18n": "3.13.0-beta.4",
-        "@ohif/ui-next": "3.13.0-beta.4",
+        "@ohif/core": "3.13.0-beta.7",
+        "@ohif/extension-cornerstone": "3.13.0-beta.7",
+        "@ohif/extension-default": "3.13.0-beta.7",
+        "@ohif/i18n": "3.13.0-beta.7",
+        "@ohif/ui-next": "3.13.0-beta.7",
       },
       "devDependencies": {
         "@babel/core": "7.28.0",
@@ -486,7 +487,7 @@
     },
     "modes/basic": {
       "name": "@ohif/mode-basic",
-      "version": "3.13.0-beta.4",
+      "version": "3.13.0-beta.7",
       "dependencies": {
         "@babel/runtime": "7.28.2",
       },
@@ -495,19 +496,19 @@
         "webpack-merge": "5.10.0",
       },
       "peerDependencies": {
-        "@ohif/core": "3.13.0-beta.4",
-        "@ohif/extension-cornerstone": "3.13.0-beta.4",
-        "@ohif/extension-cornerstone-dicom-rt": "3.13.0-beta.4",
-        "@ohif/extension-cornerstone-dicom-seg": "3.13.0-beta.4",
-        "@ohif/extension-cornerstone-dicom-sr": "3.13.0-beta.4",
-        "@ohif/extension-default": "3.13.0-beta.4",
-        "@ohif/extension-dicom-pdf": "3.13.0-beta.4",
-        "@ohif/extension-dicom-video": "3.13.0-beta.4",
+        "@ohif/core": "3.13.0-beta.7",
+        "@ohif/extension-cornerstone": "3.13.0-beta.7",
+        "@ohif/extension-cornerstone-dicom-rt": "3.13.0-beta.7",
+        "@ohif/extension-cornerstone-dicom-seg": "3.13.0-beta.7",
+        "@ohif/extension-cornerstone-dicom-sr": "3.13.0-beta.7",
+        "@ohif/extension-default": "3.13.0-beta.7",
+        "@ohif/extension-dicom-pdf": "3.13.0-beta.7",
+        "@ohif/extension-dicom-video": "3.13.0-beta.7",
       },
     },
     "modes/basic-dev-mode": {
       "name": "@ohif/mode-basic-dev-mode",
-      "version": "3.13.0-beta.4",
+      "version": "3.13.0-beta.7",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "i18next": "17.3.1",
@@ -517,17 +518,17 @@
         "webpack-merge": "5.10.0",
       },
       "peerDependencies": {
-        "@ohif/core": "3.13.0-beta.4",
-        "@ohif/extension-cornerstone": "3.13.0-beta.4",
-        "@ohif/extension-cornerstone-dicom-sr": "3.13.0-beta.4",
-        "@ohif/extension-default": "3.13.0-beta.4",
-        "@ohif/extension-dicom-pdf": "3.13.0-beta.4",
-        "@ohif/extension-dicom-video": "3.13.0-beta.4",
+        "@ohif/core": "3.13.0-beta.7",
+        "@ohif/extension-cornerstone": "3.13.0-beta.7",
+        "@ohif/extension-cornerstone-dicom-sr": "3.13.0-beta.7",
+        "@ohif/extension-default": "3.13.0-beta.7",
+        "@ohif/extension-dicom-pdf": "3.13.0-beta.7",
+        "@ohif/extension-dicom-video": "3.13.0-beta.7",
       },
     },
     "modes/basic-test-mode": {
       "name": "@ohif/mode-test",
-      "version": "3.13.0-beta.4",
+      "version": "3.13.0-beta.7",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "i18next": "17.3.1",
@@ -537,19 +538,19 @@
         "webpack-merge": "5.10.0",
       },
       "peerDependencies": {
-        "@ohif/core": "3.13.0-beta.4",
-        "@ohif/extension-cornerstone": "3.13.0-beta.4",
-        "@ohif/extension-cornerstone-dicom-sr": "3.13.0-beta.4",
-        "@ohif/extension-default": "3.13.0-beta.4",
-        "@ohif/extension-dicom-pdf": "3.13.0-beta.4",
-        "@ohif/extension-dicom-video": "3.13.0-beta.4",
-        "@ohif/extension-measurement-tracking": "3.13.0-beta.4",
-        "@ohif/extension-test": "3.13.0-beta.4",
+        "@ohif/core": "3.13.0-beta.7",
+        "@ohif/extension-cornerstone": "3.13.0-beta.7",
+        "@ohif/extension-cornerstone-dicom-sr": "3.13.0-beta.7",
+        "@ohif/extension-default": "3.13.0-beta.7",
+        "@ohif/extension-dicom-pdf": "3.13.0-beta.7",
+        "@ohif/extension-dicom-video": "3.13.0-beta.7",
+        "@ohif/extension-measurement-tracking": "3.13.0-beta.7",
+        "@ohif/extension-test": "3.13.0-beta.7",
       },
     },
     "modes/longitudinal": {
       "name": "@ohif/mode-longitudinal",
-      "version": "3.13.0-beta.4",
+      "version": "3.13.0-beta.7",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "i18next": "17.3.1",
@@ -559,33 +560,33 @@
         "webpack-merge": "5.10.0",
       },
       "peerDependencies": {
-        "@ohif/core": "3.13.0-beta.4",
-        "@ohif/extension-cornerstone": "3.13.0-beta.4",
-        "@ohif/extension-cornerstone-dicom-rt": "3.13.0-beta.4",
-        "@ohif/extension-cornerstone-dicom-seg": "3.13.0-beta.4",
-        "@ohif/extension-cornerstone-dicom-sr": "3.13.0-beta.4",
-        "@ohif/extension-default": "3.13.0-beta.4",
-        "@ohif/extension-dicom-pdf": "3.13.0-beta.4",
-        "@ohif/extension-dicom-video": "3.13.0-beta.4",
-        "@ohif/extension-measurement-tracking": "3.13.0-beta.4",
-        "@ohif/mode-basic": "3.13.0-beta.4",
+        "@ohif/core": "3.13.0-beta.7",
+        "@ohif/extension-cornerstone": "3.13.0-beta.7",
+        "@ohif/extension-cornerstone-dicom-rt": "3.13.0-beta.7",
+        "@ohif/extension-cornerstone-dicom-seg": "3.13.0-beta.7",
+        "@ohif/extension-cornerstone-dicom-sr": "3.13.0-beta.7",
+        "@ohif/extension-default": "3.13.0-beta.7",
+        "@ohif/extension-dicom-pdf": "3.13.0-beta.7",
+        "@ohif/extension-dicom-video": "3.13.0-beta.7",
+        "@ohif/extension-measurement-tracking": "3.13.0-beta.7",
+        "@ohif/mode-basic": "3.13.0-beta.7",
       },
     },
     "modes/microscopy": {
       "name": "@ohif/mode-microscopy",
-      "version": "3.13.0-beta.4",
+      "version": "3.13.0-beta.7",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "i18next": "17.3.1",
       },
       "peerDependencies": {
-        "@ohif/core": "3.13.0-beta.4",
-        "@ohif/extension-dicom-microscopy": "3.13.0-beta.4",
+        "@ohif/core": "3.13.0-beta.7",
+        "@ohif/extension-dicom-microscopy": "3.13.0-beta.7",
       },
     },
     "modes/preclinical-4d": {
       "name": "@ohif/mode-preclinical-4d",
-      "version": "3.13.0-beta.4",
+      "version": "3.13.0-beta.7",
       "dependencies": {
         "@babel/runtime": "7.28.2",
       },
@@ -594,17 +595,17 @@
         "webpack-merge": "5.10.0",
       },
       "peerDependencies": {
-        "@ohif/core": "3.13.0-beta.4",
-        "@ohif/extension-cornerstone": "3.13.0-beta.4",
-        "@ohif/extension-cornerstone-dicom-seg": "3.13.0-beta.4",
-        "@ohif/extension-cornerstone-dynamic-volume": "3.13.0-beta.4",
-        "@ohif/extension-default": "3.13.0-beta.4",
-        "@ohif/extension-tmtv": "3.13.0-beta.4",
+        "@ohif/core": "3.13.0-beta.7",
+        "@ohif/extension-cornerstone": "3.13.0-beta.7",
+        "@ohif/extension-cornerstone-dicom-seg": "3.13.0-beta.7",
+        "@ohif/extension-cornerstone-dynamic-volume": "3.13.0-beta.7",
+        "@ohif/extension-default": "3.13.0-beta.7",
+        "@ohif/extension-tmtv": "3.13.0-beta.7",
       },
     },
     "modes/segmentation": {
       "name": "@ohif/mode-segmentation",
-      "version": "3.13.0-beta.4",
+      "version": "3.13.0-beta.7",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "i18next": "17.3.1",
@@ -636,20 +637,20 @@
         "webpack-merge": "5.10.0",
       },
       "peerDependencies": {
-        "@ohif/core": "3.13.0-beta.4",
-        "@ohif/extension-cornerstone": "3.13.0-beta.4",
-        "@ohif/extension-cornerstone-dicom-rt": "3.13.0-beta.4",
-        "@ohif/extension-cornerstone-dicom-seg": "3.13.0-beta.4",
-        "@ohif/extension-cornerstone-dicom-sr": "3.13.0-beta.4",
-        "@ohif/extension-default": "3.13.0-beta.4",
-        "@ohif/extension-dicom-pdf": "3.13.0-beta.4",
-        "@ohif/extension-dicom-video": "3.13.0-beta.4",
-        "@ohif/mode-basic": "3.13.0-beta.4",
+        "@ohif/core": "3.13.0-beta.7",
+        "@ohif/extension-cornerstone": "3.13.0-beta.7",
+        "@ohif/extension-cornerstone-dicom-rt": "3.13.0-beta.7",
+        "@ohif/extension-cornerstone-dicom-seg": "3.13.0-beta.7",
+        "@ohif/extension-cornerstone-dicom-sr": "3.13.0-beta.7",
+        "@ohif/extension-default": "3.13.0-beta.7",
+        "@ohif/extension-dicom-pdf": "3.13.0-beta.7",
+        "@ohif/extension-dicom-video": "3.13.0-beta.7",
+        "@ohif/mode-basic": "3.13.0-beta.7",
       },
     },
     "modes/tmtv": {
       "name": "@ohif/mode-tmtv",
-      "version": "3.13.0-beta.4",
+      "version": "3.13.0-beta.7",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "i18next": "17.3.1",
@@ -659,25 +660,25 @@
         "webpack-merge": "5.10.0",
       },
       "peerDependencies": {
-        "@ohif/core": "3.13.0-beta.4",
-        "@ohif/extension-cornerstone": "3.13.0-beta.4",
-        "@ohif/extension-cornerstone-dicom-sr": "3.13.0-beta.4",
-        "@ohif/extension-default": "3.13.0-beta.4",
-        "@ohif/extension-dicom-pdf": "3.13.0-beta.4",
-        "@ohif/extension-dicom-video": "3.13.0-beta.4",
-        "@ohif/extension-measurement-tracking": "3.13.0-beta.4",
+        "@ohif/core": "3.13.0-beta.7",
+        "@ohif/extension-cornerstone": "3.13.0-beta.7",
+        "@ohif/extension-cornerstone-dicom-sr": "3.13.0-beta.7",
+        "@ohif/extension-default": "3.13.0-beta.7",
+        "@ohif/extension-dicom-pdf": "3.13.0-beta.7",
+        "@ohif/extension-dicom-video": "3.13.0-beta.7",
+        "@ohif/extension-measurement-tracking": "3.13.0-beta.7",
       },
     },
     "modes/usAnnotation": {
       "name": "@ohif/mode-ultrasound-pleura-bline",
-      "version": "3.13.0-beta.4",
+      "version": "3.13.0-beta.7",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "@cornerstonejs/core": "4.15.29",
         "@cornerstonejs/tools": "4.15.29",
-        "@ohif/core": "3.13.0-beta.4",
-        "@ohif/extension-cornerstone-dicom-sr": "3.13.0-beta.4",
-        "@ohif/extension-ultrasound-pleura-bline": "3.13.0-beta.4",
+        "@ohif/core": "3.13.0-beta.7",
+        "@ohif/extension-cornerstone-dicom-sr": "3.13.0-beta.7",
+        "@ohif/extension-ultrasound-pleura-bline": "3.13.0-beta.7",
         "i18next": "17.3.1",
       },
       "devDependencies": {
@@ -709,7 +710,7 @@
     },
     "platform/app": {
       "name": "@ohif/app",
-      "version": "3.13.0-beta.4",
+      "version": "3.13.0-beta.7",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "@cornerstonejs/codec-charls": "1.2.3",
@@ -718,25 +719,25 @@
         "@cornerstonejs/codec-openjph": "2.4.7",
         "@cornerstonejs/dicom-image-loader": "4.15.29",
         "@emotion/serialize": "1.3.3",
-        "@ohif/core": "3.13.0-beta.4",
-        "@ohif/extension-cornerstone": "3.13.0-beta.4",
-        "@ohif/extension-cornerstone-dicom-rt": "3.13.0-beta.4",
-        "@ohif/extension-cornerstone-dicom-seg": "3.13.0-beta.4",
-        "@ohif/extension-cornerstone-dicom-sr": "3.13.0-beta.4",
-        "@ohif/extension-default": "3.13.0-beta.4",
-        "@ohif/extension-dicom-microscopy": "3.13.0-beta.4",
-        "@ohif/extension-dicom-pdf": "3.13.0-beta.4",
-        "@ohif/extension-dicom-video": "3.13.0-beta.4",
-        "@ohif/extension-test": "3.13.0-beta.4",
-        "@ohif/extension-ultrasound-pleura-bline": "3.13.0-beta.4",
-        "@ohif/i18n": "3.13.0-beta.4",
-        "@ohif/mode-basic-dev-mode": "3.13.0-beta.4",
-        "@ohif/mode-longitudinal": "3.13.0-beta.4",
-        "@ohif/mode-microscopy": "3.13.0-beta.4",
-        "@ohif/mode-test": "3.13.0-beta.4",
-        "@ohif/mode-ultrasound-pleura-bline": "3.13.0-beta.4",
-        "@ohif/ui": "3.13.0-beta.4",
-        "@ohif/ui-next": "3.13.0-beta.4",
+        "@ohif/core": "3.13.0-beta.7",
+        "@ohif/extension-cornerstone": "3.13.0-beta.7",
+        "@ohif/extension-cornerstone-dicom-rt": "3.13.0-beta.7",
+        "@ohif/extension-cornerstone-dicom-seg": "3.13.0-beta.7",
+        "@ohif/extension-cornerstone-dicom-sr": "3.13.0-beta.7",
+        "@ohif/extension-default": "3.13.0-beta.7",
+        "@ohif/extension-dicom-microscopy": "3.13.0-beta.7",
+        "@ohif/extension-dicom-pdf": "3.13.0-beta.7",
+        "@ohif/extension-dicom-video": "3.13.0-beta.7",
+        "@ohif/extension-test": "3.13.0-beta.7",
+        "@ohif/extension-ultrasound-pleura-bline": "3.13.0-beta.7",
+        "@ohif/i18n": "3.13.0-beta.7",
+        "@ohif/mode-basic-dev-mode": "3.13.0-beta.7",
+        "@ohif/mode-longitudinal": "3.13.0-beta.7",
+        "@ohif/mode-microscopy": "3.13.0-beta.7",
+        "@ohif/mode-test": "3.13.0-beta.7",
+        "@ohif/mode-ultrasound-pleura-bline": "3.13.0-beta.7",
+        "@ohif/ui": "3.13.0-beta.7",
+        "@ohif/ui-next": "3.13.0-beta.7",
         "@svgr/webpack": "8.1.0",
         "@types/react": "18.3.23",
         "classnames": "2.5.1",
@@ -788,7 +789,7 @@
     },
     "platform/cli": {
       "name": "@ohif/cli",
-      "version": "3.13.0-beta.4",
+      "version": "3.13.0-beta.7",
       "bin": {
         "ohif-cli": "src/index.js",
       },
@@ -812,7 +813,7 @@
     },
     "platform/core": {
       "name": "@ohif/core",
-      "version": "3.13.0-beta.4",
+      "version": "3.13.0-beta.7",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "dcmjs": "0.49.4",
@@ -839,14 +840,14 @@
         "@cornerstonejs/codec-openjph": "2.4.7",
         "@cornerstonejs/core": "4.15.29",
         "@cornerstonejs/dicom-image-loader": "4.15.29",
-        "@ohif/ui": "3.13.0-beta.4",
+        "@ohif/ui": "3.13.0-beta.7",
         "cornerstone-math": "0.1.9",
         "dicom-parser": "1.8.21",
       },
     },
     "platform/i18n": {
       "name": "@ohif/i18n",
-      "version": "3.13.0-beta.4",
+      "version": "3.13.0-beta.7",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "i18next-locize-backend": "2.2.2",
@@ -871,7 +872,7 @@
     },
     "platform/ui": {
       "name": "@ohif/ui",
-      "version": "3.13.0-beta.4",
+      "version": "3.13.0-beta.7",
       "dependencies": {
         "@testing-library/react": "13.4.0",
         "browser-detect": "0.2.28",
@@ -922,7 +923,7 @@
     },
     "platform/ui-next": {
       "name": "@ohif/ui-next",
-      "version": "3.13.0-beta.4",
+      "version": "3.13.0-beta.7",
       "dependencies": {
         "@radix-ui/react-accordion": "1.2.11",
         "@radix-ui/react-checkbox": "1.3.2",
@@ -967,7 +968,11 @@
   },
   "overrides": {
     "@babel/runtime-corejs2": "7.26.10",
+    "@cornerstonejs/adapters": "link:@cornerstonejs/adapters",
     "@cornerstonejs/codec-openjpeg": "1.3.0",
+    "@cornerstonejs/core": "link:@cornerstonejs/core",
+    "@cornerstonejs/dicom-image-loader": "file:../cornerstone3D-beta/packages/dicomImageLoader/cornerstonejs-dicom-image-loader-4.15.31.tgz",
+    "@cornerstonejs/tools": "link:@cornerstonejs/tools",
     "axios": "1.13.5",
     "body-parser": "1.20.3",
     "commander": "8.3.0",
@@ -1233,7 +1238,7 @@
 
     "@bcoe/v8-coverage": ["@bcoe/v8-coverage@0.2.3", "", {}, "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="],
 
-    "@cornerstonejs/adapters": ["@cornerstonejs/adapters@4.15.29", "", { "dependencies": { "@babel/runtime-corejs2": "7.26.10", "buffer": "6.0.3", "dcmjs": "0.48.0", "gl-matrix": "3.4.3", "ndarray": "1.0.19" }, "peerDependencies": { "@cornerstonejs/core": "4.15.29", "@cornerstonejs/tools": "4.15.29" } }, "sha512-OcG3YtCQ+C7X/f7buK3dsMOc8NyqsgH/LZRT/JbvppUnqhhfyKIpBTtJG+2+roMyLsi3QrsCeI9Eu6KaQgFFvw=="],
+    "@cornerstonejs/adapters": ["@cornerstonejs/adapters@link:@cornerstonejs/adapters", {}],
 
     "@cornerstonejs/ai": ["@cornerstonejs/ai@4.15.29", "", { "dependencies": { "@babel/runtime-corejs2": "7.26.10", "buffer": "6.0.3", "dcmjs": "0.48.0", "gl-matrix": "3.4.3", "lodash.clonedeep": "4.5.0", "ndarray": "1.0.19", "onnxruntime-common": "1.17.1", "onnxruntime-web": "1.17.1" }, "peerDependencies": { "@cornerstonejs/core": "4.15.29", "@cornerstonejs/tools": "4.15.29" } }, "sha512-fTbfAE7HpXES+vPYzhP0eGljmwykGkbY38LymbMsrn7p6DmvKuJIh4sfUzUtIPW+5kMnCiXAEUhi3+oebQZs0g=="],
 
@@ -1247,15 +1252,15 @@
 
     "@cornerstonejs/codec-openjph": ["@cornerstonejs/codec-openjph@2.4.7", "", {}, "sha512-qvP4q4JDib7mi9r7LqKOwqz7YZ8gjtDX4ZCezeYf8+eb7MBXCz5uXAMeVF3yz9Axw4XiIMdB/pqXkm8tqCl13w=="],
 
-    "@cornerstonejs/core": ["@cornerstonejs/core@4.15.29", "", { "dependencies": { "@kitware/vtk.js": "34.15.1", "comlink": "4.4.2", "gl-matrix": "3.4.3", "loglevel": "1.9.2" } }, "sha512-o+5gXbxtZde1GIULmw+hWwf6KI3eiXCre0U1C372jbovxA66JH2t+2VW1nj0F2JRRnO0FjgT/+DWYCWt0ILGoA=="],
+    "@cornerstonejs/core": ["@cornerstonejs/core@link:@cornerstonejs/core", {}],
 
-    "@cornerstonejs/dicom-image-loader": ["@cornerstonejs/dicom-image-loader@4.15.29", "", { "dependencies": { "@cornerstonejs/codec-charls": "1.2.3", "@cornerstonejs/codec-libjpeg-turbo-8bit": "1.2.2", "@cornerstonejs/codec-openjpeg": "1.3.0", "@cornerstonejs/codec-openjph": "2.4.7", "comlink": "4.4.2", "dicom-parser": "1.8.21", "jpeg-lossless-decoder-js": "2.1.2", "pako": "2.1.0", "uuid": "9.0.1" }, "peerDependencies": { "@cornerstonejs/core": "4.15.29" } }, "sha512-+R7NoFyVTz2OSKclVQ21dqwgYmFM5q7SZc59YPcxfop7rk2+9H5rRxa04ytKHPjz+N5AlqbLKpJvy/RE10Xcew=="],
+    "@cornerstonejs/dicom-image-loader": ["@cornerstonejs/dicom-image-loader@../cornerstone3D-beta/packages/dicomImageLoader/cornerstonejs-dicom-image-loader-4.15.31.tgz", { "dependencies": { "@cornerstonejs/codec-charls": "1.2.3", "@cornerstonejs/codec-libjpeg-turbo-8bit": "1.2.2", "@cornerstonejs/codec-openjpeg": "1.3.0", "@cornerstonejs/codec-openjph": "2.4.7", "comlink": "4.4.2", "dicom-parser": "1.8.21", "jpeg-lossless-decoder-js": "2.1.2", "pako": "2.1.0", "uuid": "9.0.1" }, "peerDependencies": { "@cornerstonejs/core": "4.15.31", "dicom-parser": "1.8.21" } }],
 
     "@cornerstonejs/labelmap-interpolation": ["@cornerstonejs/labelmap-interpolation@4.15.29", "", { "dependencies": { "@itk-wasm/morphological-contour-interpolation": "1.1.0", "itk-wasm": "1.0.0-b.165" }, "peerDependencies": { "@cornerstonejs/core": "4.15.29", "@cornerstonejs/tools": "4.15.29", "@kitware/vtk.js": "34.15.1" } }, "sha512-4pZTcZWv88l59HDSd/arlJ/WNcdxf9WZbm4GiwsrOZxKx8vkLivnKA+pjPUu1LugCJjlLMgugEVnBhZCk+hW7w=="],
 
     "@cornerstonejs/polymorphic-segmentation": ["@cornerstonejs/polymorphic-segmentation@4.15.29", "", { "dependencies": { "@icr/polyseg-wasm": "0.4.0" }, "peerDependencies": { "@cornerstonejs/core": "4.15.29", "@cornerstonejs/tools": "4.15.29", "@kitware/vtk.js": "34.15.1" } }, "sha512-EMCw2Y+bjtI3qfCAv1VbAumWH8XNokEMA1roI03jLzaCvr0+8Jts9Z3P4kyQmOm60veaad9214yM9IZ41J4zGQ=="],
 
-    "@cornerstonejs/tools": ["@cornerstonejs/tools@4.15.29", "", { "dependencies": { "@types/offscreencanvas": "2019.7.3", "comlink": "4.4.2", "lodash.get": "4.4.2" }, "peerDependencies": { "@cornerstonejs/core": "4.15.29", "@kitware/vtk.js": "34.15.1", "@types/d3-array": "3.2.1", "@types/d3-interpolate": "3.0.4", "d3-array": "3.2.4", "d3-interpolate": "3.0.1", "gl-matrix": "3.4.3" } }, "sha512-MG+RPJ8EUyT3tWcHimSoDHOTeodNQAz7vPG+H03BjkbRu2RPsRVQRqSqoWHkyTOgyUv1XTk0JXJTXZQ/I7xcdA=="],
+    "@cornerstonejs/tools": ["@cornerstonejs/tools@link:@cornerstonejs/tools", {}],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 
@@ -1909,12 +1914,6 @@
 
     "@types/connect-history-api-fallback": ["@types/connect-history-api-fallback@1.5.4", "", { "dependencies": { "@types/express-serve-static-core": "*", "@types/node": "*" } }, "sha512-n6Cr2xS1h4uAulPRdlw6Jl6s1oG8KrVilPN2yUITEs+K48EzMJJ3W1xy8K5eWuFvjp3R74AOIGSmp2UfBJ8HFw=="],
 
-    "@types/d3-array": ["@types/d3-array@3.2.1", "", {}, "sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg=="],
-
-    "@types/d3-color": ["@types/d3-color@3.1.3", "", {}, "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="],
-
-    "@types/d3-interpolate": ["@types/d3-interpolate@3.0.4", "", { "dependencies": { "@types/d3-color": "*" } }, "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA=="],
-
     "@types/debug": ["@types/debug@4.1.12", "", { "dependencies": { "@types/ms": "*" } }, "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ=="],
 
     "@types/emscripten": ["@types/emscripten@1.40.1", "", {}, "sha512-sr53lnYkQNhjHNN0oJDdUm5564biioI5DuOpycufDVK7D3y+GR3oUswe2rlwY1nPNyusHbrJ9WoTyIHl4/Bpwg=="],
@@ -1970,8 +1969,6 @@
     "@types/node-forge": ["@types/node-forge@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-zePQJSW5QkwSHKRApqWCVKeKoSOt4xvEnLENZPjyvm9Ezdf/EyDeJM7jqLzOwjVICQQzvLZ63T55MKdJB5H6ww=="],
 
     "@types/normalize-package-data": ["@types/normalize-package-data@2.4.4", "", {}, "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA=="],
-
-    "@types/offscreencanvas": ["@types/offscreencanvas@2019.7.3", "", {}, "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A=="],
 
     "@types/parse-json": ["@types/parse-json@4.0.2", "", {}, "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw=="],
 
@@ -5234,8 +5231,6 @@
     "@babel/plugin-transform-runtime/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@babel/preset-env/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
-
-    "@cornerstonejs/adapters/buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
 
     "@cornerstonejs/ai/buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
 

--- a/package.json
+++ b/package.json
@@ -76,7 +76,9 @@
     "lerna:cache": "./netlify-lerna-cache.sh",
     "lerna:restore": "./netlify-lerna-restore.sh",
     "lerna:customVersion": "node version.mjs",
-    "link-list": "npm ls --depth=0 --link=true"
+    "link-list": "npm ls --depth=0 --link=true",
+    "pack-dicom-image-loader": "node -e \"require('child_process').execSync('npm run build:loader && npm pack', {cwd: require('path').resolve(__dirname, '../cornerstone3D-beta/packages/dicomImageLoader'), stdio: 'inherit'})\"",
+    "install:with-dicom-loader": "yarn pack-dicom-image-loader && yarn install"
   },
   "dependencies": {
     "execa": "8.0.1"
@@ -136,6 +138,10 @@
     ]
   },
   "resolutions": {
+    "@cornerstonejs/tools": "link:@cornerstonejs/tools",
+    "@cornerstonejs/core": "link:@cornerstonejs/core",
+    "@cornerstonejs/adapters": "link:@cornerstonejs/adapters",
+    "@cornerstonejs/dicom-image-loader": "file:../cornerstone3D-beta/packages/dicomImageLoader/cornerstonejs-dicom-image-loader-4.15.31.tgz",
     "commander": "8.3.0",
     "cross-env": "7.0.3",
     "cross-spawn": "7.0.6",

--- a/platform/app/.webpack/writePluginImportsFile.js
+++ b/platform/app/.webpack/writePluginImportsFile.js
@@ -66,8 +66,19 @@ function getRuntimeLoadModesExtensions(modules) {
   const dynamicLoad = [];
   dynamicLoad.push(
     '\n\n// Add a dynamic runtime loader',
-    'async function loadModule(module) {',
-    "  if (typeof module !== 'string') return module;"
+    'async function loadModule(module, fallback) {',
+    "  if (typeof module !== 'string') return module;",
+    '  // If a fallback import function is provided, try it first.',
+    "  if (typeof fallback === 'function') {",
+    '    try {',
+    '      const fallbackModule = await fallback();',
+    '      if (fallbackModule != null) {',
+    '        return fallbackModule;',
+    '      }',
+    '    } catch (e) {',
+    '      // Ignore and continue with the runtime/global loader below.',
+    '    }',
+    '  }'
   );
   modules.forEach(module => {
     const packageName = extractName(module);

--- a/platform/core/src/extensions/ExtensionManager.ts
+++ b/platform/core/src/extensions/ExtensionManager.ts
@@ -31,7 +31,7 @@ export interface ExtensionParams extends ExtensionConstructor {
   servicesManager: AppTypes.ServicesManager;
   serviceProvidersManager: ServiceProvidersManager;
   configuration?: ExtensionConfiguration;
-  peerImport: (moduleId: string) => Promise<any>;
+  peerImport: (moduleId: string, fallback?: () => Promise<unknown>) => Promise<any>;
 }
 
 /**

--- a/platform/core/src/types/AppTypes.ts
+++ b/platform/core/src/types/AppTypes.ts
@@ -139,7 +139,10 @@ declare global {
       ) => Record<string, unknown>;
       dataSources?: Record<string, unknown>;
       oidc?: Record<string, unknown>;
-      peerImport?: (moduleId: string) => Promise<Record<string, unknown>>;
+      peerImport?: (
+        moduleId: string,
+        fallback?: () => Promise<unknown>
+      ) => Promise<unknown>;
       studyPrefetcher?: {
         enabled: boolean;
         displaySetsCount: number;

--- a/rsbuild.config.ts
+++ b/rsbuild.config.ts
@@ -131,6 +131,11 @@ export default defineConfig({
       PUBLIC_URL,
     },
   },
+  dev: {
+    // Avoid lazy-compilation proxy chunks; they can be served as HTML by
+    // historyApiFallback and cause "MIME type 'text/html' not executable".
+    lazyCompilation: false,
+  },
   server: {
     port: OHIF_PORT,
     open: OHIF_OPEN,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1279,15 +1279,12 @@
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
 "@cornerstonejs/adapters@4.15.29":
-  version "4.15.29"
-  resolved "https://registry.yarnpkg.com/@cornerstonejs/adapters/-/adapters-4.15.29.tgz#cd8a60c72db55a76f8e0489ad825bf0f28b0f625"
-  integrity sha512-OcG3YtCQ+C7X/f7buK3dsMOc8NyqsgH/LZRT/JbvppUnqhhfyKIpBTtJG+2+roMyLsi3QrsCeI9Eu6KaQgFFvw==
-  dependencies:
-    "@babel/runtime-corejs2" "7.26.10"
-    buffer "6.0.3"
-    dcmjs "0.48.0"
-    gl-matrix "3.4.3"
-    ndarray "1.0.19"
+  version "0.0.0"
+  uid ""
+
+"@cornerstonejs/adapters@link:@cornerstonejs/adapters":
+  version "0.0.0"
+  uid ""
 
 "@cornerstonejs/ai@4.15.29":
   version "4.15.29"
@@ -1329,19 +1326,16 @@
   integrity sha512-qvP4q4JDib7mi9r7LqKOwqz7YZ8gjtDX4ZCezeYf8+eb7MBXCz5uXAMeVF3yz9Axw4XiIMdB/pqXkm8tqCl13w==
 
 "@cornerstonejs/core@4.15.29":
-  version "4.15.29"
-  resolved "https://registry.yarnpkg.com/@cornerstonejs/core/-/core-4.15.29.tgz#498b3dd23119b9b03fbd81d859e029715766f957"
-  integrity sha512-o+5gXbxtZde1GIULmw+hWwf6KI3eiXCre0U1C372jbovxA66JH2t+2VW1nj0F2JRRnO0FjgT/+DWYCWt0ILGoA==
-  dependencies:
-    "@kitware/vtk.js" "34.15.1"
-    comlink "4.4.2"
-    gl-matrix "3.4.3"
-    loglevel "1.9.2"
+  version "0.0.0"
+  uid ""
 
-"@cornerstonejs/dicom-image-loader@4.15.29":
-  version "4.15.29"
-  resolved "https://registry.yarnpkg.com/@cornerstonejs/dicom-image-loader/-/dicom-image-loader-4.15.29.tgz#238cd5cdc4cfd310e0baffb8e9be7895db01dffe"
-  integrity sha512-+R7NoFyVTz2OSKclVQ21dqwgYmFM5q7SZc59YPcxfop7rk2+9H5rRxa04ytKHPjz+N5AlqbLKpJvy/RE10Xcew==
+"@cornerstonejs/core@link:@cornerstonejs/core":
+  version "0.0.0"
+  uid ""
+
+"@cornerstonejs/dicom-image-loader@4.15.29", "@cornerstonejs/dicom-image-loader@file:../cornerstone3D-beta/packages/dicomImageLoader/cornerstonejs-dicom-image-loader-4.15.31.tgz":
+  version "4.15.31"
+  resolved "file:../cornerstone3D-beta/packages/dicomImageLoader/cornerstonejs-dicom-image-loader-4.15.31.tgz#9bb0321ab1e3679ee1661675b0a55d0bdea6b5ca"
   dependencies:
     "@cornerstonejs/codec-charls" "1.2.3"
     "@cornerstonejs/codec-libjpeg-turbo-8bit" "1.2.2"
@@ -1369,13 +1363,12 @@
     "@icr/polyseg-wasm" "0.4.0"
 
 "@cornerstonejs/tools@4.15.29":
-  version "4.15.29"
-  resolved "https://registry.yarnpkg.com/@cornerstonejs/tools/-/tools-4.15.29.tgz#46d29b8f01d2cc702a15547b1013d2b6a94cffff"
-  integrity sha512-MG+RPJ8EUyT3tWcHimSoDHOTeodNQAz7vPG+H03BjkbRu2RPsRVQRqSqoWHkyTOgyUv1XTk0JXJTXZQ/I7xcdA==
-  dependencies:
-    "@types/offscreencanvas" "2019.7.3"
-    comlink "4.4.2"
-    lodash.get "4.4.2"
+  version "0.0.0"
+  uid ""
+
+"@cornerstonejs/tools@link:@cornerstonejs/tools":
+  version "0.0.0"
+  uid ""
 
 "@cspotcode/source-map-support@^0.8.0":
   version "0.8.1"
@@ -3342,7 +3335,7 @@
 
 "@rollup/rollup-linux-x64-gnu@4.13.0":
   version "4.13.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.13.0.tgz#f672f6508f090fc73f08ba40ff76c20b57424778"
+  resolved "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.13.0.tgz#f672f6508f090fc73f08ba40ff76c20b57424778"
   integrity sha512-yUD/8wMffnTKuiIsl6xU+4IA8UNhQ/f1sAnQebmE/lyQ8abjsVyDkyRkWop0kdMhKMprpNIhPmYlCxgHrPoXoA==
 
 "@rsbuild/core@1.5.1":
@@ -4065,11 +4058,6 @@
   version "2.4.4"
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz#56e2cc26c397c038fab0e3a917a12d5c5909e901"
   integrity sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==
-
-"@types/offscreencanvas@2019.7.3":
-  version "2019.7.3"
-  resolved "https://registry.yarnpkg.com/@types/offscreencanvas/-/offscreencanvas-2019.7.3.tgz#90267db13f64d6e9ccb5ae3eac92786a7c77a516"
-  integrity sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==
 
 "@types/parse-json@^4.0.0":
   version "4.0.2"
@@ -6277,7 +6265,7 @@ combined-stream@^1.0.8, combined-stream@~1.0.6:
 
 comlink@4.4.2, comlink@^4.4.1:
   version "4.4.2"
-  resolved "https://registry.yarnpkg.com/comlink/-/comlink-4.4.2.tgz#cbbcd82742fbebc06489c28a183eedc5c60a2bca"
+  resolved "https://registry.npmjs.org/comlink/-/comlink-4.4.2.tgz#cbbcd82742fbebc06489c28a183eedc5c60a2bca"
   integrity sha512-OxGdvBmJuNKSCMO4NTl1L47VRp6xn2wG4F/2hYzB6tiCb709otOxtEYCSvK80PtjODfXXZu8ds+Nw5kVCjqd2g==
 
 commander@8.3.0, commander@9.2.0, commander@^10.0.1, commander@^11.1.0, commander@^2.20.0, commander@^2.8.1, commander@^6.2.1, commander@^7.2.0, commander@^8.3.0:
@@ -11575,7 +11563,7 @@ jju@~1.4.0:
 
 jpeg-lossless-decoder-js@2.1.2:
   version "2.1.2"
-  resolved "https://registry.yarnpkg.com/jpeg-lossless-decoder-js/-/jpeg-lossless-decoder-js-2.1.2.tgz#9ff0ecfcafa6acaee6097c532720bd526278aa3d"
+  resolved "https://registry.npmjs.org/jpeg-lossless-decoder-js/-/jpeg-lossless-decoder-js-2.1.2.tgz#9ff0ecfcafa6acaee6097c532720bd526278aa3d"
   integrity sha512-fYf/plymnuKwVw+s8gJ8O/BPw8y8OLaN11MBvEcT05kuy3m45o7BEC4J0JbxMNUYyO+MdK/I/jq0q1gkVYZm2Q==
   optionalDependencies:
     "@rollup/rollup-linux-x64-gnu" "4.13.0"
@@ -12300,7 +12288,7 @@ log-update@^4.0.0:
     slice-ansi "^4.0.0"
     wrap-ansi "^6.2.0"
 
-loglevel@1.9.2, loglevel@^1.8.1:
+loglevel@^1.8.1:
   version "1.9.2"
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.9.2.tgz#c2e028d6c757720107df4e64508530db6621ba08"
   integrity sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==
@@ -14268,7 +14256,7 @@ pacote@^15.2.0:
 
 pako@2.1.0, pako@^2.0.4:
   version "2.1.0"
-  resolved "https://registry.yarnpkg.com/pako/-/pako-2.1.0.tgz#266cc37f98c7d883545d11335c00fbd4062c9a86"
+  resolved "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz#266cc37f98c7d883545d11335c00fbd4062c9a86"
   integrity sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==
 
 pako@^1.0.5, pako@~1.0.5:
@@ -18409,7 +18397,7 @@ utrie@^1.0.2:
 
 uuid@9.0.1, uuid@^9.0, uuid@^9.0.0:
   version "9.0.1"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
+  resolved "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
   integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
 
 uuid@^8.3.2:


### PR DESCRIPTION
### Context

Adds a set of definitions to allow loading a linked dicom image loader as well as the normal package dependency.

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] OS: <!--[e.g. Windows 10, macOS 10.15.4]-->
- [] Node version: <!--[e.g. 18.16.1]-->
- [] Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR enables loading the DICOM image loader from a linked local package instead of only from npm registry. The implementation adds a fallback mechanism to the module loading system.

**Key changes:**
- Extended `peerImport` function signature to accept an optional `fallback` parameter that provides an alternative import source
- Modified the dynamic module loader in `writePluginImportsFile.js` to try the fallback function first before falling back to runtime imports
- Added yarn/bun resolutions to use linked packages for `@cornerstonejs/core`, `@cornerstonejs/tools`, `@cornerstonejs/adapters`, and a local tarball for `@cornerstonejs/dicom-image-loader`
- Disabled rsbuild lazy compilation to prevent MIME type errors with history API fallback
- Added npm scripts to build and pack the dicom-image-loader from a sibling repository

**Architecture:**
The fallback mechanism integrates cleanly with the existing extension system. When extensions call `peerImport(moduleId, fallback)`, the loader first attempts the fallback import, then falls back to the standard runtime import if the fallback fails or returns null. This allows developers to work with linked packages while maintaining backward compatibility with standard npm package imports.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with some environment setup considerations
- The changes are well-structured and backward compatible - the fallback parameter is optional and the logic gracefully degrades to existing behavior. However, the score is 4/5 because: (1) the `file:` resolution depends on a sibling directory structure that may not exist in all environments, (2) the PR is marked WIP suggesting incomplete testing, and (3) there's no documentation for the new development workflow
- Check `package.json` resolutions work correctly in CI/CD and different development setups

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| platform/core/src/types/AppTypes.ts | Added optional `fallback` parameter to `peerImport` function signature for loading alternative module sources |
| platform/core/src/extensions/ExtensionManager.ts | Updated `peerImport` type signature in `ExtensionParams` to accept optional fallback function parameter |
| platform/app/.webpack/writePluginImportsFile.js | Modified `loadModule` to support fallback import function, enabling linked package loading before runtime imports |
| rsbuild.config.ts | Disabled lazy compilation to prevent MIME type errors when serving proxy chunks as HTML |
| package.json | Added yarn resolutions for cornerstone packages to support linked development and local tarball for dicom-image-loader |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Ext as Extension
    participant EM as ExtensionManager
    participant Loader as loadModule()
    participant Fallback as fallback()
    participant Runtime as Runtime Import
    
    Ext->>EM: peerImport(moduleId, fallback)
    EM->>Loader: loadModule(moduleId, fallback)
    
    alt fallback provided
        Loader->>Fallback: Try fallback()
        alt fallback succeeds
            Fallback-->>Loader: Return module
            Loader-->>EM: Return module
        else fallback fails/returns null
            Loader->>Runtime: Dynamic import(moduleId)
            Runtime-->>Loader: Return module
            Loader-->>EM: Return module
        end
    else no fallback
        Loader->>Runtime: Dynamic import(moduleId)
        Runtime-->>Loader: Return module
        Loader-->>EM: Return module
    end
    
    EM-->>Ext: Return loaded module
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->