### PR TITLE
fix(usAnnotation): Prevent error after JSON download

### DIFF
--- a/extensions/usAnnotation/src/getCommandsModule.ts
+++ b/extensions/usAnnotation/src/getCommandsModule.ts
@@ -279,14 +279,6 @@ function commandsModule({
       downloadBlob(blob, {
         filename: `ultrasound_annotations_${new Date().toISOString().slice(0, 10)}.json`,
       });
-
-      // Append to the document, click to download, and remove
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-
-      // Clean up by revoking the URL
-      URL.revokeObjectURL(url);
     },
   };
 


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

Removes leftover dead code in downloadUSPleuraBLineAnnotationsJSON that referenced undefined variables a and url, causing a ReferenceError and "Something went wrong" error after downloading


### Changes & Results

Fixes [#5658](https://github.com/OHIF/Viewers/issues/5658)

The downloadBlob utility already handles the full download lifecycle (creating an anchor element, clicking it, removing it, and revoking the blob URL). Lines after the downloadBlob call were remnants of a manual download implementation that was replaced but never cleaned up. These lines referenced two never-declared variables (a and url), which threw a ReferenceError after every otherwise-successful JSON download.

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

  - Open the US Annotation mode with a study
  - Add some annotations
  - Click the JSON download button
  - Verify the file downloads successfully with no "Something went wrong" error

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] OS: macOS 15.7.3 Sequoia (24G419)<!--[e.g. Windows 10, macOS 10.15.4]-->
- [x] Node version: 20.19.1 <!--[e.g. 18.16.1]-->
- [x] Browser: Chrome 45.0.7632.46 (Official Build) (arm64)
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Removed dead code that caused a ReferenceError after downloading ultrasound annotations as JSON. The removed lines (282-289) were leftover from a manual download implementation that referenced undefined variables `a` and `url`, causing the application to show "Something went wrong" error after every otherwise-successful JSON download. The `downloadBlob` utility already handles the complete download lifecycle internally, making these lines redundant and erroneous.

- Removed 8 lines of dead code referencing undefined variables `a` and `url`
- Fix resolves ReferenceError that occurred after successful JSON downloads
- No functional changes to the download behavior itself

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The change only removes dead code with undefined variable references that was causing runtime errors. The `downloadBlob` utility already performs all the removed functionality correctly, making these lines both redundant and broken. This is a straightforward bug fix with no side effects.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| extensions/usAnnotation/src/getCommandsModule.ts | Removed dead code with undefined variable references that caused ReferenceError after JSON download |

</details>


</details>


<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->