### PR TITLE
chore(security): Updates for running bun audit during CI and dependabot PR version update settings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,11 +112,22 @@ jobs:
       - checkout
       - attach_workspace:
           at: ~/repo
-      # SECURITY AUDIT
+      # SECURITY AUDIT - only when bun.lock has changed
       - run:
           name: 'Security Audit - High Risk Vulnerabilities'
           command: |
-            echo "🔍 Running bun audit for security vulnerabilities..."
+            git fetch origin master 2>/dev/null || true
+            BASE_REF=$(git merge-base HEAD origin/master 2>/dev/null)
+            if [[ -z "$BASE_REF" ]]; then
+              echo "Could not determine base ref (e.g. shallow clone or no origin/master), skipping security audit."
+              exit 0
+            fi
+            CHANGED_FILES=$(git diff --name-only origin/master...HEAD 2>/dev/null || echo "")
+            if ! echo "$CHANGED_FILES" | grep -qx 'bun.lock'; then
+              echo "⏭️ bun.lock unchanged - skipping security audit."
+              exit 0
+            fi
+            echo "🔍 bun.lock changed - running bun audit for security vulnerabilities..."
             echo "Checking for HIGH-RISK vulnerabilities..."
 
             # Define ignored vulnerabilities with comments

--- a/.github/.dependabot.yaml
+++ b/.github/.dependabot.yaml
@@ -2,6 +2,8 @@ version: 2
 enable-beta-ecosystems: true
 updates:
   - package-ecosystem: 'bun'
+    # Disable all pull requests for bun version updates.
+    open-pull-requests-limit: 0
     directory: '/'
     schedule:
       interval: 'daily'
@@ -10,6 +12,8 @@ updates:
       prefix: 'chore'
       include: 'scope'
   - package-ecosystem: 'npm'
+    # Disable all pull requests for npm version updates.
+    open-pull-requests-limit: 0
     directory: '/'
     schedule:
       interval: 'daily'


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context
`bun audit` and `dependabot` has useful alerts concerning vulnerabilities in dependent packages. In the case of `bun audit`, holding up PRs that did not alter dependencies for some alert discovered on existing dependencies does not make sense. Such vulnerabilities can be addressed in separate PRs. In the case of `dependabot`, many of the PRs it creates are for less than HIGH severity vulnerabilities which for this project are not considered urgent. Also many times `dependabot` updates the lock files instead of the package.json files which is susceptible to `yarn` and/or `bun` reverting the change at some point in the future - negating the patch that was applied.

Ultimately, it is best for vulnerabilities to be handled at the discretion of the team.

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results
Update circleci config to only run bun audit for lockfile changes.

Disabled all dependabot pull requests for bun and npm version updates.
<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing
Run CI

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR optimizes CI/CD security workflows by conditionally running `bun audit` only when lock files change, and disables automated dependabot PRs to allow manual vulnerability management.

**Key Changes:**
- Modified CircleCI config to skip security audits when `bun.lock` is unchanged, preventing unnecessary PR delays
- Disabled dependabot automated PRs for both bun and npm ecosystems by setting `open-pull-requests-limit: 0`
- Added git-based detection logic to determine if lock files were modified before running audits

**Issues Found:**
- Base branch hardcoded as `master` - won't work correctly for release branches
- Grep pattern may miss lock file changes in subdirectories or miss `bun.lockb` files
- `-qx` flag requires exact line match which could fail if file paths include directories

<h3>Confidence Score: 3/5</h3>

- This PR has logical issues that could cause the security audit to be skipped incorrectly
- The changes improve CI efficiency but contain bugs in the git diff logic that could cause security audits to be skipped when they shouldn't be. The hardcoded `master` branch won't work for release branches, and the grep pattern won't catch all lock file changes.
- `.circleci/config.yml` needs attention for the base branch reference and grep pattern logic

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .circleci/config.yml | Added conditional logic to skip `bun audit` when `bun.lock` is unchanged, improving CI efficiency |
| .github/.dependabot.yaml | Disabled automated dependabot PRs by setting `open-pull-requests-limit: 0` for bun and npm ecosystems |

</details>


</details>


<sub>Last reviewed commit: 65ee8b1</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->