### PR TITLE
fix capture not maintaining flip/rotate state

### DIFF
--- a/extensions/cornerstone/src/utils/CornerstoneViewportDownloadForm.tsx
+++ b/extensions/cornerstone/src/utils/CornerstoneViewportDownloadForm.tsx
@@ -118,6 +118,11 @@ const CornerstoneViewportDownloadForm = ({
     const downloadViewport = renderingEngine.getViewport(VIEWPORT_ID);
 
     try {
+      // Capture current viewport state
+      // - properties: VOI, colormap, interpolation, etc.
+      // - viewPresentation: flip/rotate/zoom presentation state added for
+      //   saving flip and rotation for capture
+      // - viewReference: image/volume reference
       const properties = viewport.getProperties();
       const viewPresentation = viewport.getViewPresentation?.();
       const viewRef = viewport.getViewReference?.();
@@ -130,18 +135,22 @@ const CornerstoneViewportDownloadForm = ({
         await downloadViewport.setVolumes([{ volumeId: volumeIds[0] }]);
       }
 
+      // Apply presentation state so captured image preserves flip/rotate
       if (viewPresentation && downloadViewport.setViewPresentation) {
         downloadViewport.setViewPresentation(viewPresentation);
       }
 
+      // Apply viewport display properties
       downloadViewport.setProperties(properties);
 
+      // Ensure correct image/volume reference
       if (viewRef && downloadViewport.setViewReference) {
         downloadViewport.setViewReference(viewRef);
       }
 
       downloadViewport.render();
 
+      // Re-apply segmentation overlays to the download viewport
       if (segmentationRepresentations?.length) {
         segmentationRepresentations.forEach(segRepresentation => {
           const { segmentationId, colorLUTIndex, type } = segRepresentation;


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

[Fixes #5750
](https://github.com/OHIF/Viewers/issues/5750)
<!--
When downloading/capturing a viewport, the captured image did not preserve the current flip/rotate (view presentation) state. This happened because the download viewport copied properties + viewReference, but not the viewPresentation from the active viewport.
-->

### Changes & Results

<!--
- Copy `viewPresentation` from the active viewport to the download viewport before rendering.
- Keep existing behavior for stack/volume loading and segmentation overlays.

What are the effects of this change?
After Video:

-->

### Testing

<!--
1. Run the OHIF viewer 
2. Load any study/series.
3. Apply flip and/or rotate in the active viewport.
4. Save Image.
6. Verify the downloaded image matches the current viewport orientation (flip/rotate).
-->

https://github.com/user-attachments/assets/e358210a-9629-436c-88ca-dfec9e68ac29


### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

fix(Capture): preserve flip/rotate state in viewport download

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals. 

#### Tested Environment

- [x] OS: Windows 11 + WSL (Ubuntu 24.04)
- [x] Node version: v20.20.0
- [x] Browser: Chrome Version 145.0.7632.111

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where downloaded/captured viewport images did not preserve flip and rotate transformations. The fix captures the `viewPresentation` state (which contains flip/rotate data) from the active viewport and applies it to the download viewport before rendering.

**Key Changes:**
- Captures `viewPresentation` using optional chaining (`viewport.getViewPresentation?.()`)
- Applies `viewPresentation` to download viewport before setting properties and view reference
- Adds comprehensive comments explaining each state component (properties, viewPresentation, viewReference)
- Minor code formatting improvements (config object condensing)

**Implementation Details:**
- Uses optional chaining and null checks to safely handle viewports that may not support `getViewPresentation`/`setViewPresentation`
- Maintains correct order of operations: load stack/volume → apply presentation state → apply properties → set view reference
- Preserves existing segmentation overlay functionality

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a focused bug fix with proper defensive programming (optional chaining and null checks). The implementation follows existing patterns in the codebase for handling viewPresentation. The fix addresses a specific reported issue without introducing breaking changes or side effects.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| extensions/cornerstone/src/utils/CornerstoneViewportDownloadForm.tsx | Adds `viewPresentation` capture and application to preserve flip/rotate state during viewport download. Code is well-structured with proper null checks and ordering. |

</details>


</details>


<sub>Last reviewed commit: c793854</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->