### PR TITLE
fix(security): Address various security vulnerabilities in the release/3.12 branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,8 +132,10 @@ jobs:
 
             # Define ignored vulnerabilities with comments
             IGNORED_VULNS=(
-              "GHSA-3ppc-4f35-3m26"  # CVE-2026-26996 - OHIF's use of minimatch via glob is safe because it does NOT use the CLI
-                                     # CVE-2026-26996 - OHIF's other uses of minimatch are strictly for building and CI/CD purposes
+              "GHSA-3ppc-4f35-3m26"  # CVE-2026-26996 - minimatch via itk-wasm and glob is safe because it does NOT use the CLI
+                                     # CVE-2026-26996 - minimatch via other packages are strictly for building and CI/CD purposes; no user supplied expressions are passed to minimatch
+              "GHSA-7r86-cg39-jmmj"  # CVE-2026-27903 - minimatch same as above
+              "GHSA-23c5-xmqv-rm74"  # CVE-2026-27904 - minimatch same as above
             )
 
             # Build ignore flags

--- a/bun.lock
+++ b/bun.lock
@@ -967,7 +967,8 @@
     "package-json": "8.1.1",
     "path-to-regexp": "0.1.12",
     "qs": "6.14.1",
-    "rollup": "2.79.2",
+    "rollup": "2.80.0",
+    "serialize-javascript": "7.0.4",
     "tapable": "2.2.2",
     "tar": "7.5.9",
     "trim": "1.0.1",
@@ -4625,7 +4626,7 @@
 
     "ripemd160": ["ripemd160@2.0.2", "", { "dependencies": { "hash-base": "^3.0.0", "inherits": "^2.0.1" } }, "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA=="],
 
-    "rollup": ["rollup@2.79.2", "", { "optionalDependencies": { "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ=="],
+    "rollup": ["rollup@2.80.0", "", { "optionalDependencies": { "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ=="],
 
     "rollup-plugin-terser": ["rollup-plugin-terser@7.0.2", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "jest-worker": "^26.2.1", "serialize-javascript": "^4.0.0", "terser": "^5.0.0" }, "peerDependencies": { "rollup": "^2.0.0" } }, "sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ=="],
 
@@ -4671,7 +4672,7 @@
 
     "send": ["send@0.19.0", "", { "dependencies": { "debug": "2.6.9", "depd": "2.0.0", "destroy": "1.2.0", "encodeurl": "~1.0.2", "escape-html": "~1.0.3", "etag": "~1.8.1", "fresh": "0.5.2", "http-errors": "2.0.0", "mime": "1.6.0", "ms": "2.1.3", "on-finished": "2.4.1", "range-parser": "~1.2.1", "statuses": "2.0.1" } }, "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw=="],
 
-    "serialize-javascript": ["serialize-javascript@6.0.2", "", { "dependencies": { "randombytes": "^2.1.0" } }, "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g=="],
+    "serialize-javascript": ["serialize-javascript@7.0.4", "", {}, "sha512-DuGdB+Po43Q5Jxwpzt1lhyFSYKryqoNjQSA9M92tyw0lyHIOur+XCalOUe0KTJpyqzT8+fQ5A0Jf7vCx/NKmIg=="],
 
     "serve": ["serve@14.2.5", "", { "dependencies": { "@zeit/schemas": "2.36.0", "ajv": "8.12.0", "arg": "5.0.2", "boxen": "7.0.0", "chalk": "5.0.1", "chalk-template": "0.4.0", "clipboardy": "3.0.0", "compression": "1.8.1", "is-port-reachable": "4.0.0", "serve-handler": "6.1.6", "update-check": "1.5.4" }, "bin": { "serve": "build/main.js" } }, "sha512-Qn/qMkzCcMFVPb60E/hQy+iRLpiU8PamOfOSYoAHmmF+fFFmpPpqa6Oci2iWYpTdOUM3VF+TINud7CfbQnsZbA=="],
 
@@ -6067,8 +6068,6 @@
 
     "oidc-client/acorn": ["acorn@7.4.1", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="],
 
-    "oidc-client/serialize-javascript": ["serialize-javascript@4.0.0", "", { "dependencies": { "randombytes": "^2.1.0" } }, "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw=="],
-
     "ora/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "ora/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
@@ -6148,8 +6147,6 @@
     "restore-cursor/onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
 
     "rollup-plugin-terser/jest-worker": ["jest-worker@26.6.2", "", { "dependencies": { "@types/node": "*", "merge-stream": "^2.0.0", "supports-color": "^7.0.0" } }, "sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ=="],
-
-    "rollup-plugin-terser/serialize-javascript": ["serialize-javascript@4.0.0", "", { "dependencies": { "randombytes": "^2.1.0" } }, "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw=="],
 
     "schema-utils/ajv": ["ajv@8.12.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2", "uri-js": "^4.2.2" } }, "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA=="],
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "install:update-lockfile": "yarn install && bun install --config=./bunfig.update-lockfile.toml",
     "install:yarn:frozen-lockfile": "echo Deprecated - use install:frozen && yarn install --frozen-lockfile",
     "install:frozen": "yarn install --frozen-lockfile",
-    "audit": "bun audit --ignore=GHSA-3ppc-4f35-3m26",
+    "audit": "bun audit --ignore=GHSA-3ppc-4f35-3m26 --ignore=GHSA-7r86-cg39-jmmj --ignore=GHSA-23c5-xmqv-rm74",
     "preinstall": "node preinstall.js",
     "start": "yarn run dev",
     "test": "yarn run test:unit",
@@ -157,7 +157,8 @@
     "lodash-es": "4.17.23",
     "diff": "5.2.2",
     "webpack": "5.105.0",
-    "tar": "7.5.9"
+    "tar": "7.5.9",
+    "serialize-javascript": "7.0.4"
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/platform/docs/package.json
+++ b/platform/docs/package.json
@@ -100,6 +100,8 @@
     "qs": "6.14.1",
     "lodash": "4.17.23",
     "webpack": "5.105.0",
-    "sharp": "0.34.5"
+    "sharp": "0.34.5",
+    "serialize-javascript": "7.0.4",
+    "rollup": "2.80.0"
   }
 }

--- a/platform/docs/yarn.lock
+++ b/platform/docs/yarn.lock
@@ -10255,13 +10255,6 @@ quick-lru@^5.1.1:
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-5.1.1.tgz#366493e6b3e42a3a6885e2e99d18f80fb7a8c932"
   integrity sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==
 
-randombytes@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
-  integrity sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==
-  dependencies:
-    safe-buffer "^5.1.0"
-
 range-parser@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
@@ -10895,10 +10888,10 @@ rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
-rollup@^2.43.1:
-  version "2.79.2"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.79.2.tgz#f150e4a5db4b121a21a747d762f701e5e9f49090"
-  integrity sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==
+rollup@2.80.0, rollup@^2.43.1:
+  version "2.80.0"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.80.0.tgz#a82efc15b748e986a7c76f0f771221b1fa108a2c"
+  integrity sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==
   optionalDependencies:
     fsevents "~2.3.2"
 
@@ -10930,7 +10923,7 @@ safe-array-concat@^1.1.3:
     has-symbols "^1.1.0"
     isarray "^2.0.5"
 
-safe-buffer@5.2.1, safe-buffer@>=5.1.0, safe-buffer@^5.1.0, safe-buffer@~5.2.0:
+safe-buffer@5.2.1, safe-buffer@>=5.1.0, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -11074,12 +11067,10 @@ send@0.19.0:
     range-parser "~1.2.1"
     statuses "2.0.1"
 
-serialize-javascript@^6.0.0, serialize-javascript@^6.0.1, serialize-javascript@^6.0.2:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.2.tgz#defa1e055c83bf6d59ea805d8da862254eb6a6c2"
-  integrity sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==
-  dependencies:
-    randombytes "^2.1.0"
+serialize-javascript@7.0.4, serialize-javascript@^6.0.0, serialize-javascript@^6.0.1, serialize-javascript@^6.0.2:
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-7.0.4.tgz#c517735bd5b7631dd1fc191ee19cbb713ff8e05c"
+  integrity sha512-DuGdB+Po43Q5Jxwpzt1lhyFSYKryqoNjQSA9M92tyw0lyHIOur+XCalOUe0KTJpyqzT8+fQ5A0Jf7vCx/NKmIg==
 
 serve-handler@^6.1.6:
   version "6.1.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -17491,10 +17491,10 @@ rollup-plugin-terser@^7.0.0:
     serialize-javascript "^4.0.0"
     terser "^5.0.0"
 
-rollup@2.79.2, rollup@^2.43.1:
-  version "2.79.2"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.79.2.tgz#f150e4a5db4b121a21a747d762f701e5e9f49090"
-  integrity sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==
+rollup@2.80.0, rollup@^2.43.1:
+  version "2.80.0"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.80.0.tgz#a82efc15b748e986a7c76f0f771221b1fa108a2c"
+  integrity sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==
   optionalDependencies:
     fsevents "~2.3.2"
 
@@ -17719,19 +17719,10 @@ send@0.19.0:
     range-parser "~1.2.1"
     statuses "2.0.1"
 
-serialize-javascript@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-4.0.0.tgz#b525e1238489a5ecfc42afacc3fe99e666f4b1aa"
-  integrity sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==
-  dependencies:
-    randombytes "^2.1.0"
-
-serialize-javascript@^6.0.0, serialize-javascript@^6.0.2:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.2.tgz#defa1e055c83bf6d59ea805d8da862254eb6a6c2"
-  integrity sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==
-  dependencies:
-    randombytes "^2.1.0"
+serialize-javascript@7.0.4, serialize-javascript@^4.0.0, serialize-javascript@^6.0.0, serialize-javascript@^6.0.2:
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-7.0.4.tgz#c517735bd5b7631dd1fc191ee19cbb713ff8e05c"
+  integrity sha512-DuGdB+Po43Q5Jxwpzt1lhyFSYKryqoNjQSA9M92tyw0lyHIOur+XCalOUe0KTJpyqzT8+fQ5A0Jf7vCx/NKmIg==
 
 serve-handler@6.1.6:
   version "6.1.6"


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context
Fix rollup (GHSA-mw96-cpmx-2vgc) and serialize-javascript (GHSA-5c6j-r48x-rmvq) vulnerabilities.

See:

- https://github.com/advisories/GHSA-mw96-cpmx-2vgc

- https://github.com/advisories/GHSA-5c6j-r48x-rmvq

Also there some minimatch vulnerabilities that can just be ignored…

- https://github.com/advisories/GHSA-7r86-cg39-jmmj

- https://github.com/advisories/GHSA-23c5-xmqv-rm74

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results
Ignored the minimatch vulnerabilities as they are constrained to dev environments where no user expression is ever passed to minimatch.
Bumped some package versions for rollup and serialize-javascript.
<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing
Run the PR checks.

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR addresses two known security vulnerabilities in the `release/3.12` branch by bumping `rollup` from `2.79.2` to `2.80.0` (GHSA-mw96-cpmx-2vgc) and `serialize-javascript` from `6.0.2` to `7.0.4` (GHSA-5c6j-r48x-rmvq), and separately adds three minimatch CVEs to the audit ignore lists because those code paths are strictly confined to build/CI environments where no user-supplied expressions are passed to minimatch.

Key changes:
- `rollup` and `serialize-javascript` version pins added to the `resolutions` field in the root `package.json` and mirrored in `platform/docs/package.json`, ensuring the patched versions are used across all yarn workspaces and the bun lockfile.
- `yarn.lock` and `bun.lock` updated consistently: all `serialize-javascript` version ranges (`^4.0.0`, `^6.0.0`, `^6.0.1`, `^6.0.2`) are now resolved to `7.0.4`, and the nested per-package lockfile entries for `oidc-client` and `rollup-plugin-terser` are removed since they now rely on the top-level resolution.
- The `randombytes` transitive dependency (previously required by `serialize-javascript`) is removed; `v7` uses the native `crypto.getRandomValues` API, which is safe given the repository's `node >= 18` engine requirement.
- `.circleci/config.yml` and the `package.json` `audit` script are updated to ignore the same three minimatch CVEs consistently.
- The previously-ignored `GHSA-5j98-mcp5-4vw2` in the `package.json` audit script is removed without explicit documentation; it should be confirmed this is intentionally fixed by the upgrades rather than accidentally dropped.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — changes are limited to dependency version bumps and audit-ignore list housekeeping with no application logic touched.
- Both lock files (yarn and bun) are updated consistently, the serialize-javascript v7 API is backward compatible with v4/v6 for the packages that consume it, and the Node.js engine constraint (>=18) satisfies v7's native crypto requirement. The one open question is whether `GHSA-5j98-mcp5-4vw2` was intentionally removed from the audit ignore list because it is now fixed, or whether it was accidentally dropped; if the latter, local `bun audit` runs will start failing but CI is unaffected (it uses the circleci config ignore list).
- package.json — the removal of the `GHSA-5j98-mcp5-4vw2` audit ignore should be verified as intentional.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .circleci/config.yml | Added two new minimatch CVEs (GHSA-7r86-cg39-jmmj, GHSA-23c5-xmqv-rm74) to the CI ignored vulnerabilities list with appropriate justification comments, matching the updated ignore list in package.json |
| package.json | Bumped rollup to 2.80.0, added serialize-javascript 7.0.4 to resolutions, and updated the audit ignore list from a single old CVE (GHSA-5j98-mcp5-4vw2) to the three current minimatch CVEs; the old ignore ID is intentionally removed as its underlying vulnerability (serialize-javascript) is now fixed |
| bun.lock | Bumped rollup 2.79.2→2.80.0 and serialize-javascript 6.0.2→7.0.4; removed nested per-package serialize-javascript entries (oidc-client, rollup-plugin-terser) in favour of the single top-level resolution; randombytes dependency dropped as v7 uses native crypto |
| yarn.lock | Consolidated two separate serialize-javascript entries (^4.0.0 at 4.0.0 and ^6.x at 6.0.2) into a single entry resolving all ranges to 7.0.4 via yarn resolutions; rollup entry updated to 2.80.0 |
| platform/docs/package.json | Added serialize-javascript 7.0.4 and rollup 2.80.0 as explicit overrides so the docs workspace also gets the patched versions |
| platform/docs/yarn.lock | Updated rollup to 2.80.0, collapsed all serialize-javascript version ranges (^6.0.0/^6.0.1/^6.0.2) to 7.0.4, and removed the now-unused randombytes dependency entry |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Security Audit detects vulnerabilities] --> B{Vulnerability type}
    B -->|rollup GHSA-mw96-cpmx-2vgc| C[Bump rollup 2.79.2 → 2.80.0]
    B -->|serialize-javascript GHSA-5c6j-r48x-rmvq| D[Bump serialize-javascript 6.0.2 → 7.0.4]
    B -->|minimatch GHSA-3ppc-4f35-3m26\nGHSA-7r86-cg39-jmmj\nGHSA-23c5-xmqv-rm74| E[Add to ignore list - build/CI only, no user input]

    C --> F[Update resolutions in package.json]
    D --> F
    F --> G[Update yarn.lock - root]
    F --> H[Update bun.lock]
    F --> I[Update platform/docs/package.json\n+ platform/docs/yarn.lock]

    G --> J[All serialize-javascript ranges\n^4.0.0 / ^6.0.x → 7.0.4\nrandombytes dep removed]
    H --> K[Top-level serialize-javascript 7.0.4\nnested oidc-client + rollup-plugin-terser\nentries removed]

    E --> L[Update .circleci/config.yml IGNORED_VULNS]
    E --> M[Update package.json audit script ignores]
```

<sub>Last reviewed commit: 77eb5ad</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->