### PR TITLE
fix(security): Bump svgo and tar to fix vulnerabilities.

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -50,7 +50,7 @@
     },
     "addOns/externals/devDependencies": {
       "name": "@externals/devDependencies",
-      "version": "3.13.0-beta.27",
+      "version": "3.13.0-beta.32",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "@kitware/vtk.js": "34.15.1",
@@ -131,14 +131,14 @@
     },
     "addOns/externals/dicom-microscopy-viewer": {
       "name": "@externals/dicom-microscopy-viewer",
-      "version": "3.13.0-beta.27",
+      "version": "3.13.0-beta.32",
       "dependencies": {
         "dicom-microscopy-viewer": "0.48.17",
       },
     },
     "extensions/cornerstone": {
       "name": "@ohif/extension-cornerstone",
-      "version": "3.13.0-beta.27",
+      "version": "3.13.0-beta.32",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "@cornerstonejs/adapters": "4.18.2",
@@ -165,8 +165,8 @@
         "@cornerstonejs/codec-openjpeg": "1.3.0",
         "@cornerstonejs/codec-openjph": "2.4.7",
         "@cornerstonejs/dicom-image-loader": "4.18.2",
-        "@ohif/core": "3.13.0-beta.27",
-        "@ohif/ui": "3.13.0-beta.27",
+        "@ohif/core": "3.13.0-beta.32",
+        "@ohif/ui": "3.13.0-beta.32",
         "dcmjs": "0.49.4",
         "dicom-parser": "1.8.21",
         "hammerjs": "2.0.8",
@@ -178,7 +178,7 @@
     },
     "extensions/cornerstone-dicom-pmap": {
       "name": "@ohif/extension-cornerstone-dicom-pmap",
-      "version": "3.13.0-beta.27",
+      "version": "3.13.0-beta.32",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "@cornerstonejs/adapters": "4.18.2",
@@ -186,10 +186,10 @@
         "@kitware/vtk.js": "34.15.1",
       },
       "peerDependencies": {
-        "@ohif/core": "3.13.0-beta.27",
-        "@ohif/extension-cornerstone": "3.13.0-beta.27",
-        "@ohif/extension-default": "3.13.0-beta.27",
-        "@ohif/i18n": "3.13.0-beta.27",
+        "@ohif/core": "3.13.0-beta.32",
+        "@ohif/extension-cornerstone": "3.13.0-beta.32",
+        "@ohif/extension-default": "3.13.0-beta.32",
+        "@ohif/i18n": "3.13.0-beta.32",
         "prop-types": "15.8.1",
         "react": "18.3.1",
         "react-dom": "18.3.1",
@@ -200,15 +200,15 @@
     },
     "extensions/cornerstone-dicom-rt": {
       "name": "@ohif/extension-cornerstone-dicom-rt",
-      "version": "3.13.0-beta.27",
+      "version": "3.13.0-beta.32",
       "dependencies": {
         "@babel/runtime": "7.28.2",
       },
       "peerDependencies": {
-        "@ohif/core": "3.13.0-beta.27",
-        "@ohif/extension-cornerstone": "3.13.0-beta.27",
-        "@ohif/extension-default": "3.13.0-beta.27",
-        "@ohif/i18n": "3.13.0-beta.27",
+        "@ohif/core": "3.13.0-beta.32",
+        "@ohif/extension-cornerstone": "3.13.0-beta.32",
+        "@ohif/extension-default": "3.13.0-beta.32",
+        "@ohif/i18n": "3.13.0-beta.32",
         "prop-types": "15.8.1",
         "react": "18.3.1",
         "react-dom": "18.3.1",
@@ -219,7 +219,7 @@
     },
     "extensions/cornerstone-dicom-seg": {
       "name": "@ohif/extension-cornerstone-dicom-seg",
-      "version": "3.13.0-beta.27",
+      "version": "3.13.0-beta.32",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "@cornerstonejs/adapters": "4.18.2",
@@ -227,10 +227,10 @@
         "@kitware/vtk.js": "34.15.1",
       },
       "peerDependencies": {
-        "@ohif/core": "3.13.0-beta.27",
-        "@ohif/extension-cornerstone": "3.13.0-beta.27",
-        "@ohif/extension-default": "3.13.0-beta.27",
-        "@ohif/i18n": "3.13.0-beta.27",
+        "@ohif/core": "3.13.0-beta.32",
+        "@ohif/extension-cornerstone": "3.13.0-beta.32",
+        "@ohif/extension-default": "3.13.0-beta.32",
+        "@ohif/i18n": "3.13.0-beta.32",
         "prop-types": "15.8.1",
         "react": "18.3.1",
         "react-dom": "18.3.1",
@@ -241,7 +241,7 @@
     },
     "extensions/cornerstone-dicom-sr": {
       "name": "@ohif/extension-cornerstone-dicom-sr",
-      "version": "3.13.0-beta.27",
+      "version": "3.13.0-beta.32",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "@cornerstonejs/adapters": "4.18.2",
@@ -250,10 +250,10 @@
         "classnames": "2.5.1",
       },
       "peerDependencies": {
-        "@ohif/core": "3.13.0-beta.27",
-        "@ohif/extension-cornerstone": "3.13.0-beta.27",
-        "@ohif/extension-measurement-tracking": "3.13.0-beta.27",
-        "@ohif/ui": "3.13.0-beta.27",
+        "@ohif/core": "3.13.0-beta.32",
+        "@ohif/extension-cornerstone": "3.13.0-beta.32",
+        "@ohif/extension-measurement-tracking": "3.13.0-beta.32",
+        "@ohif/ui": "3.13.0-beta.32",
         "dcmjs": "0.49.4",
         "dicom-parser": "1.8.21",
         "hammerjs": "2.0.8",
@@ -263,7 +263,7 @@
     },
     "extensions/cornerstone-dynamic-volume": {
       "name": "@ohif/extension-cornerstone-dynamic-volume",
-      "version": "3.13.0-beta.27",
+      "version": "3.13.0-beta.32",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "@cornerstonejs/core": "4.18.2",
@@ -271,11 +271,11 @@
         "classnames": "2.5.1",
       },
       "peerDependencies": {
-        "@ohif/core": "3.13.0-beta.27",
-        "@ohif/extension-cornerstone": "3.13.0-beta.27",
-        "@ohif/extension-default": "3.13.0-beta.27",
-        "@ohif/i18n": "3.13.0-beta.27",
-        "@ohif/ui": "3.13.0-beta.27",
+        "@ohif/core": "3.13.0-beta.32",
+        "@ohif/extension-cornerstone": "3.13.0-beta.32",
+        "@ohif/extension-default": "3.13.0-beta.32",
+        "@ohif/i18n": "3.13.0-beta.32",
+        "@ohif/ui": "3.13.0-beta.32",
         "dcmjs": "0.49.4",
         "dicom-parser": "1.8.21",
         "hammerjs": "2.0.8",
@@ -285,7 +285,7 @@
     },
     "extensions/default": {
       "name": "@ohif/extension-default",
-      "version": "3.13.0-beta.27",
+      "version": "3.13.0-beta.32",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "@cornerstonejs/calculate-suv": "1.1.0",
@@ -294,8 +294,8 @@
         "react-color": "2.19.3",
       },
       "peerDependencies": {
-        "@ohif/core": "3.13.0-beta.27",
-        "@ohif/i18n": "3.13.0-beta.27",
+        "@ohif/core": "3.13.0-beta.32",
+        "@ohif/i18n": "3.13.0-beta.32",
         "dcmjs": "0.49.4",
         "dicomweb-client": "0.10.4",
         "prop-types": "15.8.1",
@@ -309,7 +309,7 @@
     },
     "extensions/dicom-microscopy": {
       "name": "@ohif/extension-dicom-microscopy",
-      "version": "3.13.0-beta.27",
+      "version": "3.13.0-beta.32",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "@cornerstonejs/codec-charls": "1.2.3",
@@ -320,10 +320,10 @@
         "mathjs": "12.4.3",
       },
       "peerDependencies": {
-        "@ohif/core": "3.13.0-beta.27",
-        "@ohif/extension-default": "3.13.0-beta.27",
-        "@ohif/i18n": "3.13.0-beta.27",
-        "@ohif/ui": "3.13.0-beta.27",
+        "@ohif/core": "3.13.0-beta.32",
+        "@ohif/extension-default": "3.13.0-beta.32",
+        "@ohif/i18n": "3.13.0-beta.32",
+        "@ohif/ui": "3.13.0-beta.32",
         "prop-types": "15.8.1",
         "react": "18.3.1",
         "react-dom": "18.3.1",
@@ -334,14 +334,14 @@
     },
     "extensions/dicom-pdf": {
       "name": "@ohif/extension-dicom-pdf",
-      "version": "3.13.0-beta.27",
+      "version": "3.13.0-beta.32",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "classnames": "2.5.1",
       },
       "peerDependencies": {
-        "@ohif/core": "3.13.0-beta.27",
-        "@ohif/ui": "3.13.0-beta.27",
+        "@ohif/core": "3.13.0-beta.32",
+        "@ohif/ui": "3.13.0-beta.32",
         "dcmjs": "0.49.4",
         "dicom-parser": "1.8.21",
         "hammerjs": "2.0.8",
@@ -351,14 +351,14 @@
     },
     "extensions/dicom-video": {
       "name": "@ohif/extension-dicom-video",
-      "version": "3.13.0-beta.27",
+      "version": "3.13.0-beta.32",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "classnames": "2.5.1",
       },
       "peerDependencies": {
-        "@ohif/core": "3.13.0-beta.27",
-        "@ohif/ui": "3.13.0-beta.27",
+        "@ohif/core": "3.13.0-beta.32",
+        "@ohif/ui": "3.13.0-beta.32",
         "dcmjs": "0.49.4",
         "dicom-parser": "1.8.21",
         "hammerjs": "2.0.8",
@@ -368,20 +368,20 @@
     },
     "extensions/measurement-tracking": {
       "name": "@ohif/extension-measurement-tracking",
-      "version": "3.13.0-beta.27",
+      "version": "3.13.0-beta.32",
       "dependencies": {
         "@babel/runtime": "7.28.2",
-        "@ohif/ui": "3.13.0-beta.27",
+        "@ohif/ui": "3.13.0-beta.32",
         "@xstate/react": "3.2.2",
         "xstate": "4.38.3",
       },
       "peerDependencies": {
         "@cornerstonejs/core": "4.18.2",
         "@cornerstonejs/tools": "4.18.2",
-        "@ohif/core": "3.13.0-beta.27",
-        "@ohif/extension-cornerstone-dicom-sr": "3.13.0-beta.27",
-        "@ohif/extension-default": "3.13.0-beta.27",
-        "@ohif/ui": "3.13.0-beta.27",
+        "@ohif/core": "3.13.0-beta.32",
+        "@ohif/extension-cornerstone-dicom-sr": "3.13.0-beta.32",
+        "@ohif/extension-default": "3.13.0-beta.32",
+        "@ohif/ui": "3.13.0-beta.32",
         "classnames": "2.5.1",
         "dcmjs": "0.49.4",
         "lodash.debounce": "4.0.8",
@@ -394,14 +394,14 @@
     },
     "extensions/test-extension": {
       "name": "@ohif/extension-test",
-      "version": "3.13.0-beta.27",
+      "version": "3.13.0-beta.32",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "classnames": "2.5.1",
       },
       "peerDependencies": {
-        "@ohif/core": "3.13.0-beta.27",
-        "@ohif/ui": "3.13.0-beta.27",
+        "@ohif/core": "3.13.0-beta.32",
+        "@ohif/ui": "3.13.0-beta.32",
         "dcmjs": "0.49.4",
         "dicom-parser": "1.8.21",
         "hammerjs": "2.0.8",
@@ -411,14 +411,14 @@
     },
     "extensions/tmtv": {
       "name": "@ohif/extension-tmtv",
-      "version": "3.13.0-beta.27",
+      "version": "3.13.0-beta.32",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "classnames": "2.5.1",
       },
       "peerDependencies": {
-        "@ohif/core": "3.13.0-beta.27",
-        "@ohif/ui": "3.13.0-beta.27",
+        "@ohif/core": "3.13.0-beta.32",
+        "@ohif/ui": "3.13.0-beta.32",
         "dcmjs": "0.49.4",
         "dicom-parser": "1.8.21",
         "hammerjs": "2.0.8",
@@ -428,16 +428,16 @@
     },
     "extensions/usAnnotation": {
       "name": "@ohif/extension-ultrasound-pleura-bline",
-      "version": "3.13.0-beta.27",
+      "version": "3.13.0-beta.32",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "@cornerstonejs/core": "4.18.2",
         "@cornerstonejs/tools": "4.18.2",
-        "@ohif/core": "3.13.0-beta.27",
-        "@ohif/extension-cornerstone": "3.13.0-beta.27",
-        "@ohif/extension-default": "3.13.0-beta.27",
-        "@ohif/i18n": "3.13.0-beta.27",
-        "@ohif/ui-next": "3.13.0-beta.27",
+        "@ohif/core": "3.13.0-beta.32",
+        "@ohif/extension-cornerstone": "3.13.0-beta.32",
+        "@ohif/extension-default": "3.13.0-beta.32",
+        "@ohif/i18n": "3.13.0-beta.32",
+        "@ohif/ui-next": "3.13.0-beta.32",
       },
       "devDependencies": {
         "@babel/core": "7.28.0",
@@ -476,7 +476,7 @@
     },
     "modes/basic": {
       "name": "@ohif/mode-basic",
-      "version": "3.13.0-beta.27",
+      "version": "3.13.0-beta.32",
       "dependencies": {
         "@babel/runtime": "7.28.2",
       },
@@ -485,19 +485,19 @@
         "webpack-merge": "5.10.0",
       },
       "peerDependencies": {
-        "@ohif/core": "3.13.0-beta.27",
-        "@ohif/extension-cornerstone": "3.13.0-beta.27",
-        "@ohif/extension-cornerstone-dicom-rt": "3.13.0-beta.27",
-        "@ohif/extension-cornerstone-dicom-seg": "3.13.0-beta.27",
-        "@ohif/extension-cornerstone-dicom-sr": "3.13.0-beta.27",
-        "@ohif/extension-default": "3.13.0-beta.27",
-        "@ohif/extension-dicom-pdf": "3.13.0-beta.27",
-        "@ohif/extension-dicom-video": "3.13.0-beta.27",
+        "@ohif/core": "3.13.0-beta.32",
+        "@ohif/extension-cornerstone": "3.13.0-beta.32",
+        "@ohif/extension-cornerstone-dicom-rt": "3.13.0-beta.32",
+        "@ohif/extension-cornerstone-dicom-seg": "3.13.0-beta.32",
+        "@ohif/extension-cornerstone-dicom-sr": "3.13.0-beta.32",
+        "@ohif/extension-default": "3.13.0-beta.32",
+        "@ohif/extension-dicom-pdf": "3.13.0-beta.32",
+        "@ohif/extension-dicom-video": "3.13.0-beta.32",
       },
     },
     "modes/basic-dev-mode": {
       "name": "@ohif/mode-basic-dev-mode",
-      "version": "3.13.0-beta.27",
+      "version": "3.13.0-beta.32",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "i18next": "17.3.1",
@@ -507,17 +507,17 @@
         "webpack-merge": "5.10.0",
       },
       "peerDependencies": {
-        "@ohif/core": "3.13.0-beta.27",
-        "@ohif/extension-cornerstone": "3.13.0-beta.27",
-        "@ohif/extension-cornerstone-dicom-sr": "3.13.0-beta.27",
-        "@ohif/extension-default": "3.13.0-beta.27",
-        "@ohif/extension-dicom-pdf": "3.13.0-beta.27",
-        "@ohif/extension-dicom-video": "3.13.0-beta.27",
+        "@ohif/core": "3.13.0-beta.32",
+        "@ohif/extension-cornerstone": "3.13.0-beta.32",
+        "@ohif/extension-cornerstone-dicom-sr": "3.13.0-beta.32",
+        "@ohif/extension-default": "3.13.0-beta.32",
+        "@ohif/extension-dicom-pdf": "3.13.0-beta.32",
+        "@ohif/extension-dicom-video": "3.13.0-beta.32",
       },
     },
     "modes/basic-test-mode": {
       "name": "@ohif/mode-test",
-      "version": "3.13.0-beta.27",
+      "version": "3.13.0-beta.32",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "i18next": "17.3.1",
@@ -527,19 +527,19 @@
         "webpack-merge": "5.10.0",
       },
       "peerDependencies": {
-        "@ohif/core": "3.13.0-beta.27",
-        "@ohif/extension-cornerstone": "3.13.0-beta.27",
-        "@ohif/extension-cornerstone-dicom-sr": "3.13.0-beta.27",
-        "@ohif/extension-default": "3.13.0-beta.27",
-        "@ohif/extension-dicom-pdf": "3.13.0-beta.27",
-        "@ohif/extension-dicom-video": "3.13.0-beta.27",
-        "@ohif/extension-measurement-tracking": "3.13.0-beta.27",
-        "@ohif/extension-test": "3.13.0-beta.27",
+        "@ohif/core": "3.13.0-beta.32",
+        "@ohif/extension-cornerstone": "3.13.0-beta.32",
+        "@ohif/extension-cornerstone-dicom-sr": "3.13.0-beta.32",
+        "@ohif/extension-default": "3.13.0-beta.32",
+        "@ohif/extension-dicom-pdf": "3.13.0-beta.32",
+        "@ohif/extension-dicom-video": "3.13.0-beta.32",
+        "@ohif/extension-measurement-tracking": "3.13.0-beta.32",
+        "@ohif/extension-test": "3.13.0-beta.32",
       },
     },
     "modes/longitudinal": {
       "name": "@ohif/mode-longitudinal",
-      "version": "3.13.0-beta.27",
+      "version": "3.13.0-beta.32",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "i18next": "17.3.1",
@@ -549,33 +549,33 @@
         "webpack-merge": "5.10.0",
       },
       "peerDependencies": {
-        "@ohif/core": "3.13.0-beta.27",
-        "@ohif/extension-cornerstone": "3.13.0-beta.27",
-        "@ohif/extension-cornerstone-dicom-rt": "3.13.0-beta.27",
-        "@ohif/extension-cornerstone-dicom-seg": "3.13.0-beta.27",
-        "@ohif/extension-cornerstone-dicom-sr": "3.13.0-beta.27",
-        "@ohif/extension-default": "3.13.0-beta.27",
-        "@ohif/extension-dicom-pdf": "3.13.0-beta.27",
-        "@ohif/extension-dicom-video": "3.13.0-beta.27",
-        "@ohif/extension-measurement-tracking": "3.13.0-beta.27",
-        "@ohif/mode-basic": "3.13.0-beta.27",
+        "@ohif/core": "3.13.0-beta.32",
+        "@ohif/extension-cornerstone": "3.13.0-beta.32",
+        "@ohif/extension-cornerstone-dicom-rt": "3.13.0-beta.32",
+        "@ohif/extension-cornerstone-dicom-seg": "3.13.0-beta.32",
+        "@ohif/extension-cornerstone-dicom-sr": "3.13.0-beta.32",
+        "@ohif/extension-default": "3.13.0-beta.32",
+        "@ohif/extension-dicom-pdf": "3.13.0-beta.32",
+        "@ohif/extension-dicom-video": "3.13.0-beta.32",
+        "@ohif/extension-measurement-tracking": "3.13.0-beta.32",
+        "@ohif/mode-basic": "3.13.0-beta.32",
       },
     },
     "modes/microscopy": {
       "name": "@ohif/mode-microscopy",
-      "version": "3.13.0-beta.27",
+      "version": "3.13.0-beta.32",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "i18next": "17.3.1",
       },
       "peerDependencies": {
-        "@ohif/core": "3.13.0-beta.27",
-        "@ohif/extension-dicom-microscopy": "3.13.0-beta.27",
+        "@ohif/core": "3.13.0-beta.32",
+        "@ohif/extension-dicom-microscopy": "3.13.0-beta.32",
       },
     },
     "modes/preclinical-4d": {
       "name": "@ohif/mode-preclinical-4d",
-      "version": "3.13.0-beta.27",
+      "version": "3.13.0-beta.32",
       "dependencies": {
         "@babel/runtime": "7.28.2",
       },
@@ -584,17 +584,17 @@
         "webpack-merge": "5.10.0",
       },
       "peerDependencies": {
-        "@ohif/core": "3.13.0-beta.27",
-        "@ohif/extension-cornerstone": "3.13.0-beta.27",
-        "@ohif/extension-cornerstone-dicom-seg": "3.13.0-beta.27",
-        "@ohif/extension-cornerstone-dynamic-volume": "3.13.0-beta.27",
-        "@ohif/extension-default": "3.13.0-beta.27",
-        "@ohif/extension-tmtv": "3.13.0-beta.27",
+        "@ohif/core": "3.13.0-beta.32",
+        "@ohif/extension-cornerstone": "3.13.0-beta.32",
+        "@ohif/extension-cornerstone-dicom-seg": "3.13.0-beta.32",
+        "@ohif/extension-cornerstone-dynamic-volume": "3.13.0-beta.32",
+        "@ohif/extension-default": "3.13.0-beta.32",
+        "@ohif/extension-tmtv": "3.13.0-beta.32",
       },
     },
     "modes/segmentation": {
       "name": "@ohif/mode-segmentation",
-      "version": "3.13.0-beta.27",
+      "version": "3.13.0-beta.32",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "i18next": "17.3.1",
@@ -623,20 +623,20 @@
         "webpack-merge": "5.10.0",
       },
       "peerDependencies": {
-        "@ohif/core": "3.13.0-beta.27",
-        "@ohif/extension-cornerstone": "3.13.0-beta.27",
-        "@ohif/extension-cornerstone-dicom-rt": "3.13.0-beta.27",
-        "@ohif/extension-cornerstone-dicom-seg": "3.13.0-beta.27",
-        "@ohif/extension-cornerstone-dicom-sr": "3.13.0-beta.27",
-        "@ohif/extension-default": "3.13.0-beta.27",
-        "@ohif/extension-dicom-pdf": "3.13.0-beta.27",
-        "@ohif/extension-dicom-video": "3.13.0-beta.27",
-        "@ohif/mode-basic": "3.13.0-beta.27",
+        "@ohif/core": "3.13.0-beta.32",
+        "@ohif/extension-cornerstone": "3.13.0-beta.32",
+        "@ohif/extension-cornerstone-dicom-rt": "3.13.0-beta.32",
+        "@ohif/extension-cornerstone-dicom-seg": "3.13.0-beta.32",
+        "@ohif/extension-cornerstone-dicom-sr": "3.13.0-beta.32",
+        "@ohif/extension-default": "3.13.0-beta.32",
+        "@ohif/extension-dicom-pdf": "3.13.0-beta.32",
+        "@ohif/extension-dicom-video": "3.13.0-beta.32",
+        "@ohif/mode-basic": "3.13.0-beta.32",
       },
     },
     "modes/tmtv": {
       "name": "@ohif/mode-tmtv",
-      "version": "3.13.0-beta.27",
+      "version": "3.13.0-beta.32",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "i18next": "17.3.1",
@@ -646,25 +646,25 @@
         "webpack-merge": "5.10.0",
       },
       "peerDependencies": {
-        "@ohif/core": "3.13.0-beta.27",
-        "@ohif/extension-cornerstone": "3.13.0-beta.27",
-        "@ohif/extension-cornerstone-dicom-sr": "3.13.0-beta.27",
-        "@ohif/extension-default": "3.13.0-beta.27",
-        "@ohif/extension-dicom-pdf": "3.13.0-beta.27",
-        "@ohif/extension-dicom-video": "3.13.0-beta.27",
-        "@ohif/extension-measurement-tracking": "3.13.0-beta.27",
+        "@ohif/core": "3.13.0-beta.32",
+        "@ohif/extension-cornerstone": "3.13.0-beta.32",
+        "@ohif/extension-cornerstone-dicom-sr": "3.13.0-beta.32",
+        "@ohif/extension-default": "3.13.0-beta.32",
+        "@ohif/extension-dicom-pdf": "3.13.0-beta.32",
+        "@ohif/extension-dicom-video": "3.13.0-beta.32",
+        "@ohif/extension-measurement-tracking": "3.13.0-beta.32",
       },
     },
     "modes/usAnnotation": {
       "name": "@ohif/mode-ultrasound-pleura-bline",
-      "version": "3.13.0-beta.27",
+      "version": "3.13.0-beta.32",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "@cornerstonejs/core": "4.18.2",
         "@cornerstonejs/tools": "4.18.2",
-        "@ohif/core": "3.13.0-beta.27",
-        "@ohif/extension-cornerstone-dicom-sr": "3.13.0-beta.27",
-        "@ohif/extension-ultrasound-pleura-bline": "3.13.0-beta.27",
+        "@ohif/core": "3.13.0-beta.32",
+        "@ohif/extension-cornerstone-dicom-sr": "3.13.0-beta.32",
+        "@ohif/extension-ultrasound-pleura-bline": "3.13.0-beta.32",
         "i18next": "17.3.1",
       },
       "devDependencies": {
@@ -693,7 +693,7 @@
     },
     "platform/app": {
       "name": "@ohif/app",
-      "version": "3.13.0-beta.27",
+      "version": "3.13.0-beta.32",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "@cornerstonejs/codec-charls": "1.2.3",
@@ -702,25 +702,25 @@
         "@cornerstonejs/codec-openjph": "2.4.7",
         "@cornerstonejs/dicom-image-loader": "4.18.2",
         "@emotion/serialize": "1.3.3",
-        "@ohif/core": "3.13.0-beta.27",
-        "@ohif/extension-cornerstone": "3.13.0-beta.27",
-        "@ohif/extension-cornerstone-dicom-rt": "3.13.0-beta.27",
-        "@ohif/extension-cornerstone-dicom-seg": "3.13.0-beta.27",
-        "@ohif/extension-cornerstone-dicom-sr": "3.13.0-beta.27",
-        "@ohif/extension-default": "3.13.0-beta.27",
-        "@ohif/extension-dicom-microscopy": "3.13.0-beta.27",
-        "@ohif/extension-dicom-pdf": "3.13.0-beta.27",
-        "@ohif/extension-dicom-video": "3.13.0-beta.27",
-        "@ohif/extension-test": "3.13.0-beta.27",
-        "@ohif/extension-ultrasound-pleura-bline": "3.13.0-beta.27",
-        "@ohif/i18n": "3.13.0-beta.27",
-        "@ohif/mode-basic-dev-mode": "3.13.0-beta.27",
-        "@ohif/mode-longitudinal": "3.13.0-beta.27",
-        "@ohif/mode-microscopy": "3.13.0-beta.27",
-        "@ohif/mode-test": "3.13.0-beta.27",
-        "@ohif/mode-ultrasound-pleura-bline": "3.13.0-beta.27",
-        "@ohif/ui": "3.13.0-beta.27",
-        "@ohif/ui-next": "3.13.0-beta.27",
+        "@ohif/core": "3.13.0-beta.32",
+        "@ohif/extension-cornerstone": "3.13.0-beta.32",
+        "@ohif/extension-cornerstone-dicom-rt": "3.13.0-beta.32",
+        "@ohif/extension-cornerstone-dicom-seg": "3.13.0-beta.32",
+        "@ohif/extension-cornerstone-dicom-sr": "3.13.0-beta.32",
+        "@ohif/extension-default": "3.13.0-beta.32",
+        "@ohif/extension-dicom-microscopy": "3.13.0-beta.32",
+        "@ohif/extension-dicom-pdf": "3.13.0-beta.32",
+        "@ohif/extension-dicom-video": "3.13.0-beta.32",
+        "@ohif/extension-test": "3.13.0-beta.32",
+        "@ohif/extension-ultrasound-pleura-bline": "3.13.0-beta.32",
+        "@ohif/i18n": "3.13.0-beta.32",
+        "@ohif/mode-basic-dev-mode": "3.13.0-beta.32",
+        "@ohif/mode-longitudinal": "3.13.0-beta.32",
+        "@ohif/mode-microscopy": "3.13.0-beta.32",
+        "@ohif/mode-test": "3.13.0-beta.32",
+        "@ohif/mode-ultrasound-pleura-bline": "3.13.0-beta.32",
+        "@ohif/ui": "3.13.0-beta.32",
+        "@ohif/ui-next": "3.13.0-beta.32",
         "@svgr/webpack": "8.1.0",
         "@types/react": "18.3.23",
         "classnames": "2.5.1",
@@ -772,7 +772,7 @@
     },
     "platform/cli": {
       "name": "@ohif/cli",
-      "version": "3.13.0-beta.27",
+      "version": "3.13.0-beta.32",
       "bin": {
         "ohif-cli": "src/index.js",
       },
@@ -796,7 +796,7 @@
     },
     "platform/core": {
       "name": "@ohif/core",
-      "version": "3.13.0-beta.27",
+      "version": "3.13.0-beta.32",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "dcmjs": "0.49.4",
@@ -823,14 +823,14 @@
         "@cornerstonejs/codec-openjph": "2.4.7",
         "@cornerstonejs/core": "4.18.2",
         "@cornerstonejs/dicom-image-loader": "4.18.2",
-        "@ohif/ui": "3.13.0-beta.27",
+        "@ohif/ui": "3.13.0-beta.32",
         "cornerstone-math": "0.1.9",
         "dicom-parser": "1.8.21",
       },
     },
     "platform/i18n": {
       "name": "@ohif/i18n",
-      "version": "3.13.0-beta.27",
+      "version": "3.13.0-beta.32",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "i18next-locize-backend": "2.2.2",
@@ -855,7 +855,7 @@
     },
     "platform/ui": {
       "name": "@ohif/ui",
-      "version": "3.13.0-beta.27",
+      "version": "3.13.0-beta.32",
       "dependencies": {
         "@testing-library/react": "13.4.0",
         "browser-detect": "0.2.28",
@@ -905,7 +905,7 @@
     },
     "platform/ui-next": {
       "name": "@ohif/ui-next",
-      "version": "3.13.0-beta.27",
+      "version": "3.13.0-beta.32",
       "dependencies": {
         "@radix-ui/react-accordion": "1.2.11",
         "@radix-ui/react-checkbox": "1.3.2",
@@ -969,8 +969,9 @@
     "qs": "6.14.1",
     "rollup": "2.80.0",
     "serialize-javascript": "7.0.4",
+    "svgo": "3.3.3",
     "tapable": "2.2.2",
-    "tar": "7.5.9",
+    "tar": "7.5.10",
     "trim": "1.0.1",
     "trim-newlines": "5.0.0",
     "webpack": "5.105.0",
@@ -1943,8 +1944,6 @@
     "@thewtex/zstddec": ["@thewtex/zstddec@0.2.1", "", {}, "sha512-1yTu7m/qU1nsJy4mCZAB3GAhczsClhw+WIXK0oe598eHcvefH16WLOYN4Uko7K2/Ttz9KEBvvT7WFrZD41ShgA=="],
 
     "@tootallnate/once": ["@tootallnate/once@2.0.0", "", {}, "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A=="],
-
-    "@trysound/sax": ["@trysound/sax@0.2.0", "", {}, "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA=="],
 
     "@tsconfig/node10": ["@tsconfig/node10@1.0.11", "", {}, "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw=="],
 
@@ -4652,6 +4651,8 @@
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
+    "sax": ["sax@1.5.0", "", {}, "sha512-21IYA3Q5cQf089Z6tgaUTr7lDAyzoTPx5HRtbhsME8Udispad8dC/+sziTNugOEx54ilvatQ9YCzl4KQLPcRHA=="],
+
     "saxes": ["saxes@6.0.0", "", { "dependencies": { "xmlchars": "^2.2.0" } }, "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA=="],
 
     "scheduler": ["scheduler@0.23.2", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ=="],
@@ -4790,8 +4791,6 @@
 
     "ssri": ["ssri@12.0.0", "", { "dependencies": { "minipass": "^7.0.3" } }, "sha512-S7iGNosepx9RadX82oimUkvr0Ct7IjJbEbs4mJcTxst8um95J3sDYU1RBEOvdu6oL1Wek2ODI5i4MAw+dZ6cAQ=="],
 
-    "stable": ["stable@0.1.8", "", {}, "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w=="],
-
     "stack-utils": ["stack-utils@2.0.6", "", { "dependencies": { "escape-string-regexp": "^2.0.0" } }, "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ=="],
 
     "stackframe": ["stackframe@1.3.4", "", {}, "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw=="],
@@ -4860,7 +4859,7 @@
 
     "svg-parser": ["svg-parser@2.0.4", "", {}, "sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ=="],
 
-    "svgo": ["svgo@3.3.2", "", { "dependencies": { "@trysound/sax": "0.2.0", "commander": "^7.2.0", "css-select": "^5.1.0", "css-tree": "^2.3.1", "css-what": "^6.1.0", "csso": "^5.0.5", "picocolors": "^1.0.0" }, "bin": "./bin/svgo" }, "sha512-OoohrmuUlBs8B8o6MB2Aevn+pRIH9zDALSR+6hhqVfa6fRwG/Qw9VUMSMW9VNg2CFc/MTIfabtdOVl9ODIJjpw=="],
+    "svgo": ["svgo@3.3.3", "", { "dependencies": { "commander": "^7.2.0", "css-select": "^5.1.0", "css-tree": "^2.3.1", "css-what": "^6.1.0", "csso": "^5.0.5", "picocolors": "^1.0.0", "sax": "^1.5.0" }, "bin": "./bin/svgo" }, "sha512-+wn7I4p7YgJhHs38k2TNjy1vCfPIfLIJWR5MnCStsN8WuuTcBnRKcMHQLMM2ijxGZmDoZwNv8ipl5aTTen62ng=="],
 
     "symbol-observable": ["symbol-observable@1.2.0", "", {}, "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="],
 
@@ -4876,7 +4875,7 @@
 
     "tapable": ["tapable@2.2.2", "", {}, "sha512-Re10+NauLTMCudc7T5WLFLAwDhQ0JWdrMK+9B2M8zR5hRExKmsRDCBA7/aV/pNJFltmBFO5BAMlQFi/vq3nKOg=="],
 
-    "tar": ["tar@7.5.9", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-BTLcK0xsDh2+PUe9F6c2TlRp4zOOBMTkoQHQIWSIzI0R7KG46uEwq4OPk2W7bZcprBMsuaeFsqwYr7pjh6CuHg=="],
+    "tar": ["tar@7.5.10", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-8mOPs1//5q/rlkNSPcCegA6hiHJYDmSLEI8aMH/CdSQJNWztHC9WHNam5zdQlfpTwB9Xp7IBEsHfV5LKMJGVAw=="],
 
     "tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
 
@@ -6098,8 +6097,6 @@
 
     "postcss-normalize-url/normalize-url": ["normalize-url@6.1.0", "", {}, "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A=="],
 
-    "postcss-svgo/svgo": ["svgo@2.8.0", "", { "dependencies": { "@trysound/sax": "0.2.0", "commander": "^7.2.0", "css-select": "^4.1.3", "css-tree": "^1.1.3", "csso": "^4.2.0", "picocolors": "^1.0.0", "stable": "^0.1.8" }, "bin": { "svgo": "bin/svgo" } }, "sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg=="],
-
     "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
     "pretty-format/react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
@@ -6990,12 +6987,6 @@
 
     "pkg-install/execa/npm-run-path": ["npm-run-path@2.0.2", "", { "dependencies": { "path-key": "^2.0.0" } }, "sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw=="],
 
-    "postcss-svgo/svgo/css-select": ["css-select@4.3.0", "", { "dependencies": { "boolbase": "^1.0.0", "css-what": "^6.0.1", "domhandler": "^4.3.1", "domutils": "^2.8.0", "nth-check": "^2.0.1" } }, "sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ=="],
-
-    "postcss-svgo/svgo/css-tree": ["css-tree@1.1.3", "", { "dependencies": { "mdn-data": "2.0.14", "source-map": "^0.6.1" } }, "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q=="],
-
-    "postcss-svgo/svgo/csso": ["csso@4.2.0", "", { "dependencies": { "css-tree": "^1.1.2" } }, "sha512-wvlcdIbf6pwKEk7vHj8/Bkc0B4ylXZruLvOgs9doS5eOsOpuodOV2zJChSpkp+pRpYQLQMeF04nr3Z68Sta9jA=="],
-
     "read-pkg-up/find-up/locate-path": ["locate-path@2.0.0", "", { "dependencies": { "p-locate": "^2.0.0", "path-exists": "^3.0.0" } }, "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA=="],
 
     "read-pkg-up/read-pkg/load-json-file": ["load-json-file@4.0.0", "", { "dependencies": { "graceful-fs": "^4.1.2", "parse-json": "^4.0.0", "pify": "^3.0.0", "strip-bom": "^3.0.0" } }, "sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw=="],
@@ -7334,14 +7325,6 @@
 
     "pkg-install/execa/npm-run-path/path-key": ["path-key@2.0.1", "", {}, "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw=="],
 
-    "postcss-svgo/svgo/css-select/domhandler": ["domhandler@4.3.1", "", { "dependencies": { "domelementtype": "^2.2.0" } }, "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ=="],
-
-    "postcss-svgo/svgo/css-select/domutils": ["domutils@2.8.0", "", { "dependencies": { "dom-serializer": "^1.0.1", "domelementtype": "^2.2.0", "domhandler": "^4.2.0" } }, "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A=="],
-
-    "postcss-svgo/svgo/css-tree/mdn-data": ["mdn-data@2.0.14", "", {}, "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow=="],
-
-    "postcss-svgo/svgo/css-tree/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
-
     "read-pkg-up/find-up/locate-path/p-locate": ["p-locate@2.0.0", "", { "dependencies": { "p-limit": "^1.1.0" } }, "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg=="],
 
     "read-pkg-up/find-up/locate-path/path-exists": ["path-exists@3.0.0", "", {}, "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ=="],
@@ -7442,8 +7425,6 @@
 
     "pacote/npm-pick-manifest/npm-package-arg/hosted-git-info/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
-    "postcss-svgo/svgo/css-select/domutils/dom-serializer": ["dom-serializer@1.4.1", "", { "dependencies": { "domelementtype": "^2.0.1", "domhandler": "^4.2.0", "entities": "^2.0.0" } }, "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag=="],
-
     "read-pkg-up/find-up/locate-path/p-locate/p-limit": ["p-limit@1.3.0", "", { "dependencies": { "p-try": "^1.0.0" } }, "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q=="],
 
     "renderkid/css-select/domutils/dom-serializer/entities": ["entities@2.2.0", "", {}, "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="],
@@ -7459,8 +7440,6 @@
     "lerna/rimraf/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.3", "", {}, "sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g=="],
 
     "listr-update-renderer/log-update/cli-cursor/restore-cursor/onetime/mimic-fn": ["mimic-fn@1.2.0", "", {}, "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="],
-
-    "postcss-svgo/svgo/css-select/domutils/dom-serializer/entities": ["entities@2.2.0", "", {}, "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="],
 
     "read-pkg-up/find-up/locate-path/p-locate/p-limit/p-try": ["p-try@1.0.0", "", {}, "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww=="],
   }

--- a/package.json
+++ b/package.json
@@ -157,8 +157,9 @@
     "lodash-es": "4.17.23",
     "diff": "5.2.2",
     "webpack": "5.105.0",
-    "tar": "7.5.9",
-    "serialize-javascript": "7.0.4"
+    "tar": "7.5.10",
+    "serialize-javascript": "7.0.4",
+    "svgo": "3.3.3"
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/platform/docs/package.json
+++ b/platform/docs/package.json
@@ -102,6 +102,7 @@
     "webpack": "5.105.0",
     "sharp": "0.34.5",
     "serialize-javascript": "7.0.4",
-    "rollup": "2.80.0"
+    "rollup": "2.80.0",
+    "svgo": "3.3.3"
   }
 }

--- a/platform/docs/yarn.lock
+++ b/platform/docs/yarn.lock
@@ -3647,11 +3647,6 @@
   dependencies:
     defer-to-connect "^2.0.1"
 
-"@trysound/sax@0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@trysound/sax/-/sax-0.2.0.tgz#cccaab758af56761eb7bf37af6f03f326dd798ad"
-  integrity sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==
-
 "@types/acorn@^4.0.0":
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/@types/acorn/-/acorn-4.0.6.tgz#d61ca5480300ac41a7d973dd5b84d0a591154a22"
@@ -10960,6 +10955,11 @@ sax@^1.2.4:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.4.1.tgz#44cc8988377f126304d3b3fc1010c733b929ef0f"
   integrity sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==
 
+sax@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.5.0.tgz#b5549b671069b7aa392df55ec7574cf411179eb8"
+  integrity sha512-21IYA3Q5cQf089Z6tgaUTr7lDAyzoTPx5HRtbhsME8Udispad8dC/+sziTNugOEx54ilvatQ9YCzl4KQLPcRHA==
+
 scheduler@^0.23.2:
   version "0.23.2"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.23.2.tgz#414ba64a3b282892e944cf2108ecc078d115cdc3"
@@ -11663,18 +11663,18 @@ svg-parser@^2.0.4:
   resolved "https://registry.yarnpkg.com/svg-parser/-/svg-parser-2.0.4.tgz#fdc2e29e13951736140b76cb122c8ee6630eb6b5"
   integrity sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==
 
-svgo@^3.0.2, svgo@^3.2.0:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/svgo/-/svgo-3.3.2.tgz#ad58002652dffbb5986fc9716afe52d869ecbda8"
-  integrity sha512-OoohrmuUlBs8B8o6MB2Aevn+pRIH9zDALSR+6hhqVfa6fRwG/Qw9VUMSMW9VNg2CFc/MTIfabtdOVl9ODIJjpw==
+svgo@3.3.3, svgo@^3.0.2, svgo@^3.2.0:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/svgo/-/svgo-3.3.3.tgz#8246aee0b08791fde3b0ed22b5661b471fadf58e"
+  integrity sha512-+wn7I4p7YgJhHs38k2TNjy1vCfPIfLIJWR5MnCStsN8WuuTcBnRKcMHQLMM2ijxGZmDoZwNv8ipl5aTTen62ng==
   dependencies:
-    "@trysound/sax" "0.2.0"
     commander "^7.2.0"
     css-select "^5.1.0"
     css-tree "^2.3.1"
     css-what "^6.1.0"
     csso "^5.0.5"
     picocolors "^1.0.0"
+    sax "^1.5.0"
 
 swc-loader@^0.2.6:
   version "0.2.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4770,11 +4770,6 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"
   integrity sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==
 
-"@trysound/sax@0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@trysound/sax/-/sax-0.2.0.tgz#cccaab758af56761eb7bf37af6f03f326dd798ad"
-  integrity sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==
-
 "@tsconfig/node10@^1.0.7":
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.11.tgz#6ee46400685f130e278128c7b38b7e031ff5b2f2"
@@ -8003,14 +7998,6 @@ css-select@^5.1.0:
     domutils "^3.0.1"
     nth-check "^2.0.1"
 
-css-tree@^1.1.2, css-tree@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-1.1.3.tgz#eb4870fb6fd7707327ec95c2ff2ab09b5e8db91d"
-  integrity sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==
-  dependencies:
-    mdn-data "2.0.14"
-    source-map "^0.6.1"
-
 css-tree@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-2.3.1.tgz#10264ce1e5442e8572fc82fbe490644ff54b5c20"
@@ -8095,13 +8082,6 @@ cssnano@^5.0.2:
     cssnano-preset-default "^5.2.14"
     lilconfig "^2.0.3"
     yaml "^1.10.2"
-
-csso@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/csso/-/csso-4.2.0.tgz#ea3a561346e8dc9f546d6febedd50187cf389529"
-  integrity sha512-wvlcdIbf6pwKEk7vHj8/Bkc0B4ylXZruLvOgs9doS5eOsOpuodOV2zJChSpkp+pRpYQLQMeF04nr3Z68Sta9jA==
-  dependencies:
-    css-tree "^1.1.2"
 
 csso@^5.0.5:
   version "5.0.5"
@@ -13799,11 +13779,6 @@ mdast-util-to-string@^3.0.0, mdast-util-to-string@^3.1.0:
   dependencies:
     "@types/mdast" "^3.0.0"
 
-mdn-data@2.0.14:
-  version "2.0.14"
-  resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.14.tgz#7113fc4281917d63ce29b43446f701e68c25ba50"
-  integrity sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==
-
 mdn-data@2.0.28:
   version "2.0.28"
   resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.28.tgz#5ec48e7bef120654539069e1ae4ddc81ca490eba"
@@ -17589,6 +17564,11 @@ safe-regex-test@^1.0.3, safe-regex-test@^1.1.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
+sax@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.5.0.tgz#b5549b671069b7aa392df55ec7574cf411179eb8"
+  integrity sha512-21IYA3Q5cQf089Z6tgaUTr7lDAyzoTPx5HRtbhsME8Udispad8dC/+sziTNugOEx54ilvatQ9YCzl4KQLPcRHA==
+
 saxes@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/saxes/-/saxes-6.0.0.tgz#fe5b4a4768df4f14a201b1ba6a65c1f3d9988cc5"
@@ -18251,11 +18231,6 @@ ssri@^13.0.0:
   dependencies:
     minipass "^7.0.3"
 
-stable@^0.1.8:
-  version "0.1.8"
-  resolved "https://registry.yarnpkg.com/stable/-/stable-0.1.8.tgz#836eb3c8382fe2936feaf544631017ce7d47a3cf"
-  integrity sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==
-
 stack-utils@^2.0.3:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-2.0.6.tgz#aaf0748169c02fc33c8232abccf933f54a1cc34f"
@@ -18605,31 +18580,18 @@ svg-parser@^2.0.4:
   resolved "https://registry.yarnpkg.com/svg-parser/-/svg-parser-2.0.4.tgz#fdc2e29e13951736140b76cb122c8ee6630eb6b5"
   integrity sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==
 
-svgo@^2.7.0:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/svgo/-/svgo-2.8.0.tgz#4ff80cce6710dc2795f0c7c74101e6764cfccd24"
-  integrity sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==
+svgo@3.3.3, svgo@^2.7.0, svgo@^3.0.2:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/svgo/-/svgo-3.3.3.tgz#8246aee0b08791fde3b0ed22b5661b471fadf58e"
+  integrity sha512-+wn7I4p7YgJhHs38k2TNjy1vCfPIfLIJWR5MnCStsN8WuuTcBnRKcMHQLMM2ijxGZmDoZwNv8ipl5aTTen62ng==
   dependencies:
-    "@trysound/sax" "0.2.0"
-    commander "^7.2.0"
-    css-select "^4.1.3"
-    css-tree "^1.1.3"
-    csso "^4.2.0"
-    picocolors "^1.0.0"
-    stable "^0.1.8"
-
-svgo@^3.0.2:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/svgo/-/svgo-3.3.2.tgz#ad58002652dffbb5986fc9716afe52d869ecbda8"
-  integrity sha512-OoohrmuUlBs8B8o6MB2Aevn+pRIH9zDALSR+6hhqVfa6fRwG/Qw9VUMSMW9VNg2CFc/MTIfabtdOVl9ODIJjpw==
-  dependencies:
-    "@trysound/sax" "0.2.0"
     commander "^7.2.0"
     css-select "^5.1.0"
     css-tree "^2.3.1"
     css-what "^6.1.0"
     csso "^5.0.5"
     picocolors "^1.0.0"
+    sax "^1.5.0"
 
 symbol-observable@^1.1.0:
   version "1.2.0"
@@ -18716,10 +18678,10 @@ tar-stream@~2.2.0:
     inherits "^2.0.3"
     readable-stream "^3.1.1"
 
-tar@7.5.7, tar@7.5.9, tar@^6.1.13, tar@^7.4.3, tar@^7.5.4:
-  version "7.5.9"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-7.5.9.tgz#817ac12a54bc4362c51340875b8985d7dc9724b8"
-  integrity sha512-BTLcK0xsDh2+PUe9F6c2TlRp4zOOBMTkoQHQIWSIzI0R7KG46uEwq4OPk2W7bZcprBMsuaeFsqwYr7pjh6CuHg==
+tar@7.5.10, tar@7.5.7, tar@^6.1.13, tar@^7.4.3, tar@^7.5.4:
+  version "7.5.10"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-7.5.10.tgz#2281541123f5507db38bc6eb22619f4bbaef73ad"
+  integrity sha512-8mOPs1//5q/rlkNSPcCegA6hiHJYDmSLEI8aMH/CdSQJNWztHC9WHNam5zdQlfpTwB9Xp7IBEsHfV5LKMJGVAw==
   dependencies:
     "@isaacs/fs-minipass" "^4.0.0"
     chownr "^3.0.0"


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context
- https://github.com/advisories/GHSA-xpqw-6gx7-v673
- https://github.com/advisories/GHSA-qffp-2rhf-9h96

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results
Patched the vulnerable packages.

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing
Run the automated tests.

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR addresses two security advisories by bumping `svgo` to `3.3.3` (GHSA-xpqw-6gx7-v673 — ReDoS) and `tar` to `7.5.10` (GHSA-qffp-2rhf-9h96) via Yarn `resolutions` overrides in both the root and `platform/docs` workspaces, with lock files updated accordingly.

- `package.json` and `platform/docs/package.json` both add `svgo@3.3.3` to `resolutions`; root also bumps `tar` from `7.5.9` → `7.5.10`
- `yarn.lock` / `platform/docs/yarn.lock` correctly deduplicate both packages to their patched versions, and remove the old `postcss-svgo`-scoped `svgo@2.8.0` subtree
- **Potential compatibility risk**: forcing `svgo@^2.7.0` (consumed by `postcss-svgo`) to resolve to `3.3.3` is a major-version jump with known breaking API changes in svgo v3; a build-time smoke test is recommended to confirm CSS/SVG minification is unaffected
- `bun.lock` contains additional internal workspace-package version bumps (`3.13.0-beta.27` → `3.13.0-beta.32`) that appear unrelated to the stated security scope and should be verified as intentional

<h3>Confidence Score: 3/5</h3>

- Safe to merge pending verification that forcing `svgo` v2 consumers to v3 doesn't break the build.
- The security intent is correct and the resolutions approach is appropriate. However, the major-version coercion of `svgo@^2.7.0` → `3.3.3` introduces API-incompatibility risk for `postcss-svgo`, and the unrelated workspace version bumps in `bun.lock` add surface area that should be explicitly confirmed before merging.
- `yarn.lock` and `platform/docs/yarn.lock` — verify `postcss-svgo` compatibility with svgo v3. `bun.lock` — confirm the workspace version bumps are intentional.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| package.json | Added `svgo@3.3.3` and bumped `tar` from `7.5.9` to `7.5.10` in the `resolutions` section to patch the respective security advisories — straightforward and correct use of the resolutions override mechanism. |
| platform/docs/package.json | Added `svgo@3.3.3` to the `resolutions` section of the docs workspace, mirroring the root-level fix. |
| yarn.lock | Updated `svgo` from `3.3.2` to `3.3.3` and `tar` from `7.5.9` to `7.5.10`; notably the `svgo@^2.7.0` semver range (used by `postcss-svgo`) is now resolved to `3.3.3` — a major-version jump that warrants attention. |
| platform/docs/yarn.lock | Same `svgo` and `tar` lock-file updates as the root yarn.lock; `svgo@^2.7.0` now also deduped to `3.3.3` here, with the old v2.8.0 subtree removed. |
| bun.lock | Reflects the svgo/tar version bumps correctly, but also contains workspace-package version changes from `3.13.0-beta.27` to `3.13.0-beta.32` across many internal packages that appear unrelated to this security fix. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph Resolutions["yarn resolutions (package.json / platform/docs/package.json)"]
        R1["svgo → 3.3.3"]
        R2["tar → 7.5.10"]
    end

    subgraph Consumers["Downstream package consumers"]
        A["postcss-svgo\n(expects svgo ^2.7.0)"]
        B["webpack / build tools\n(expect tar ^6.1.13 / ^7.x)"]
        C["svgo direct consumers\n(expect svgo ^3.0.2)"]
    end

    subgraph Patched["Patched versions (yarn.lock)"]
        P1["svgo@3.3.3\n✅ fixes GHSA-xpqw-6gx7-v673"]
        P2["tar@7.5.10\n✅ fixes GHSA-qffp-2rhf-9h96"]
    end

    R1 -->|forces resolution| P1
    R2 -->|forces resolution| P2

    A -->|semver ^2.7.0 overridden\n⚠️ major-version jump| P1
    C -->|semver ^3.0.2 satisfied| P1
    B -->|semver range satisfied| P2
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `yarn.lock`, line 843 ([link](https://github.com/ohif/viewers/blob/7eb2240b03a5dc684e065b722704a101c055057c/yarn.lock#L843)) 

   **`svgo@^2.7.0` forced to a breaking major version**

   The resolution causes `svgo@^2.7.0` (consumed by `postcss-svgo`) to resolve to `svgo@3.3.3` — a major-version bump that introduced breaking API and plugin-format changes. The `postcss-svgo` package expects the v2 API, and this mismatch can silently produce incorrect SVG optimisation in CSS output or, depending on the version of `postcss-svgo` installed, throw at build time.

   The same issue exists in `platform/docs/yarn.lock` where the second occurrence of this dedup also maps `svgo@^2.7.0` → `3.3.3`.

   Before merging it would be worth confirming:
   1. That the installed version of `postcss-svgo` internally guards against the svgo v3 API, or
   2. Running a build end-to-end to ensure SVG/CSS minification still works as expected.


2. `bun.lock`, line 9-10 ([link](https://github.com/ohif/viewers/blob/7eb2240b03a5dc684e065b722704a101c055057c/bun.lock#L9-L10)) 

   **Unrelated workspace version bumps in bun.lock**

   Beyond the expected `svgo` and `tar` updates, `bun.lock` contains a large number of internal workspace-package version changes (`3.13.0-beta.27` → `3.13.0-beta.32`) across packages such as `extensions/cornerstone`, `addOns/externals/devDependencies`, and many others. These changes do not appear to be part of this security-patch PR.

   This typically happens when `bun install` is re-run from a state where the workspace `package.json` versions were already bumped. If those bumps were intentional and already on the base branch, there is no issue. However, if they weren't, these extra changes could introduce unintended modifications. It may be worth verifying that `bun.lock` was regenerated from a clean, up-to-date checkout of `master`.

</details>

<!-- /greptile_failed_comments -->

<sub>Last reviewed commit: 7eb2240</sub>

<!-- /greptile_comment -->