### PR TITLE
fix(Threshold tool): Threshold tool no longer becomes deselected when the Dynamic option is selected

### DIFF
--- a/modes/tmtv/src/toolbarButtons.ts
+++ b/modes/tmtv/src/toolbarButtons.ts
@@ -301,7 +301,7 @@ const toolbarButtons = [
       evaluate: [
         {
           name: 'evaluate.cornerstone.segmentation',
-          toolNames: ['ThresholdCircularBrush', 'ThresholdSphereBrush'],
+          toolNames: ['ThresholdCircularBrush', 'ThresholdSphereBrush', 'ThresholdCircularBrushDynamic'],
         },
         {
           name: 'evaluate.cornerstone.segmentation.synchronizeDrawingRadius',


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context
See #5654 

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results
Added 'ThresholdCircularBrushDynamic' to the toolNames array so the evaluator correctly recognizes it as an active state for the Threshold button when Dynamic mode is selected.
<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing
See #5654
<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

  System:
    OS: Windows 11 10.0.26200
    CPU: (20) x64 12th Gen Intel(R) Core(TM) i7-12700H
    Memory: 6.33 GB / 31.68 GB
  Binaries:
    Node: 20.9.0 - C:\Users\joebo\AppData\Local\fnm_multishells\37948_1772465949655\node.EXE
    Yarn: 1.22.22 - C:\Program Files (x86)\Yarn\bin\yarn.CMD
    npm: 10.1.0 - C:\Users\joebo\AppData\Local\fnm_multishells\37948_1772465949655\npm.CMD
    bun: 1.2.23 - C:\Users\joebo\.bun\bin\bun.EXE
  Browsers:
    Chrome: 145.0.7632.111
<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a UI state bug where the Threshold tool button would appear deselected when the Dynamic threshold option was chosen. The fix adds `ThresholdCircularBrushDynamic` to the evaluator's `toolNames` array (line 303) in the TMTV mode's toolbar configuration.

**Root cause:** `ThresholdCircularBrushDynamic` was already correctly wired up in the `setBrushSize` command (lines 320–329) and in the `setToolActive` command handler (lines 341–351), but was missing from the top-level evaluator array that determines the button's active state. When the Dynamic option was selected, the evaluator would not recognize the active tool and the button would appear deselected.

**Key observations:**
- The fix is consistent with the segmentation mode's toolbar configuration, which already includes both `ThresholdCircularBrushDynamic` and `ThresholdSphereBrushDynamic` in its evaluator.
- TMTV intentionally includes only `ThresholdCircularBrushDynamic` (not the sphere variant) because the circular brush is the only shape registered and activated in Dynamic mode for this mode.
- The change is minimal, targeted, and safe—it adds a single missing tool name to a configuration array.

<h3>Confidence Score: 4/5</h3>

- Safe to merge—adds a single missing tool name to an evaluator array, fixing a UI state regression with no impact on data integrity or logic.
- This PR is straightforward and low-risk. It adds one entry to a configuration array to fix a recognized UI state bug. The change is consistent with analogous code in the segmentation mode, and the fix directly addresses the root cause. The score is 4 rather than 5 only because there are no automated tests covering toolbar active-state behaviour.
- No files require special attention.

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User clicks Threshold button] --> B{Evaluate toolNames}
    B --> C["ThresholdCircularBrush<br/>ThresholdSphereBrush<br/>ThresholdCircularBrushDynamic ✅ NEW"]
    C --> D{Active tool matches?}
    D -- Yes --> E[Button shows as ACTIVE]
    D -- No --> F[Button shows as INACTIVE]

    G[User selects Dynamic option] --> H["setToolActive:<br/>ThresholdCircularBrushDynamic"]
    H --> B

    I[User selects Range option] --> J["setToolActive:<br/>ThresholdCircularBrush or<br/>ThresholdSphereBrush"]
    J --> B
```

<sub>Last reviewed commit: fd303c4</sub>

<!-- /greptile_comment -->