### PR TITLE
fix: Modalities in study list should select starts with as primary

### DIFF
--- a/platform/ui/src/components/Select/Select.tsx
+++ b/platform/ui/src/components/Select/Select.tsx
@@ -1,10 +1,38 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import ReactSelect, { components } from 'react-select';
 import { Icons } from '@ohif/ui-next';
 
 import './Select.css';
+
+/**
+ * Reorder options so items that START with the search text come first
+ * (shortest first), then items that only contain the text. This order is
+ * passed to react-select so the focused/highlighted option (e.g. on Enter) is correct.
+ */
+function orderOptionsByStartsWith(options, searchInput) {
+  if (!options?.length || !searchInput?.trim()) return options ?? [];
+  const input = searchInput.trim().toLowerCase();
+  const startsWith = options.filter(opt => {
+    const label = (opt.label ?? opt.value ?? '').toString().toLowerCase();
+    return label.startsWith(input);
+  });
+  const containsOnly = options.filter(opt => {
+    const label = (opt.label ?? opt.value ?? '').toString().toLowerCase();
+    return label.includes(input) && !label.startsWith(input);
+  });
+  const rest = options.filter(opt => {
+    const label = (opt.label ?? opt.value ?? '').toString().toLowerCase();
+    return !label.includes(input);
+  });
+  startsWith.sort((a, b) => {
+    const lenA = (a.label ?? a.value ?? '').toString().length;
+    const lenB = (b.label ?? b.value ?? '').toString().length;
+    return lenA - lenB;
+  });
+  return [...startsWith, ...containsOnly, ...rest];
+}
 
 const MultiValue = props => {
   const values = props.selectProps.value;
@@ -56,6 +84,11 @@ const Select = ({
   components = {},
   value = [],
 }) => {
+  const [filterInput, setFilterInput] = useState('');
+  const orderedOptions = isSearchable
+    ? orderOptionsByStartsWith(options, filterInput)
+    : options;
+
   const _noIconComponents = {
     DropdownIndicator: () => null,
     IndicatorSeparator: () => null,
@@ -92,9 +125,11 @@ const Select = ({
       hideSelectedOptions={hideSelectedOptions}
       components={_components}
       placeholder={placeholder}
-      options={options}
+      options={orderedOptions}
       blurInputOnSelect={true}
       menuPortalTarget={document.body}
+      onInputChange={isSearchable ? setFilterInput : undefined}
+      onMenuClose={isSearchable ? () => setFilterInput('') : undefined}
       styles={{
         menuPortal: base => ({ ...base, zIndex: 9999 }),
       }}


### PR DESCRIPTION
### Context

The ui select list used for modalities in study selection selects the wrong modality when there is a prefixed modality item.
I KNOW we are replacing it in ui-next, but it is so irritating and a tiny fix

### Changes & Results
Change the sort order to: something with starts with, something with contains and then everything else

### Testing

Type us in the modalities in study drop down entry field
Hit enter
Should select US to search
Should have shown US, BDUS and I think IVUS (one more whatever it is)

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] OS: <!--[e.g. Windows 10, macOS 10.15.4]-->
- [] Node version: <!--[e.g. 18.16.1]-->
- [] Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a UX bug in the `Select` component where typing a modality prefix (e.g. "US") would incorrectly highlight a longer, prefixed modality (e.g. "BDUS", "IVUS") instead of the exact/shorter match. The fix introduces a `filterInput` state and a `orderOptionsByStartsWith` helper that reorders the `options` array passed to react-select so that exact-start matches appear first (sorted by label length, shortest first), followed by contains-only matches, then the rest — before react-select applies its own built-in filtering.

**Key changes:**
- New `orderOptionsByStartsWith` pure function: correctly buckets options into `startsWith`, `containsOnly`, and `rest`, then stable-sorts the `startsWith` bucket by label length so the shortest (most exact) match is always at index 0.
- `filterInput` state wired to react-select's `onInputChange` so the reordering reacts live to the user's keystrokes.
- `onMenuClose` resets `filterInput`; this is redundant since `onInputChange` already fires with `''` on menu close, but it is harmless.
- A minor performance improvement opportunity exists: `orderOptionsByStartsWith` is recomputed on every render. Wrapping it in `useMemo(() => orderOptionsByStartsWith(options, filterInput), [options, filterInput])` would avoid unnecessary recalculations, though for typical small modality lists this is negligible.

<h3>Confidence Score: 4/5</h3>

- Safe to merge; the fix is narrowly scoped, logically correct, and has no breaking changes.
- The implementation correctly leverages react-select's ordering semantics (first option in the list is focused/selected on Enter) to surface "starts with" matches ahead of "contains" matches. There are no critical logic errors, type errors, or regressions introduced. The only findings are a redundant `onMenuClose` reset and a missing `useMemo` optimisation, both of which are style-level concerns.
- No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| platform/ui/src/components/Select/Select.tsx | Adds `orderOptionsByStartsWith` helper and `filterInput` state to reorder options so "starts with" matches appear first; logic is correct and the interaction with react-select's built-in filtering is sound, with one minor redundancy in state cleanup. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([User types in Select input]) --> B[onInputChange fires\nsetFilterInput called]
    B --> C{isSearchable?}
    C -- No --> D[options passed as-is to ReactSelect]
    C -- Yes --> E[orderOptionsByStartsWith\noptions, filterInput]
    E --> F{filterInput empty\nor no options?}
    F -- Yes --> G[Return original options unchanged]
    F -- No --> H[Split into 3 buckets]
    H --> I["startsWith: label starts with input\n(sorted shortest→longest)"]
    H --> J[containsOnly: label contains input\nbut does NOT start with it]
    H --> K[rest: label does not contain input]
    I --> L["orderedOptions =\n[...startsWith, ...containsOnly, ...rest]"]
    J --> L
    K --> L
    L --> M[ReactSelect receives orderedOptions]
    M --> N[ReactSelect applies default filterOption\nremoves non-matching entries]
    N --> O[Displayed list:\nstartsWith matches first]
    O --> P([User presses Enter → selects\nfirst focused option = shortest startsWith match])
    P --> Q[onMenuClose fires\nsetFilterInput reset to empty string]
```

<sub>Last reviewed commit: 5c40eb9</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->