### PR TITLE
Fix Dockerfile build failure by updating Node.js to 20.19.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@
 # Stage 1: Build the application
 # docker build -t ohif/viewer:latest .
 # Copy Files
-FROM node:20.18.1-slim as builder
+FROM node:20.19.0-slim as builder
 
 RUN apt-get update && apt-get install -y build-essential python3
 

--- a/platform/app/.recipes/Nginx-Dcm4chee-Keycloak/dockerfile
+++ b/platform/app/.recipes/Nginx-Dcm4chee-Keycloak/dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build the application
-FROM node:20.18.1-slim as builder
+FROM node:20.19.0-slim as builder
 
 # Setup the working directory
 RUN mkdir /usr/src/app

--- a/platform/app/.recipes/Nginx-Dcm4chee/dockerfile
+++ b/platform/app/.recipes/Nginx-Dcm4chee/dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build the application
-FROM node:20.18.1-slim as builder
+FROM node:20.19.0-slim as builder
 
 # Setup the working directory
 RUN mkdir /usr/src/app

--- a/platform/app/.recipes/Nginx-Orthanc-Keycloak/dockerfile
+++ b/platform/app/.recipes/Nginx-Orthanc-Keycloak/dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build the application
-FROM node:20.18.1-slim as builder
+FROM node:20.19.0-slim as builder
 
 # Setup the working directory
 RUN mkdir /usr/src/app

--- a/platform/app/.recipes/Nginx-Orthanc/dockerfile
+++ b/platform/app/.recipes/Nginx-Orthanc/dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build the application
-FROM node:20.18.1-slim as builder
+FROM node:20.19.0-slim as builder
 
 # Setup the working directory
 RUN mkdir /usr/src/app


### PR DESCRIPTION
## Fixes #5860

### Problem
Docker builds fail because `lerna@9.0.4` requires Node `^20.19.0 || ^22.12.0 || >=24.0.0`, but the Dockerfiles use `node:20.18.1-slim`.

### Fix
Updated `node:20.18.1-slim` → `node:20.19.0-slim` in all Dockerfiles:
- `Dockerfile` (root)
- `platform/app/.recipes/Nginx-Orthanc-Keycloak/dockerfile`
- `platform/app/.recipes/Nginx-Orthanc/dockerfile`
- `platform/app/.recipes/Nginx-Dcm4chee-Keycloak/dockerfile`
- `platform/app/.recipes/Nginx-Dcm4chee/dockerfile`

This matches the Node version already used in `.circleci/config.yml` (20.19.0).

Signed-off-by: haoyu-haoyu <haoyu-haoyu@users.noreply.github.com>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes Docker build failures by updating the Node.js base image from `node:20.18.1-slim` to `node:20.19.0-slim` across all five Dockerfiles, bringing them in line with the version already used in `.circleci/config.yml`. The change is minimal, targeted, and correctly applied to every affected file.

**Note on PR description accuracy:** The PR attributes the failure to `lerna@9.0.4` requiring `^20.19.0`, but the root `Dockerfile` explicitly installs `lerna@7.4.2` globally. The underlying cause of the version incompatibility may differ from what is described, though the fix (bumping Node.js to 20.19.0) aligns with CI and resolves the build issue regardless.

- All five Dockerfiles updated consistently from `20.18.1-slim` → `20.19.0-slim`
- The new version matches `cimg/node:20.19.0` already used in `.circleci/config.yml`
- The `.node-version` file (used by local tooling like `nvm`/`fnm`) still references `20.9.0` and was not updated — this pre-existing inconsistency between local dev tooling and the Docker/CI environment may cause subtle differences between local and containerized builds

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a straightforward and low-risk Node.js patch version bump across Dockerfiles.
- The change is a single-line patch version bump (20.18.1 → 20.19.0) applied consistently to all five Dockerfiles. It resolves a build failure, aligns with the already-working CI configuration, and introduces no functional or logic changes.
- No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| Dockerfile | Updates Node.js base image from 20.18.1-slim to 20.19.0-slim; change is correct and aligns with CI config. |
| platform/app/.recipes/Nginx-Dcm4chee-Keycloak/dockerfile | Updates Node.js base image from 20.18.1-slim to 20.19.0-slim; consistent with the root Dockerfile change. |
| platform/app/.recipes/Nginx-Dcm4chee/dockerfile | Updates Node.js base image from 20.18.1-slim to 20.19.0-slim; consistent with the root Dockerfile change. |
| platform/app/.recipes/Nginx-Orthanc-Keycloak/dockerfile | Updates Node.js base image from 20.18.1-slim to 20.19.0-slim; consistent with the root Dockerfile change. |
| platform/app/.recipes/Nginx-Orthanc/dockerfile | Updates Node.js base image from 20.18.1-slim to 20.19.0-slim; consistent with the root Dockerfile change. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Docker Build Triggered] --> B{Which Dockerfile?}
    B --> C[Dockerfile - root]
    B --> D[Nginx-Orthanc/dockerfile]
    B --> E[Nginx-Orthanc-Keycloak/dockerfile]
    B --> F[Nginx-Dcm4chee/dockerfile]
    B --> G[Nginx-Dcm4chee-Keycloak/dockerfile]

    C --> H["Stage 1: Builder\nFROM node:20.19.0-slim ✅"]
    D --> H
    E --> H
    F --> H
    G --> H

    H --> I["apt-get install build-essential python3\nnpm install -g bun & lerna@7.4.2"]
    I --> J[Copy package files & install deps]
    J --> K[Copy source & build app]
    K --> L["Stage 2: Nginx\nnginx:alpine"]
    L --> M[Copy built assets from Stage 1]
    M --> N[Final Docker Image]
```

<sub>Last reviewed commit: d1cf213</sub>

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->