### PR TITLE
fix(security): Bump tar version to address CVE-2026-31802 in release/3.12

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -971,7 +971,7 @@
     "serialize-javascript": "7.0.4",
     "svgo": "3.3.3",
     "tapable": "2.2.2",
-    "tar": "7.5.10",
+    "tar": "7.5.11",
     "trim": "1.0.1",
     "trim-newlines": "5.0.0",
     "webpack": "5.105.0",
@@ -4875,7 +4875,7 @@
 
     "tapable": ["tapable@2.2.2", "", {}, "sha512-Re10+NauLTMCudc7T5WLFLAwDhQ0JWdrMK+9B2M8zR5hRExKmsRDCBA7/aV/pNJFltmBFO5BAMlQFi/vq3nKOg=="],
 
-    "tar": ["tar@7.5.10", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-8mOPs1//5q/rlkNSPcCegA6hiHJYDmSLEI8aMH/CdSQJNWztHC9WHNam5zdQlfpTwB9Xp7IBEsHfV5LKMJGVAw=="],
+    "tar": ["tar@7.5.11", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ=="],
 
     "tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
 

--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
     "lodash-es": "4.17.23",
     "diff": "5.2.2",
     "webpack": "5.105.0",
-    "tar": "7.5.10",
+    "tar": "7.5.11",
     "serialize-javascript": "7.0.4",
     "svgo": "3.3.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -18678,10 +18678,10 @@ tar-stream@~2.2.0:
     inherits "^2.0.3"
     readable-stream "^3.1.1"
 
-tar@7.5.10, tar@7.5.7, tar@^6.1.13, tar@^7.4.3, tar@^7.5.4:
-  version "7.5.10"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-7.5.10.tgz#2281541123f5507db38bc6eb22619f4bbaef73ad"
-  integrity sha512-8mOPs1//5q/rlkNSPcCegA6hiHJYDmSLEI8aMH/CdSQJNWztHC9WHNam5zdQlfpTwB9Xp7IBEsHfV5LKMJGVAw==
+tar@7.5.11, tar@7.5.7, tar@^6.1.13, tar@^7.4.3, tar@^7.5.4:
+  version "7.5.11"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-7.5.11.tgz#1250fae45d98806b36d703b30973fa8e0a6d8868"
+  integrity sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ==
   dependencies:
     "@isaacs/fs-minipass" "^4.0.0"
     chownr "^3.0.0"


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context
See https://github.com/advisories/GHSA-9ppj-qmqm-q256
<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results
Bumped tar version to 7.5.11.

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing
Run automated tests. 

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR is a targeted security patch that bumps the `tar` dependency from `7.5.10` to `7.5.11` across the monorepo to address CVE-2026-31802 (GHSA-9ppj-qmqm-q256). The fix is enforced via the `resolutions` field in `package.json` (yarn's mechanism for forcing transitive dependency versions), and both lock files (`yarn.lock` and `bun.lock`) are updated consistently.

Key observations:
- The `resolutions` field in `package.json` now specifies `"tar": "7.5.11"`, ensuring all transitive dependents—including packages that previously requested `tar@7.5.7`, `tar@^6.1.13`, `tar@^7.4.3`, and `tar@^7.5.4`—are resolved to the patched version.
- The integrity hashes in `bun.lock` and `yarn.lock` are identical, confirming both lock files reference the same published package artifact.
- The new CVE (GHSA-9ppj-qmqm-q256) is correctly **not** added to the `--ignore` list in the `audit` script—it is being fixed, not suppressed.
- No application logic, public API, or user-facing behavior is changed.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge; it is a minimal, targeted security patch with no logic changes.
- The change is limited to bumping a single transitive dependency (`tar`) one patch version to remediate a known CVE. Both lock files are internally consistent and carry matching integrity hashes. The `resolutions` override correctly covers all version ranges that previously resolved to older `tar` releases. No application code, configuration, or public API is touched.
- No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| package.json | Updates `tar` version from `7.5.10` to `7.5.11` in the `resolutions` field to force all transitive dependents to use the patched version; no other changes. |
| yarn.lock | Regenerated entry consolidates `tar@7.5.11`, `tar@7.5.7`, and semver ranges under the new resolved version `7.5.11`; integrity hash updated and consistent with bun.lock. |
| bun.lock | Both the package list entry and the full package-details entry for `tar` are bumped to `7.5.11` with the correct integrity hash; consistent with yarn.lock. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["package.json\nresolutions: tar → 7.5.11"] -->|yarn install| B["yarn.lock\ntar@7.5.11 resolved"]
    A -->|bun install| C["bun.lock\ntar@7.5.11 resolved"]
    B --> D["All transitive dependents\ntar@7.5.7 / ^6 / ^7 ranges\nforced to 7.5.11"]
    C --> D
    D --> E["CVE-2026-31802\nGHSA-9ppj-qmqm-q256\nremediated"]
    style E fill:#22c55e,color:#fff
```

<sub>Last reviewed commit: 9ae5cd5</sub>

<!-- /greptile_comment -->