### PR TITLE
fix(security): Bump flattened version to address CVE-2026-32141 for release 3.12

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -959,6 +959,7 @@
     "cross-spawn": "7.0.6",
     "dcmjs": "0.49.4",
     "diff": "5.2.2",
+    "flatted": "3.4.0",
     "glob-parent": "6.0.2",
     "lodash": "4.17.23",
     "lodash-es": "4.17.23",
@@ -3131,7 +3132,7 @@
 
     "flatbuffers": ["flatbuffers@1.12.0", "", {}, "sha512-c7CZADjRcl6j0PlvFy0ZqXQ67qSEZfrVPynmnL+2zPc+NtMvrF8Y0QceMo7QqnSPc7+uWjUIAbvCQ5WIKlMVdQ=="],
 
-    "flatted": ["flatted@3.3.3", "", {}, "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg=="],
+    "flatted": ["flatted@3.4.0", "", {}, "sha512-kC6Bb+ooptOIvWj5B63EQWkF0FEnNjV2ZNkLMLZRDDduIiWeFF4iKnslwhiWxjAdbg4NzTNo6h0qLuvFrcx+Sw=="],
 
     "follow-redirects": ["follow-redirects@1.15.11", "", {}, "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ=="],
 

--- a/package.json
+++ b/package.json
@@ -159,7 +159,8 @@
     "webpack": "5.105.0",
     "tar": "7.5.11",
     "serialize-javascript": "7.0.4",
-    "svgo": "3.3.3"
+    "svgo": "3.3.3",
+    "flatted": "3.4.0"
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10217,10 +10217,10 @@ flatbuffers@^1.12.0:
   resolved "https://registry.yarnpkg.com/flatbuffers/-/flatbuffers-1.12.0.tgz#72e87d1726cb1b216e839ef02658aa87dcef68aa"
   integrity sha512-c7CZADjRcl6j0PlvFy0ZqXQ67qSEZfrVPynmnL+2zPc+NtMvrF8Y0QceMo7QqnSPc7+uWjUIAbvCQ5WIKlMVdQ==
 
-flatted@^3.2.9:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.3.3.tgz#67c8fad95454a7c7abebf74bb78ee74a44023358"
-  integrity sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==
+flatted@3.4.0, flatted@^3.2.9:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.4.0.tgz#92ab2efec9b272eb85a3a25a106c3afbbc990d8b"
+  integrity sha512-kC6Bb+ooptOIvWj5B63EQWkF0FEnNjV2ZNkLMLZRDDduIiWeFF4iKnslwhiWxjAdbg4NzTNo6h0qLuvFrcx+Sw==
 
 follow-redirects@^1.0.0:
   version "1.15.9"


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context
See https://github.com/advisories/GHSA-25h7-pfq9-p65f
<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results
Bumped flatted package version
<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing
Run automated tests.

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment


<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR is a targeted security patch for the `release/3.12` branch that bumps the `flatted` package from `3.3.3` to `3.4.0` to address CVE-2026-32141 (GHSA-25h7-pfq9-p65f), a Prototype Pollution vulnerability in `flatted`. The fix is applied via a forced resolution override across both package managers used in the repository (yarn and bun).

- `package.json`: `"flatted": "3.4.0"` is added to the `resolutions` field, consistent with the project's existing pattern of security-pinning transitive dependencies (e.g., `cross-spawn`, `tar`, `serialize-javascript`).
- `yarn.lock`: The `flatted` entry is updated from `3.3.3` → `3.4.0`; the two specifiers (`flatted@3.4.0` and `flatted@^3.2.9`) are correctly deduplicated into a single resolved entry with the new integrity hash.
- `bun.lock`: The `overrides` entry and top-level package record are updated to `3.4.0` with a consistent checksum, keeping both package managers in sync.
- `flatted` is a transitive dependency pulled in by `flat-cache` → `file-entry-cache` → ESLint's caching layer — it is a dev/build-time dependency only with no direct surface in the OHIF viewer runtime, so there is no risk of user-visible regression.
- The existing `audit` script already ignores three unrelated CVEs; no additional ignore entry was needed here because the vulnerability is properly resolved rather than suppressed.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a well-scoped, non-breaking dependency version bump that resolves a known CVE with no runtime surface area.
- The change exclusively touches lockfiles and the `resolutions`/`overrides` fields in `package.json`. The `flatted` package is only used by ESLint's file-caching layer at dev/build time and is not part of the OHIF viewer runtime bundle. The upgrade from `3.3.3` to `3.4.0` is a backward-compatible patch that resolves the Prototype Pollution vulnerability. Both `yarn.lock` and `bun.lock` are updated with consistent, valid integrity hashes, and the resolution pattern matches the project's established approach for pinning transitive deps.
- No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| package.json | Adds `"flatted": "3.4.0"` to the yarn `resolutions` field, forcing all transitive consumers to use the patched version that fixes the Prototype Pollution CVE. |
| yarn.lock | Updates the `flatted` entry from `3.3.3` to `3.4.0`, deduplicating the two version specifiers (`flatted@3.4.0, flatted@^3.2.9`) into a single resolved entry with a correct integrity hash. |
| bun.lock | Adds `"flatted": "3.4.0"` to the bun `overrides` section and updates the package entry from `3.3.3` to `3.4.0` with a matching integrity hash, keeping both package managers in sync. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["package.json\nresolutions: flatted@3.4.0"] --> B["yarn install"]
    A --> C["bun install"]
    B --> D["yarn.lock\nflatted@3.4.0"]
    C --> E["bun.lock\noverrides: flatted@3.4.0"]
    D --> F["file-entry-cache\n(ESLint caching)"]
    E --> F
    F --> G["flat-cache"]
    G --> H["flatted@3.4.0\nCVE-2026-32141 patched"]
    H --> I["Prototype Pollution\nvulnerability resolved"]

    style I fill:#22c55e,color:#fff
    style H fill:#3b82f6,color:#fff
```

<sub>Last reviewed commit: 8d60c30</sub>

<!-- /greptile_comment -->