### PR TITLE
OHIF 同步與資料源設定調整：回傳 series 選擇並改走 3001 proxy

### DIFF
--- a/platform/app/public/config/local_orthanc.js
+++ b/platform/app/public/config/local_orthanc.js
@@ -18,9 +18,10 @@ window.config = {
       configuration: {
         friendlyName: 'local Orthanc DICOMWeb Server',
         name: 'DCM4CHEE',
-        wadoUriRoot: 'http://localhost/dicom-web',
-        qidoRoot: 'http://localhost/dicom-web',
-        wadoRoot: 'http://localhost/dicom-web',
+        // Route DICOMWeb through liverct-server so auth/cors are handled in one place.
+        wadoUriRoot: 'http://127.0.0.1:3001/api/orthanc/wado',
+        qidoRoot: 'http://127.0.0.1:3001/api/orthanc/dicom-web',
+        wadoRoot: 'http://127.0.0.1:3001/api/orthanc/dicom-web',
         qidoSupportsIncludeField: true,
         supportsReject: true,
         dicomUploadEnabled: true,

--- a/platform/app/src/index.js
+++ b/platform/app/src/index.js
@@ -20,6 +20,55 @@ import loadDynamicConfig from './loadDynamicConfig';
 export { history } from './utils/history';
 export { preserveQueryParameters, preserveQueryStrings } from './utils/preserveQueryParameters';
 
+function setupParentSelectionBridge() {
+  // Bridge OHIF selection state to embedding parent app (iframe host).
+  if (!window.parent || window.parent === window) {
+    return;
+  }
+
+  let lastPayload = '';
+
+  const emitSelection = () => {
+    try {
+      const params = new URLSearchParams(window.location.search || '');
+      const studyInstanceUIDs = params.get('StudyInstanceUIDs') || '';
+      const payload = JSON.stringify({
+        type: 'OHIF_SELECTION',
+        studyInstanceUIDs,
+        href: window.location.href,
+      });
+
+      if (payload === lastPayload) {
+        return;
+      }
+
+      lastPayload = payload;
+      window.parent.postMessage(JSON.parse(payload), '*');
+    } catch (error) {
+      // Ignore bridge errors to avoid impacting viewer rendering.
+    }
+  };
+
+  const wrapHistoryMethod = methodName => {
+    const original = window.history[methodName];
+    window.history[methodName] = function (...args) {
+      const result = original.apply(this, args);
+      setTimeout(emitSelection, 0);
+      return result;
+    };
+  };
+
+  wrapHistoryMethod('pushState');
+  wrapHistoryMethod('replaceState');
+
+  window.addEventListener('popstate', emitSelection);
+  window.addEventListener('hashchange', emitSelection);
+
+  emitSelection();
+  // Poll as fallback for navigation paths that do not trigger history events.
+  setInterval(emitSelection, 1200);
+}
+
 loadDynamicConfig(window.config).then(config_json => {
   // Reset Dynamic config if defined
   if (config_json !== null) {
@@ -37,6 +86,8 @@ loadDynamicConfig(window.config).then(config_json => {
   };
 
   const container = document.getElementById('root');
+
+  setupParentSelectionBridge();
 
   const root = createRoot(container);
   root.render(React.createElement(App, appProps));

--- a/platform/app/src/routes/Mode/Mode.tsx
+++ b/platform/app/src/routes/Mode/Mode.tsx
@@ -61,6 +61,7 @@ export default function ModeRoute({
 
   const {
     displaySetService,
+    viewportGridService,
     panelService,
     hangingProtocolService,
     userAuthenticationService,
@@ -198,6 +199,72 @@ export default function ModeRoute({
       layoutTemplateData.current = null;
     };
   }, [studyInstanceUIDs, ExtensionDependenciesLoaded]);
+
+  useEffect(() => {
+    // Emit active viewport selection (study + series) to parent app so it can
+    // sync right-side Result/Run against the exact selected series.
+    if (!ExtensionDependenciesLoaded || !studyInstanceUIDs?.length) {
+      return;
+    }
+    if (!window.parent || window.parent === window) {
+      return;
+    }
+
+    const postSelection = () => {
+      try {
+        const gridState = viewportGridService?.getState?.();
+        const activeViewportId = gridState?.activeViewportId;
+        const activeViewport =
+          gridState?.viewports?.get?.(activeViewportId) ??
+          (activeViewportId && gridState?.viewports?.[activeViewportId]);
+
+        const viewportOptions = activeViewport?.viewportOptions ?? {};
+        const displaySetUID =
+          activeViewport?.displaySetInstanceUID ??
+          activeViewport?.displaySetInstanceUIDs?.[0] ??
+          activeViewport?.displaySets?.[0] ??
+          viewportOptions?.displaySetInstanceUID ??
+          viewportOptions?.displaySetInstanceUIDs?.[0] ??
+          viewportOptions?.displaySets?.[0];
+
+        const displaySet = displaySetUID ? displaySetService.getDisplaySetByUID(displaySetUID) : null;
+        const studyInstanceUID = displaySet?.StudyInstanceUID ?? studyInstanceUIDs?.[0] ?? '';
+        const seriesInstanceUID = displaySet?.SeriesInstanceUID ?? '';
+
+        window.parent.postMessage(
+          {
+            type: 'OHIF_SELECTION',
+            studyInstanceUIDs: studyInstanceUID,
+            seriesInstanceUIDs: seriesInstanceUID,
+            href: window.location.href,
+          },
+          '*'
+        );
+      } catch (error) {
+        // Keep silent to avoid impacting viewer runtime.
+      }
+    };
+
+    const subscriptions = [];
+    subscriptions.push(
+      viewportGridService?.subscribe?.(
+        viewportGridService.EVENTS.ACTIVE_VIEWPORT_ID_CHANGED,
+        postSelection
+      )
+    );
+    subscriptions.push(
+      viewportGridService?.subscribe?.(viewportGridService.EVENTS.GRID_STATE_CHANGED, postSelection)
+    );
+    subscriptions.push(
+      displaySetService?.subscribe?.(displaySetService.EVENTS.DISPLAY_SETS_CHANGED, postSelection)
+    );
+
+    postSelection();
+
+    return () => {
+      subscriptions.forEach(sub => sub?.unsubscribe?.());
+    };
+  }, [ExtensionDependenciesLoaded, studyInstanceUIDs, viewportGridService, displaySetService]);
 
   useEffect(() => {
     if (!layoutTemplateData.current || !ExtensionDependenciesLoaded || !studyInstanceUIDs?.length) {


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] OS: <!--[e.g. Windows 10, macOS 10.15.4]-->
- [] Node version: <!--[e.g. 18.16.1]-->
- [] Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an iframe-to-parent communication bridge that forwards the active OHIF selection (study UID and series UID) to an embedding parent application, and redirects local DICOMWeb traffic through a custom proxy on port 3001. While the core idea of syncing selection state to a parent frame is sound, the implementation has several notable issues that need addressing before merging.

**Key changes:**
- `local_orthanc.js`: Replaces standard `http://localhost/dicom-web` Orthanc endpoints with a hardcoded personal proxy at `http://127.0.0.1:3001/api/orthanc/...` — **this will break local Orthanc setup for all other contributors**
- `index.js`: Adds `setupParentSelectionBridge()` which monkey-patches `window.history` and polls every 1.2 s to send `OHIF_SELECTION` messages to a parent iframe; the `setInterval` is never cleared
- `Mode.tsx`: Adds a `useEffect` that subscribes to viewport grid/display-set events and posts richer `OHIF_SELECTION` messages (including `seriesInstanceUID`) — but creates a duplicate message stream conflicting with the one in `index.js`

**Issues found:**
- `local_orthanc.js` hardcodes a non-standard proxy that is specific to one developer's environment and will break other contributors' setups
- Both `index.js` and `Mode.tsx` independently emit `type: 'OHIF_SELECTION'` messages, so the parent app receives duplicate and potentially conflicting events on every navigation
- The `setInterval` fallback in `index.js` is never cleared — a permanent resource leak
- `postMessage` uses `'*'` as the target origin in both files, which can leak DICOM study UIDs to any malicious host page embedding the viewer
- The message payload in `Mode.tsx` uses plural field names (`studyInstanceUIDs`, `seriesInstanceUIDs`) but sets them to single strings, creating an inconsistent API contract for the parent consumer

<h3>Confidence Score: 1/5</h3>

- Not safe to merge — the config change breaks the shared local dev setup, and the dual-bridge design creates duplicate messages with a security concern.
- Three files each have at least one blocking issue: `local_orthanc.js` commits a personal proxy URL that will break other contributors' environments; `index.js` introduces a permanent uncleared interval and duplicates the message type already emitted by `Mode.tsx`; and both JavaScript files use `postMessage('*')` which leaks DICOM metadata to any embedding origin. None of the checklist items in the PR template are ticked, and no context, screenshots, or testing instructions are provided.
- `platform/app/public/config/local_orthanc.js` (breaks shared config), `platform/app/src/index.js` (resource leak + duplicate messages + security), `platform/app/src/routes/Mode/Mode.tsx` (security + naming inconsistency)

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| platform/app/src/index.js | Adds `setupParentSelectionBridge()` to forward navigation events to an iframe parent via `postMessage`. Three issues: the `setInterval` fallback is never cleared (resource leak), the target origin is `'*'` (information disclosure), and it duplicates the `OHIF_SELECTION` message type that `Mode.tsx` now also emits with richer data. |
| platform/app/src/routes/Mode/Mode.tsx | Adds a `useEffect` that subscribes to viewport/display-set changes and posts the active study+series selection to a parent iframe via `postMessage`. The subscription cleanup is correct. Main concerns are `'*'` target origin and confusingly plural field names holding single string values. |
| platform/app/public/config/local_orthanc.js | Replaces the standard `http://localhost/dicom-web` DICOMWeb endpoints with a personal proxy at `http://127.0.0.1:3001/api/orthanc/...`. This breaks the shared local dev configuration for all other contributors who do not have this proxy running. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Parent as Parent App (iframe host)
    participant IndexJS as index.js bridge<br/>(setupParentSelectionBridge)
    participant ModeRoute as Mode.tsx useEffect<br/>(viewport subscription)
    participant VGS as viewportGridService
    participant DSS as displaySetService

    Note over IndexJS: Runs once at bootstrap.<br/>Patches pushState/replaceState.<br/>Starts setInterval(1200ms) — never cleared.

    Parent->>IndexJS: (embeds OHIF in iframe)
    IndexJS-->>Parent: postMessage OHIF_SELECTION<br/>{studyInstanceUIDs, href} target='*'

    Note over ModeRoute: Runs after ExtensionDependenciesLoaded<br/>+ studyInstanceUIDs are set.

    ModeRoute->>VGS: subscribe(ACTIVE_VIEWPORT_ID_CHANGED)
    ModeRoute->>VGS: subscribe(GRID_STATE_CHANGED)
    ModeRoute->>DSS: subscribe(DISPLAY_SETS_CHANGED)
    ModeRoute->>VGS: getState() → activeViewport
    VGS-->>ModeRoute: gridState
    ModeRoute->>DSS: getDisplaySetByUID(displaySetUID)
    DSS-->>ModeRoute: displaySet {StudyInstanceUID, SeriesInstanceUID}
    ModeRoute-->>Parent: postMessage OHIF_SELECTION<br/>{studyInstanceUIDs (single string),<br/>seriesInstanceUIDs (single string), href}<br/>target='*'

    Note over Parent: Receives TWO OHIF_SELECTION messages<br/>per navigation — first from index.js,<br/>then from Mode.tsx.
```

<sub>Last reviewed commit: b911efb</sub>

> Greptile also left **6 inline comments** on this PR.

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->