### PR TITLE
fix(measurements): read displayName in SplineROI and PlanarFreehandROI reports

### DIFF
--- a/extensions/cornerstone/src/utils/measurementServiceMappings/PlanarFreehandROI.ts
+++ b/extensions/cornerstone/src/utils/measurementServiceMappings/PlanarFreehandROI.ts
@@ -96,7 +96,7 @@ function getMappedAnnotations(annotation, displaySetService) {
   const { cachedStats } = data;
   const { referencedImageId } = metadata;
 
-  if( !cachedStats ) {
+  if (!cachedStats) {
     return;
   }
 
@@ -160,8 +160,8 @@ function getColumnValueReport(annotation, customizationService) {
   const { metadata, data } = annotation;
   const stats = data.cachedStats[`imageId:${metadata.referencedImageId}`];
 
-  report.forEach(({ name, value }) => {
-    columns.push(name);
+  report.forEach(({ displayName, value }) => {
+    columns.push(displayName);
     stats[value] ? values.push(stats[value]) : values.push('not available');
   });
 

--- a/extensions/cornerstone/src/utils/measurementServiceMappings/SplineROI.ts
+++ b/extensions/cornerstone/src/utils/measurementServiceMappings/SplineROI.ts
@@ -158,8 +158,8 @@ function getColumnValueReport(annotation, customizationService) {
   const { metadata, data } = annotation;
   const stats = data.cachedStats[`imageId:${metadata.referencedImageId}`];
 
-  report.forEach(({ name, value }) => {
-    columns.push(name);
+  report.forEach(({ displayName, value }) => {
+    columns.push(displayName);
     stats[value] ? values.push(stats[value]) : values.push('not available');
   });
 


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

Related to issue #5588 

- `getColumnValueReport` in `PlanarFreehandROI.ts` and `SplineROI.ts` was destructuring `{ name, value }` from each report config item, but the `cornerstone.measurements` customization schema defines `displayName`, not `name`.
- This caused all measurement-specific column headers (Mean, Max, Area, Unit) not to be read in downloaded CSV reports.



<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

- `PlanarFreehandROI.ts` — changed `{ name, value }` → `{ displayName, value }` in `getColumnValueReport`
- `SplineROI.ts` — same fix

**Before**
The report were missing some entries like:
- `Area` and `Unit` for SplineROI 
- `Mean`, `Max`,  `Area` and `Unit` for PlanarFreehandROI

**After**
The report has all the missing fields above. 

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing
1. Open a study in the viewer mode
2. Draw a PlanarFreehandROI annotation on an image
3. Draw a SplineROI annotation on an image  
4. Open the measurement panel 
5. Download the CSV report from the measurements panel
6. Verify column headers (Mean, Max, Area, Unit) are correctly labelled

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] OS: <!--[e.g. Windows 10, macOS 10.15.4]-->
- [] Node version: <!--[e.g. 18.16.1]-->
- [] Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where `getColumnValueReport` in `PlanarFreehandROI.ts` and `SplineROI.ts` destructured `{ name, value }` from customization report config items, but the `cornerstone.measurements` customization schema (defined in `measurementsCustomization.ts`) uses `displayName`, not `name`. Because `name` was always `undefined`, the `downloadCSVReport` logic in `platform/core/src/utils/downloadCSVReport.js` was collapsing all measurement-specific columns (Mean, Max, Area, Unit) into a single column named `undefined` — with each subsequent value overwriting the previous one. The fix correctly aligns the destructuring key to `displayName`, so each statistic gets its own properly labelled CSV column.

- Both `PlanarFreehandROI.ts` and `SplineROI.ts` now destructure `{ displayName, value }` in `getColumnValueReport`, consistent with the `cornerstone.measurements` schema.
- The change is minimal, surgical, and consistent with how other measurement tool mappings (e.g. `CircleROI.ts`) build their column lists.
- A minor whitespace cleanup (`if( !cachedStats )` → `if (!cachedStats)`) is included in `PlanarFreehandROI.ts`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — the fix is minimal, correct, and directly matches the existing customization schema definition.
- The root cause (schema uses `displayName`, not `name`) is clearly confirmed by `measurementsCustomization.ts`. The downstream `downloadCSVReport.js` logic relies on column names being meaningful strings for `Array.includes` / `Array.indexOf` lookups, so the fix unblocks the correct CSV output. No new logic is introduced and no regressions are expected.
- No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| extensions/cornerstone/src/utils/measurementServiceMappings/PlanarFreehandROI.ts | Correctly renames `name` → `displayName` in `getColumnValueReport` to match the `cornerstone.measurements` customization schema. Includes a minor whitespace cleanup (`if( !cachedStats )` → `if (!cachedStats)`). |
| extensions/cornerstone/src/utils/measurementServiceMappings/SplineROI.ts | Correctly renames `name` → `displayName` in `getColumnValueReport`, mirroring the same fix applied to PlanarFreehandROI.ts. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant MeasurementsPanel
    participant downloadCSVReport
    participant getColumnValueReport
    participant measurementsCustomization

    User->>MeasurementsPanel: Click "Download CSV"
    MeasurementsPanel->>downloadCSVReport: measurementData[]
    loop For each measurement
        downloadCSVReport->>getColumnValueReport: annotation, customizationService
        getColumnValueReport->>measurementsCustomization: getCustomization('cornerstone.measurements')
        measurementsCustomization-->>getColumnValueReport: report: [{ displayName, value }]
        Note over getColumnValueReport: Before fix: destructured { name } → undefined<br/>After fix: destructured { displayName } → 'Mean','Max','Area','Unit'
        getColumnValueReport-->>downloadCSVReport: { columns: ['AnnotationType','Mean',...], values: [...] }
    end
    downloadCSVReport->>downloadCSVReport: Build column index map
    downloadCSVReport->>User: MeasurementReport.csv with correct headers
```

<sub>Last reviewed commit: ["fix(measurements): r..."](https://github.com/ohif/viewers/commit/0ce954940eda184773fef4cca7749469b48c183f)</sub>

<!-- /greptile_comment -->