### PR TITLE
Custom ahi extension

### DIFF
--- a/.webpack/webpack.base.js
+++ b/.webpack/webpack.base.js
@@ -65,16 +65,50 @@ module.exports = (env, argv, { SRC_DIR, ENTRY }) => {
 
   const config = {
     mode: isProdBuild ? 'production' : 'development',
-    devtool: isProdBuild ? 'source-map' : 'cheap-module-source-map',
+    devtool: isProdBuild ? 'nosources-source-map' : 'cheap-module-source-map',
     entry: ENTRY,
     optimization: {
-      // splitChunks: {
-      //   // include all types of chunks
-      //   chunks: 'all',
-      // },
-      //runtimeChunk: 'single',
+      splitChunks: {
+        chunks: 'all',
+        maxSize: 6 * 1024 * 1024, // 6MB max chunk size
+        minSize: 20000, // 20KB min size
+        maxAsyncRequests: 30,
+        maxInitialRequests: 30,
+        cacheGroups: {
+          cornerstone: {
+            test: /[\\/]node_modules[\\/](@cornerstonejs|cornerstone)/,
+            name: 'vendor-cornerstone',
+            chunks: 'all',
+            priority: 20,
+          },
+          react: {
+            test: /[\\/]node_modules[\\/](react|react-dom|react-router)/,
+            name: 'vendor-react',
+            chunks: 'all',
+            priority: 15,
+          },
+          dcmjs: {
+            test: /[\\/]node_modules[\\/](dcmjs|dicom-parser)/,
+            name: 'vendor-dicom',
+            chunks: 'all',
+            priority: 15,
+          },
+          vendors: {
+            test: /[\\/]node_modules[\\/]/,
+            name: 'vendors',
+            chunks: 'all',
+            priority: 10,
+          },
+          default: {
+            minChunks: 2,
+            priority: -20,
+            reuseExistingChunk: true,
+          },
+        },
+      },
+      runtimeChunk: 'single',
       minimize: isProdBuild,
-      sideEffects: false,
+      sideEffects: true,
     },
     output: {
       // clean: true,
@@ -101,31 +135,31 @@ module.exports = (env, argv, { SRC_DIR, ENTRY }) => {
         ...(isProdBuild
           ? []
           : [
-              ...(IS_COVERAGE
-                ? [
-                    {
-                      test: /\.[jt]sx?$/,
-                      exclude: /node_modules/,
-                      use: {
-                        loader: 'babel-loader',
-                        options: {
-                          presets: ['@babel/preset-typescript', '@babel/preset-react'],
-                          plugins: ['istanbul'],
-                        },
-                      },
+            ...(IS_COVERAGE
+              ? [
+                {
+                  test: /\.[jt]sx?$/,
+                  exclude: /node_modules/,
+                  use: {
+                    loader: 'babel-loader',
+                    options: {
+                      presets: ['@babel/preset-typescript', '@babel/preset-react'],
+                      plugins: ['istanbul'],
                     },
-                  ]
-                : [
-                    {
-                      test: /\.[jt]sx?$/,
-                      exclude: /node_modules/,
-                      loader: 'babel-loader',
-                      options: {
-                        plugins: isProdBuild ? [] : ['react-refresh/babel'],
-                      },
-                    },
-                  ]),
-            ]),
+                  },
+                },
+              ]
+              : [
+                {
+                  test: /\.[jt]sx?$/,
+                  exclude: /node_modules/,
+                  loader: 'babel-loader',
+                  options: {
+                    plugins: isProdBuild ? [] : ['react-refresh/babel'],
+                  },
+                },
+              ]),
+          ]),
         {
           test: /\.svg?$/,
           oneOf: [
@@ -238,7 +272,17 @@ module.exports = (env, argv, { SRC_DIR, ENTRY }) => {
     config.optimization.minimizer = [
       new TerserJSPlugin({
         parallel: true,
-        terserOptions: {},
+        terserOptions: {
+          compress: {
+            drop_console: false,
+            drop_debugger: true,
+          },
+          mangle: true,
+          output: {
+            comments: false,
+          },
+        },
+        extractComments: false,
       }),
     ];
   }

--- a/extensions/default/src/DicomWebDataSource/index.ts
+++ b/extensions/default/src/DicomWebDataSource/index.ts
@@ -440,7 +440,6 @@ function createDicomWebApi(dicomWebConfig: DicomWebConfig, servicesManager) {
     ) => {
       const enableStudyLazyLoad = false;
       wadoDicomWebClient.headers = generateWadoHeader(excludeTransferSyntax);
-      qidoDicomWebClient.headers = getAuthorizationHeader();
       // data is all SOPInstanceUIDs
       const data = await retrieveStudyMetadata(
         wadoDicomWebClient,
@@ -449,8 +448,7 @@ function createDicomWebApi(dicomWebConfig: DicomWebConfig, servicesManager) {
         filters,
         sortCriteria,
         sortFunction,
-        dicomWebConfig,
-        qidoDicomWebClient
+        dicomWebConfig
       );
 
       // first naturalize the data
@@ -516,7 +514,6 @@ function createDicomWebApi(dicomWebConfig: DicomWebConfig, servicesManager) {
     ) => {
       const enableStudyLazyLoad = true;
       wadoDicomWebClient.headers = generateWadoHeader(excludeTransferSyntax);
-      qidoDicomWebClient.headers = getAuthorizationHeader();
       // Get Series
       const { preLoadData: seriesSummaryMetadata, promises: seriesPromises } =
         await retrieveStudyMetadata(
@@ -526,8 +523,7 @@ function createDicomWebApi(dicomWebConfig: DicomWebConfig, servicesManager) {
           filters,
           sortCriteria,
           sortFunction,
-          dicomWebConfig,
-          qidoDicomWebClient
+          dicomWebConfig
         );
 
       /**

--- a/extensions/default/src/DicomWebDataSource/retrieveStudyMetadata.js
+++ b/extensions/default/src/DicomWebDataSource/retrieveStudyMetadata.js
@@ -25,8 +25,7 @@ export function retrieveStudyMetadata(
   filters,
   sortCriteria,
   sortFunction,
-  dicomWebConfig = {},
-  qidoClient = null
+  dicomWebConfig = {}
 ) {
   // @TODO: Whenever a study metadata request has failed, its related promise will be rejected once and for all
   // and further requests for that metadata will always fail. On failure, we probably need to remove the
@@ -55,8 +54,7 @@ export function retrieveStudyMetadata(
       enableStudyLazyLoad,
       filters,
       sortCriteria,
-      sortFunction,
-      qidoClient
+      sortFunction
     );
   } else {
     // Create a promise to handle the data retrieval
@@ -67,8 +65,7 @@ export function retrieveStudyMetadata(
         enableStudyLazyLoad,
         filters,
         sortCriteria,
-        sortFunction,
-        qidoClient
+        sortFunction
       ).then(function (data) {
         resolve(data);
       }, reject);

--- a/extensions/default/src/DicomWebDataSource/utils/retrieveMetadataFiltered.js
+++ b/extensions/default/src/DicomWebDataSource/utils/retrieveMetadataFiltered.js
@@ -19,8 +19,7 @@ function retrieveMetadataFiltered(
   enableStudyLazyLoad,
   filters,
   sortCriteria,
-  sortFunction,
-  qidoClient = null
+  sortFunction
 ) {
   const { seriesInstanceUID } = filters;
 
@@ -36,8 +35,7 @@ function retrieveMetadataFiltered(
         enableStudyLazyLoad,
         seriesSpecificFilters,
         sortCriteria,
-        sortFunction,
-        qidoClient
+        sortFunction
       );
     });
 

--- a/extensions/default/src/DicomWebDataSource/wado/retrieveMetadata.js
+++ b/extensions/default/src/DicomWebDataSource/wado/retrieveMetadata.js
@@ -21,8 +21,7 @@ async function RetrieveMetadata(
   enableStudyLazyLoad,
   filters = {},
   sortCriteria,
-  sortFunction,
-  qidoClient = null
+  sortFunction
 ) {
   const RetrieveMetadataLoader =
     enableStudyLazyLoad !== false ? RetrieveMetadataLoaderAsync : RetrieveMetadataLoaderSync;
@@ -32,8 +31,7 @@ async function RetrieveMetadata(
     StudyInstanceUID,
     filters,
     sortCriteria,
-    sortFunction,
-    qidoClient
+    sortFunction
   );
   const data = await retrieveMetadataLoader.execLoad();
 

--- a/extensions/default/src/DicomWebDataSource/wado/retrieveMetadataLoader.js
+++ b/extensions/default/src/DicomWebDataSource/wado/retrieveMetadataLoader.js
@@ -20,15 +20,13 @@ export default class RetrieveMetadataLoader {
     studyInstanceUID,
     filters = {},
     sortCriteria = undefined,
-    sortFunction = undefined,
-    qidoClient = null
+    sortFunction = undefined
   ) {
     this.client = client;
     this.studyInstanceUID = studyInstanceUID;
     this.filters = filters;
     this.sortCriteria = sortCriteria;
     this.sortFunction = sortFunction;
-    this.qidoClient = qidoClient || client;
   }
 
   async execLoad() {

--- a/extensions/default/src/DicomWebDataSource/wado/retrieveMetadataLoaderAsync.js
+++ b/extensions/default/src/DicomWebDataSource/wado/retrieveMetadataLoaderAsync.js
@@ -94,8 +94,7 @@ export default class RetrieveMetadataLoaderAsync extends RetrieveMetadataLoader 
    */
   *getPreLoaders() {
     const preLoaders = [];
-    const { studyInstanceUID, filters: { seriesInstanceUID } = {} } = this;
-    const qidoClient = this.qidoClient;
+    const { studyInstanceUID, filters: { seriesInstanceUID } = {}, client } = this;
 
     // asking to include Series Date, Series Time, Series Description
     // and Series Number in the series metadata returned to better sort series
@@ -109,10 +108,10 @@ export default class RetrieveMetadataLoaderAsync extends RetrieveMetadataLoader 
 
     if (seriesInstanceUID) {
       options.queryParams.SeriesInstanceUID = seriesInstanceUID;
-      preLoaders.push(qidoClient.searchForSeries.bind(qidoClient, options));
+      preLoaders.push(client.searchForSeries.bind(client, options));
     }
     // Fallback preloader
-    preLoaders.push(qidoClient.searchForSeries.bind(qidoClient, options));
+    preLoaders.push(client.searchForSeries.bind(client, options));
 
     yield* preLoaders;
   }

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "babel-loader": "8.4.1",
     "babel-plugin-istanbul": "7.0.1",
     "babel-plugin-transform-import-meta": "2.3.3",
+    "compression-webpack-plugin": "^12.0.0",
     "cross-env": "7.0.3",
     "css-loader": "6.11.0",
     "cypress": "14.5.2",

--- a/platform/app/.webpack/webpack.pwa.js
+++ b/platform/app/.webpack/webpack.pwa.js
@@ -131,15 +131,15 @@ module.exports = (env, argv) => {
       ...(IS_COVERAGE
         ? []
         : [
-            new InjectManifest({
-              swDest: 'sw.js',
-              swSrc: path.join(SRC_DIR, 'service-worker.js'),
-              // Need to exclude the theme as it is updated independently
-              exclude: [/theme/],
-              // Cache large files for the manifests to avoid warning messages
-              maximumFileSizeToCacheInBytes: 1024 * 1024 * 50,
-            }),
-          ]),
+          new InjectManifest({
+            swDest: 'sw.js',
+            swSrc: path.join(SRC_DIR, 'service-worker.js'),
+            // Need to exclude the theme as it is updated independently
+            exclude: [/theme/],
+            // Cache large files for the manifests to avoid warning messages
+            maximumFileSizeToCacheInBytes: 1024 * 1024 * 50,
+          }),
+        ]),
     ],
     // https://webpack.js.org/configuration/dev-server/
     devServer: {

--- a/platform/app/package.json
+++ b/platform/app/package.json
@@ -49,9 +49,6 @@
     "README.md"
   ],
   "dependencies": {
-    "@aws-crypto/sha256-js": "^5.2.0",
-    "@aws-sdk/protocol-http": "^3.374.0",
-    "@aws-sdk/signature-v4": "^3.374.0",
     "@babel/runtime": "7.28.2",
     "@cornerstonejs/codec-charls": "1.2.3",
     "@cornerstonejs/codec-libjpeg-turbo-8bit": "1.2.2",

--- a/platform/app/public/config/ahi-sigv4.js
+++ b/platform/app/public/config/ahi-sigv4.js
@@ -47,7 +47,7 @@ window.config = {
     // Enable/disable AHI plugin loading
     enabled: true,
     // URL to the AHI plugin script (can be external URL or relative path)
-    pluginUrl: '/plugins/ahi/ahi-plugin.js',
+    pluginUrl: '/viewer/plugins/ahi/ahi-plugin.js',
     // Default AWS region - can be overridden via URL params
     defaultRegion: 'us-east-1',
     // Credential refresh buffer in seconds (refresh 10s before expiration)

--- a/yarn.lock
+++ b/yarn.lock
@@ -7713,6 +7713,14 @@ compressible@~2.0.18:
   dependencies:
     mime-db ">= 1.43.0 < 2"
 
+compression-webpack-plugin@^12.0.0:
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/compression-webpack-plugin/-/compression-webpack-plugin-12.0.0.tgz#6842bb3720407afb0686500411c765c37f37164d"
+  integrity sha512-LR4mS19Jqq41XfA3xVMLrtzVNzqJbUHdzPeLRfQoLiAS9s87f0021fDuU89xxVQFcB6d20ufBkv4j1rQ4OowHw==
+  dependencies:
+    schema-utils "^4.2.0"
+    serialize-javascript "^7.0.3"
+
 compression@1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/compression/-/compression-1.8.1.tgz#4a45d909ac16509195a9a28bd91094889c180d79"
@@ -17912,6 +17920,11 @@ serialize-javascript@^6.0.0, serialize-javascript@^6.0.2:
   integrity sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==
   dependencies:
     randombytes "^2.1.0"
+
+serialize-javascript@^7.0.3:
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-7.0.4.tgz#c517735bd5b7631dd1fc191ee19cbb713ff8e05c"
+  integrity sha512-DuGdB+Po43Q5Jxwpzt1lhyFSYKryqoNjQSA9M92tyw0lyHIOur+XCalOUe0KTJpyqzT8+fQ5A0Jf7vCx/NKmIg==
 
 serve-handler@6.1.6:
   version "6.1.6"


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] OS: <!--[e.g. Windows 10, macOS 10.15.4]-->
- [] Node version: <!--[e.g. 18.16.1]-->
- [] Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a custom AWS HealthImaging (AHI) extension for the OHIF Viewer, consisting of a dynamic plugin loader (`pluginLoader.js`), an AHI-specific SigV4 signing plugin (`ahi-plugin.js`), and a new AHI config file (`ahi-sigv4.js`). The plugin intercepts all outgoing HTTP requests matching AHI hostnames and signs them using AWS SigV4 before forwarding, supporting both direct-credential and backend-fetch credential modes.

Key concerns found during review:

- **Breaking change to `default.js`**: The standard OHIF default configuration was completely replaced with AHI-specific settings (empty endpoint URLs, `showStudyList: false`, `defaultDataSourceName: 'ahi'`). This breaks the default OHIF viewer for all non-AHI users. A separate config file (`ahi-sigv4.js`) already exists for this purpose — the `default.js` changes should be reverted.
- **Credentials in URL query parameters**: The documented "Mode 1" passes `accessKeyId`, `secretAccessKey`, and `sessionToken` directly in the URL, exposing them in browser history, server logs, and referrer headers — a critical concern in a HIPAA/medical context.
- **External CDN loading without SRI**: The plugin dynamically loads `@aws-sdk` packages from `unpkg.com` at runtime without Subresource Integrity verification, introducing a supply chain attack surface in a medical imaging application.
- **Broken XHR override semantics**: `XMLHttpRequest.prototype.send` is overridden to perform async signing, but the actual `send` is dispatched asynchronously via `.then()`. Code that expects synchronous XHR send behaviour (e.g., calling `.abort()` immediately after `.send()`) will break.
- **`sideEffects: true` in webpack**: Disables global tree-shaking, increasing production bundle sizes.
- **Documentation without implementation**: `support-philips-dicomweb-server.md` documents changes to QIDO/WADO client separation that are not present in this PR's diff.

<h3>Confidence Score: 1/5</h3>

- Not safe to merge — replaces the default OHIF config, introduces credential-in-URL security risk, and loads unverified external scripts in a medical imaging context.
- Multiple high-severity issues: (1) `default.js` is completely overwritten, breaking the standard viewer for all non-AHI deployments; (2) credentials are transmitted via URL parameters in a HIPAA-sensitive application; (3) AWS SDK loaded from an external CDN without integrity verification; (4) XHR prototype override breaks synchronous send semantics. The webpack `sideEffects` regression further increases bundle sizes. Each of these issues independently warrants blocking the PR.
- `platform/app/public/config/default.js` (breaking change), `platform/app/public/plugins/ahi/ahi-plugin.js` (security: CDN loading + XHR override), `platform/app/public/config/ahi-sigv4.js` (security: credentials in URL), `.webpack/webpack.base.js` (sideEffects regression)

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| platform/app/public/plugins/ahi/ahi-plugin.js | New 862-line AHI plugin that monkey-patches global `fetch` and `XMLHttpRequest` for SigV4 signing. Critical issues: AWS SDK loaded from external CDN without SRI integrity checks; XHR `send` override breaks synchronous semantics; credentials exposed in URLs. |
| platform/app/public/config/default.js | The entire default OHIF configuration was replaced with AHI-specific settings. `showStudyList` set to `false`, all standard data sources removed, `defaultDataSourceName` changed to `'ahi'` with empty endpoint URLs — this breaks the standard OHIF viewer for all non-AHI deployments. |
| platform/app/public/config/ahi-sigv4.js | New AHI-specific config with two authentication modes. Mode 1 passes AWS credentials directly as URL query parameters, which is a security concern. The structure and intent are sound, but the credential delivery mechanism should be revised. |
| platform/app/src/utils/pluginLoader.js | New generic plugin loader that dynamically loads external scripts. AHI plugin loading is opt-out (`enabled !== false`) rather than opt-in, which could allow URL-parameter-driven plugin loading on any deployment without explicit configuration. |
| .webpack/webpack.base.js | Adds vendor chunk splitting and `runtimeChunk: 'single'` (good for caching). However, `sideEffects` was flipped from `false` to `true`, which disables tree-shaking globally and will increase bundle sizes. `devtool` changed to `nosources-source-map` in production (hides source). |
| platform/app/src/index.js | Minimal change — adds `await loadPlugins(window.config)` before the app bootstraps. The async/await plumbing is correct and the change is non-breaking for deployments without plugins configured. |
| extensions/default/src/DicomWebDataSource/index.ts | Cosmetic-only changes: whitespace fix around `HeadersInterface` import and spacing in `includeTransferSyntax !== false` comparison. No functional changes. |
| extensions/default/src/DicomWebDataSource/wado/retrieveMetadataLoader.js | Cosmetic-only reformatting of empty async method bodies (`{}` → `{ }`). No functional changes. |
| platform/app/.webpack/webpack.pwa.js | Indentation-only reformatting of `InjectManifest` plugin block. No functional changes. |
| support-philips-dicomweb-server.md | New documentation file describing changes to support Philips DICOMweb server's separate QIDO/WADO URL paths. The described code changes (passing `qidoClient` through the metadata retrieval stack) are not present in this PR's diff — the documented changes appear to be in files not included in this PR. |
| package.json | Adds `compression-webpack-plugin@^12.0.0` as a dev dependency. The plugin is added to `package.json` but its usage is not visible in the webpack config changes in this PR. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Browser
    participant PluginLoader as pluginLoader.js
    participant AHIPlugin as ahi-plugin.js
    participant CDN as unpkg.com
    participant BackendAPI as Backend API
    participant AHI as AWS HealthImaging

    Browser->>PluginLoader: loadPlugins(config)
    PluginLoader->>PluginLoader: Check URL params
    PluginLoader->>Browser: inject script tag for ahi-plugin.js
    Browser->>AHIPlugin: Load and execute
    AHIPlugin->>CDN: Load aws-sdk scripts (no SRI)
    CDN-->>AHIPlugin: SDK scripts

    alt Mode 1 - Direct credentials in URL
        AHIPlugin->>Browser: Read credentials from URL params
        AHIPlugin->>AHIPlugin: Build SigV4 signer
    else Mode 2 - Backend credential fetch
        AHIPlugin->>BackendAPI: GET /auth/credentials/orgId
        BackendAPI-->>AHIPlugin: creds plus region plus datastoreId
        AHIPlugin->>AHIPlugin: Build SigV4 signer and schedule refresh
    end

    AHIPlugin->>Browser: Override window.fetch and XHR prototype

    Browser->>AHIPlugin: fetch AHI URL intercepted
    AHIPlugin->>AHIPlugin: Sign request with SigV4
    AHIPlugin->>AHI: Forward signed request
    AHI-->>Browser: DICOM data
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (5)</h3></summary>

1. `platform/app/public/config/default.js`, line 1-111 ([link](https://github.com/ohif/viewers/blob/bfa93e4dd0179b2e0979eff4a405c95242e50b79/platform/app/public/config/default.js#L1-L111)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Default config completely replaced with AHI-specific config**

   The entire `default.js` file — which serves as the primary out-of-the-box configuration for the OHIF Viewer — has been replaced with AHI-specific settings. The original configuration contained:

   - `showStudyList: true` (changed to `false`)
   - Multiple built-in data sources (`ohif`, `ohif2`, `ohif3`, `local5000`, `orthanc`, `dicomwebproxy`)
   - `maxNumRequests`, `multimonitor`, `customizationService`, `groupEnabledModesFirst`, etc.

   After this change, anyone deploying the standard OHIF Viewer without AHI will have a broken default experience (no study list, no standard data sources, `defaultDataSourceName: 'ahi'` points to a source that has empty `qidoRoot`/`wadoRoot`/`wadoUriRoot`).

   If the intent is to add AHI support, consider creating a new config file (e.g., `ahi.js`) rather than overwriting the default. The `ahi-sigv4.js` file added in this same PR already serves this purpose — the `default.js` changes appear redundant and harmful.


2. `platform/app/public/plugins/ahi/ahi-plugin.js`, line 1082-1131 ([link](https://github.com/ohif/viewers/blob/bfa93e4dd0179b2e0979eff4a405c95242e50b79/platform/app/public/plugins/ahi/ahi-plugin.js#L1082-L1131)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`XMLHttpRequest.prototype.send` override breaks synchronous XHR semantics**

   The overridden `send` method fires `originalXHRSend` _asynchronously_ (inside a `.then()`) but returns `undefined` synchronously. The XHR object is therefore in the `OPENED` state when `send()` returns, instead of transitioning to `LOADING` as callers expect.

   Concrete consequences:
   1. Code that calls `xhr.abort()` synchronously after `xhr.send()` will abort the request before it is ever sent, because `originalXHRSend` has not been called yet.
   2. `readyState` listeners that expect `LOADING` immediately after `send()` will not fire in the expected order.
   3. The function returns `undefined` from the outer `send`, swallowing any return value that `originalXHRSend` might produce.

   Also note that if `_signRequestForXHR` rejects, the fallback path calls `originalXHRSend` _anyway_ — with unsigned headers — which will likely result in a `403` from AHI, not a graceful failure.

   The fetch override does not have this problem because `fetch` is already async. XHR is fundamentally synchronous-trigger-based; a truly safe override would need to redesign the signing to work without an async gap, or require callers to use the fetch API instead.


3. `.webpack/webpack.base.js`, line 58-59 ([link](https://github.com/ohif/viewers/blob/bfa93e4dd0179b2e0979eff4a405c95242e50b79/.webpack/webpack.base.js#L58-L59)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`sideEffects: true` disables tree-shaking across the entire application**

   The original setting was `sideEffects: false`, which told webpack that modules in this project have no side effects and enables dead-code elimination (tree-shaking). Changing this to `true` tells webpack that _every_ module _may_ have side effects and therefore none of them can be safely removed.

   For a large application like OHIF that imports from many packages, this will measurably increase the production bundle size. The change appears motivated by the dynamic plugin loading pattern (plugins register themselves as side effects on `window`), but `sideEffects: true` is a global sledgehammer. A more targeted fix would be to set `sideEffects: true` only in the packages or files that genuinely require it, or use the `/*#__PURE__*/` annotation at specific call sites.


4. `platform/app/src/utils/pluginLoader.js`, line 1644 ([link](https://github.com/ohif/viewers/blob/bfa93e4dd0179b2e0979eff4a405c95242e50b79/platform/app/src/utils/pluginLoader.js#L1644)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **AHI plugin loading is opt-out, not opt-in**

   The condition `config?.ahi?.enabled !== false` means:
   - If `config.ahi` is absent entirely → `undefined !== false` → **AHI path is entered**.
   - If `config.ahi.enabled` is not set → `undefined !== false` → **AHI path is entered**.

   Any existing OHIF deployment that does not define `config.ahi` will now evaluate URL parameters (`datastoreId`, `backendUrl`, `orgId`) on every page load. If those params are absent, `hasAHIParams` is false and nothing is loaded — so there's no functional breakage today. However, an attacker who can control URL parameters could potentially trigger plugin loading from an attacker-controlled `pluginUrl`.

   Consider flipping the guard to explicitly opt-in:


5. `platform/app/public/config/ahi-sigv4.js`, line 232-253 ([link](https://github.com/ohif/viewers/blob/bfa93e4dd0179b2e0979eff4a405c95242e50b79/platform/app/public/config/ahi-sigv4.js#L232-L253)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **AWS credentials passed as URL query parameters**

   The documented "Mode 1" instructs callers to place `accessKeyId`, `secretAccessKey`, and `sessionToken` directly in the URL query string. Even for short-lived session credentials this is a significant security risk:

   - URLs are recorded in browser history, server access logs, proxy logs, and CDN logs.
   - If a user bookmarks or shares the link, the credentials are exposed.
   - `Referer` headers can leak the full URL to any third-party resource loaded on the page.
   - Screenshots or screencasts will capture the URL bar.

   In a HIPAA/healthcare context, leaking these credentials could allow an attacker to access protected health information in the AWS HealthImaging datastore.

   A safer approach for client-side credential delivery is to use short-lived tokens delivered via a POST body, `sessionStorage`, or a first-party authentication redirect that never places secrets in the URL.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix: Optimize webpack bundle splitting a..."](https://github.com/ohif/viewers/commit/bfa93e4dd0179b2e0979eff4a405c95242e50b79) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26137409)</sub>

> Greptile also left **1 inline comment** on this PR.

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->