### PR TITLE
fix(docker): pin nginx in the deployment recipes

### DIFF
--- a/platform/app/.recipes/Nginx-Dcm4chee-Keycloak/dockerfile
+++ b/platform/app/.recipes/Nginx-Dcm4chee-Keycloak/dockerfile
@@ -22,7 +22,7 @@ ENV APP_CONFIG=config/docker-nginx-dcm4chee-keycloak.js
 RUN yarn run build
 
 # Stage 2: Setup the NGINX environment with OAuth2 Proxy
-FROM nginx:alpine
+FROM nginx:1.27.1-alpine
 
 # Install dependencies for oauth2-proxy
 RUN apk add --no-cache curl

--- a/platform/app/.recipes/Nginx-Dcm4chee/dockerfile
+++ b/platform/app/.recipes/Nginx-Dcm4chee/dockerfile
@@ -27,7 +27,7 @@ ENV APP_CONFIG=config/docker-nginx-dcm4chee.js
 RUN yarn run build
 
 # # Stage 2: Bundle the built application into a Docker container which runs NGINX using Alpine Linux
-FROM nginx:alpine
+FROM nginx:1.27.1-alpine
 
 # # Create directories for logs and html content if they don't already exist
 RUN mkdir -p /var/log/nginx /var/www/html

--- a/platform/app/.recipes/Nginx-Orthanc-Keycloak/dockerfile
+++ b/platform/app/.recipes/Nginx-Orthanc-Keycloak/dockerfile
@@ -30,7 +30,7 @@ ENV APP_CONFIG=config/docker-nginx-orthanc-keycloak.js
 RUN yarn run build
 
 # Use nginx as the base image
-FROM nginx:alpine
+FROM nginx:1.27.1-alpine
 
 # Install dependencies for oauth2-proxy
 RUN apk add --no-cache curl

--- a/platform/app/.recipes/Nginx-Orthanc/dockerfile
+++ b/platform/app/.recipes/Nginx-Orthanc/dockerfile
@@ -27,7 +27,7 @@ ENV APP_CONFIG=config/docker-nginx-orthanc.js
 RUN yarn run build
 
 # # Stage 2: Bundle the built application into a Docker container which runs NGINX using Alpine Linux
-FROM nginx:alpine
+FROM nginx:1.27.1-alpine
 
 # # Create directories for logs and html content if they don't already exist
 RUN mkdir -p /var/log/nginx /var/www/html


### PR DESCRIPTION
### Context

Fixes #5938.

The nginx-based deployment recipes currently build from `nginx:alpine`, which means they implicitly pick up upstream image changes over time. The report in #5938 shows that this is enough to break the Orthanc and dcm4chee recipes in a way that leaves REST requests hanging and the viewer unable to load studies correctly.

### Changes & Results

This pins the nginx stage in the four affected recipes to `nginx:1.27.1-alpine`:

- `platform/app/.recipes/Nginx-Orthanc/dockerfile`
- `platform/app/.recipes/Nginx-Orthanc-Keycloak/dockerfile`
- `platform/app/.recipes/Nginx-Dcm4chee/dockerfile`
- `platform/app/.recipes/Nginx-Dcm4chee-Keycloak/dockerfile`

The goal here is to make these recipes reproducible again and avoid pulling in a moving nginx base image at build time.

### Testing

I ran `git diff --check`.

I also verified that `nginx:1.27.1-alpine` is still published by checking its image manifest with Docker.

I did not run a full docker compose build for all four recipes in this environment.

### Checklist

#### PR

- [x] My Pull Request title is descriptive, accurate and follows the semantic-release format and guidelines.

#### Code

- [x] My changes are documented where they need to be.

#### Public Documentation Updates

- [x] No public documentation change is required for this fix.

#### Tested Environment

- [x] OS: macOS 26.4
- [x] Node version: v22.21.1
- [x] Browser: Not applicable

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR correctly addresses the reproducibility issue from #5938 by pinning `nginx:alpine` to a specific version across all four deployment recipe Dockerfiles. The fix direction is sound — floating base image tags are a well-known source of silent, hard-to-debug breakage. However, the chosen pinned version `nginx:1.27.1-alpine` (released August 14, 2024) predates the patch for **CVE-2024-7347** by just three weeks — the fix landed in `nginx:1.27.2` on September 4, 2024. Since these are production deployment recipes, bumping to a more recent version (e.g. `nginx:1.27.4-alpine` or the current stable) would achieve reproducibility without shipping a known vulnerability.

- All four affected recipe Dockerfiles are updated: `Nginx-Orthanc`, `Nginx-Dcm4chee`, `Nginx-Orthanc-Keycloak`, `Nginx-Dcm4chee-Keycloak`
- `FROM nginx:alpine` replaced with `FROM nginx:1.27.1-alpine` in each — correct approach, wrong specific version
- `nginx:1.27.1-alpine` is missing the CVE-2024-7347 patch (ngx_http_mp4_module OOB read) — recommend bumping to `nginx:1.27.4-alpine` or the current latest stable before merging

<h3>Confidence Score: 3/5</h3>

Functionally safe to merge; pinning approach is correct but the chosen version carries CVE-2024-7347 — should be bumped before production use

The change is minimal, correct in direction, and does not break any functionality. The only concern is that nginx:1.27.1-alpine predates the CVE-2024-7347 fix by 3 weeks, making it a slightly worse security posture than using a more current pinned version. Bumping to 1.27.4-alpine or later in all four files would raise this to a 5.

All four Dockerfile recipes need their nginx version bumped from 1.27.1-alpine to 1.27.4-alpine (or newer) before these images are deployed.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| platform/app/.recipes/Nginx-Orthanc/dockerfile | Pins nginx:alpine to nginx:1.27.1-alpine; version predates the CVE-2024-7347 patch released in nginx 1.27.2 (Sep 4, 2024) |
| platform/app/.recipes/Nginx-Dcm4chee/dockerfile | Pins nginx:alpine to nginx:1.27.1-alpine; version predates the CVE-2024-7347 patch released in nginx 1.27.2 (Sep 4, 2024) |
| platform/app/.recipes/Nginx-Orthanc-Keycloak/dockerfile | Pins nginx:alpine to nginx:1.27.1-alpine; version predates the CVE-2024-7347 patch released in nginx 1.27.2 (Sep 4, 2024) |
| platform/app/.recipes/Nginx-Dcm4chee-Keycloak/dockerfile | Pins nginx:alpine to nginx:1.27.1-alpine; version predates the CVE-2024-7347 patch released in nginx 1.27.2 (Sep 4, 2024) |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Build Stage\nnode:20.18.1-slim"] --> B["yarn install\n--frozen-lockfile"]
    B --> C["yarn build\nAPP_CONFIG per recipe"]
    C --> D["Runtime Stage\nnginx:1.27.1-alpine ⚠️"]
    D --> E["COPY dist → /var/www/html"]
    E --> F["EXPOSE 80 / 443"]
    F --> G["CMD nginx -g 'daemon off;'"]
```

<sub>Reviews (1): Last reviewed commit: ["fix(docker): pin nginx in the deployment..."](https://github.com/ohif/viewers/commit/3f15e57c96e895f5baba1d71c1fff60a1402992f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27350949)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->