### PR TITLE
fix: Enhance multiframe instance handling and improve instance valida…

### DIFF
--- a/extensions/default/src/getSopClassHandlerModule.js
+++ b/extensions/default/src/getSopClassHandlerModule.js
@@ -48,12 +48,20 @@ function getDisplaySetInfo(instances) {
     let firstTimePointInstances;
 
     if (instances[0].NumberOfFrames > 1 && timePoints.length > 1) {
-      // handle multiframe dynamic volume
-      firstTimePointInstances = timePoints[0].map(imageId => metaData.get('instance', imageId));
+      // Handle multiframe dynamic volumes. Local file frame imageIds do not
+      // always resolve to a frame-level instance object, so keep resolved
+      // entries and fall back to the source multiframe instance when needed.
+      firstTimePointInstances = timePoints[0]
+        .map(imageId => metaData.get('instance', imageId))
+        .filter(Boolean);
+
+      if (!firstTimePointInstances.length) {
+        firstTimePointInstances = [instances[0]];
+      }
     } else {
       // O(n) to convert it into a map and O(1) to find each instance
       instances.forEach(instance => instancesMap.set(instance.imageId, instance));
-      firstTimePointInstances = timePoint.map(imageId => instancesMap.get(imageId));
+      firstTimePointInstances = timePoint.map(imageId => instancesMap.get(imageId)).filter(Boolean);
     }
     displaySetInfo = isDisplaySetReconstructable(firstTimePointInstances, appConfig);
   } else {

--- a/platform/app/src/App.tsx
+++ b/platform/app/src/App.tsx
@@ -184,12 +184,16 @@ App.propTypes = {
   config: PropTypes.oneOfType([
     PropTypes.func,
     PropTypes.shape({
-      routerBasename: PropTypes.string.isRequired,
+      routerBasename: PropTypes.string,
       oidc: PropTypes.array,
       whiteLabeling: PropTypes.object,
       extensions: PropTypes.array,
+      showLoadingIndicator: PropTypes.bool,
+      showStudyList: PropTypes.bool,
+      modes: PropTypes.array,
+      dataSources: PropTypes.array,
     }),
-  ]).isRequired,
+  ]),
   /* Extensions that are "bundled" or "baked-in" to the application.
    * These would be provided at build time as part of they entry point. */
   defaultExtensions: PropTypes.array,

--- a/platform/core/src/utils/isDisplaySetReconstructable.js
+++ b/platform/core/src/utils/isDisplaySetReconstructable.js
@@ -11,12 +11,14 @@ const iopTolerance = 0.01;
  * @param {Object[]} instances An array of `OHIFInstanceMetadata` objects.
  */
 export default function isDisplaySetReconstructable(instances, appConfig) {
-  if (!instances.length) {
+  const definedInstances = instances?.filter(Boolean) || [];
+
+  if (!definedInstances.length) {
     return { value: false };
   }
-  const firstInstance = instances[0];
+  const firstInstance = definedInstances[0];
 
-  const isMultiframe = firstInstance.NumberOfFrames > 1;
+  const isMultiframe = (firstInstance.NumberOfFrames || 0) > 1;
 
   if (appConfig) {
     const rows = toNumber(firstInstance.Rows);
@@ -30,16 +32,16 @@ export default function isDisplaySetReconstructable(instances, appConfig) {
   // in favor of the calculation by metadata (orientation and positions)
 
   // Can't reconstruct if we only have one image.
-  if (!isMultiframe && instances.length === 1) {
+  if (!isMultiframe && definedInstances.length === 1) {
     return { value: false };
   }
 
   // Can't reconstruct if all instances don't have the ImagePositionPatient.
-  if (!isMultiframe && !instances.every(instance => instance.ImagePositionPatient)) {
+  if (!isMultiframe && !definedInstances.every(instance => instance.ImagePositionPatient)) {
     return { value: false };
   }
 
-  const sortedInstances = sortInstancesByPosition(instances);
+  const sortedInstances = sortInstancesByPosition(definedInstances);
 
   return isMultiframe ? processMultiframe(sortedInstances[0]) : processSingleframe(sortedInstances);
 }

--- a/platform/ui-next/src/components/CinePlayer/CinePlayer.tsx
+++ b/platform/ui-next/src/components/CinePlayer/CinePlayer.tsx
@@ -103,9 +103,10 @@ const CinePlayer: React.FC<CinePlayerProps> = ({
             onOpenChange={setPopoverOpen}
           >
             <PopoverTrigger asChild>
-              <Button
-                variant="ghost"
-                className="h-full border-none bg-transparent p-0 hover:bg-transparent"
+              <div
+                role="button"
+                tabIndex={0}
+                className="h-full cursor-pointer border-none bg-transparent p-0"
               >
                 <Numeric.Container
                   mode="stepper"
@@ -129,7 +130,7 @@ const CinePlayer: React.FC<CinePlayerProps> = ({
                     </div>
                   </Numeric.NumberStepper>
                 </Numeric.Container>
-              </Button>
+              </div>
             </PopoverTrigger>
             <PopoverContent
               side="bottom"


### PR DESCRIPTION
…tion

- Updated `getDisplaySetInfo` to ensure local file frame imageIds resolve correctly, falling back to the source multiframe instance when necessary.
- Improved instance filtering in `isDisplaySetReconstructable` to handle undefined instances more robustly.
- Modified `App` prop types to make `routerBasename` optional and added new props for loading indicators and data sources.
- Refactored `CinePlayer` component to replace Button with a div for better accessibility and interaction.

<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] OS: <!--[e.g. Windows 10, macOS 10.15.4]-->
- [] Node version: <!--[e.g. 18.16.1]-->
- [] Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds null-safety fixes for multiframe instance handling (filtering undefined instances, guarding `NumberOfFrames`), relaxes `App` prop requirements, and refactors the `CinePlayer` FPS trigger from a `<Button>` to a `<div role=\"button\">`.

- The `<div role=\"button\">` in `CinePlayer` is missing an `onKeyDown` handler for Enter/Space. Because `<div>` elements don't fire click events on keydown natively and Radix's `PopoverTrigger` relies on that native behavior, keyboard users cannot open the FPS popover — a concrete accessibility regression versus the `<Button>` it replaces.

<h3>Confidence Score: 4/5</h3>

Safe to merge after addressing the missing keyboard handler on the FPS popover trigger in CinePlayer.

The null-safety and prop-type changes are straightforward and correct. The CinePlayer change introduces a P1 accessibility regression by removing native keyboard activation without providing a replacement handler.

platform/ui-next/src/components/CinePlayer/CinePlayer.tsx — missing onKeyDown for keyboard activation of the FPS popover trigger.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| platform/ui-next/src/components/CinePlayer/CinePlayer.tsx | Replaces `<Button>` with `<div role="button" tabIndex={0}>` as PopoverTrigger child, but omits onKeyDown handler — keyboard users cannot activate the FPS popover via Enter/Space. |
| extensions/default/src/getSopClassHandlerModule.js | Adds `.filter(Boolean)` guards for local-file frame imageIds that don't resolve to instance objects, with a fallback to the source multiframe instance when all entries are filtered out. |
| platform/core/src/utils/isDisplaySetReconstructable.js | Adds null-safety via `instances?.filter(Boolean) || []` and guards `NumberOfFrames` against undefined; all logic paths now use `definedInstances`. |
| platform/app/src/App.tsx | Makes `routerBasename` and the top-level `config` prop optional in PropTypes (existing default values already cover the missing-prop case), and adds PropTypes entries for `showLoadingIndicator`, `showStudyList`, `modes`, and `dataSources`. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: platform/ui-next/src/components/CinePlayer/CinePlayer.tsx
Line: 106-133

Comment:
**Missing keyboard activation on `role="button"` div**

Replacing `<Button>` with `<div role="button">` removes native keyboard activation. A `<button>` fires a `click` event on both Enter and Space by default; a `<div>` does not, even with `role="button"` and `tabIndex={0}`. Radix UI's `PopoverTrigger` with `asChild` merges an `onClick` handler onto the child element, but that handler is only invoked on pointer clicks, not keydown events. Keyboard users who tab to this element and press Enter or Space will get no response and cannot open the FPS popover.

An `onKeyDown` handler that calls `setPopoverOpen` when Enter or Space is pressed is needed to restore keyboard accessibility.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: Enhance multiframe instance handlin..."](https://github.com/ohif/viewers/commit/96c40a5a7d8b44d92a5ac9ee81694226b22a9736) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28038016)</sub>

> Greptile also left **1 inline comment** on this PR.

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->