### PR TITLE
fix(defaultRouteInit): defer prior fetches and guard study browser thumbnails

### DIFF
--- a/extensions/default/src/Panels/StudyBrowser/PanelStudyBrowser.tsx
+++ b/extensions/default/src/Panels/StudyBrowser/PanelStudyBrowser.tsx
@@ -521,11 +521,23 @@ function _getComponentType(ds) {
 }
 
 function getImageIdForThumbnail(displaySet, imageIds) {
+  if (!Array.isArray(imageIds) || imageIds.length === 0) {
+    return;
+  }
+
   let imageId;
   if (displaySet.isDynamicVolume) {
-    const timePoints = displaySet.dynamicVolumeInfo.timePoints;
+    const timePoints = displaySet.dynamicVolumeInfo?.timePoints;
+    if (!Array.isArray(timePoints) || timePoints.length === 0) {
+      return;
+    }
+
     const middleIndex = Math.floor(timePoints.length / 2);
     const middleTimePointImageIds = timePoints[middleIndex];
+    if (!Array.isArray(middleTimePointImageIds) || middleTimePointImageIds.length === 0) {
+      return;
+    }
+
     imageId = middleTimePointImageIds[Math.floor(middleTimePointImageIds.length / 2)];
   } else {
     imageId = imageIds[Math.floor(imageIds.length / 2)];

--- a/platform/app/src/routes/Mode/defaultRouteInit.ts
+++ b/platform/app/src/routes/Mode/defaultRouteInit.ts
@@ -72,7 +72,8 @@ async function fetchAndStorePatientStudies(studyInstanceUID: string, dataSource)
 
     let qidoStudiesForPatient = qidoForStudyUID;
     try {
-      qidoStudiesForPatient = await getStudiesForPatientByMRN(dataSource, qidoForStudyUID);
+      qidoStudiesForPatient =
+        (await getStudiesForPatientByMRN(dataSource, qidoForStudyUID)) ?? qidoForStudyUID;
     } catch (error) {
       console.warn('Could not fetch patient studies by MRN:', error);
     }

--- a/platform/app/src/routes/Mode/defaultRouteInit.ts
+++ b/platform/app/src/routes/Mode/defaultRouteInit.ts
@@ -187,11 +187,7 @@ export async function defaultRouteInit(
   unsubscriptions.push(instanceAddedUnsubscribe);
 
   const firstStudyUID = studyInstanceUIDs?.[0];
-  const activeStudyUIDs = studyInstanceUIDs?.length
-    ? studyInstanceUIDs
-    : firstStudyUID
-      ? [firstStudyUID]
-      : [];
+  const activeStudyUIDs = studyInstanceUIDs?.length ? studyInstanceUIDs : [];
   const patientStudiesPromise = firstStudyUID
     ? fetchAndStorePatientStudies(firstStudyUID, dataSource)
     : Promise.resolve([]);
@@ -288,7 +284,6 @@ export async function defaultRouteInit(
     await Promise.allSettled(requiredSeriesPromises);
     applyHangingProtocol();
     startRemainingPromises(remainingPromises);
-    applyHangingProtocol();
   }
 
   const { requiredSeriesPromises, remainingPromises } = await collectSeriesPromises(allRetrieves);
@@ -298,10 +293,8 @@ export async function defaultRouteInit(
   log.time(Enums.TimingEnum.DISPLAY_SETS_TO_ALL_IMAGES);
 
   await Promise.allSettled(requiredSeriesPromises);
-  await patientStudiesPromise;
   applyHangingProtocol();
   startRemainingPromises(remainingPromises);
-  applyHangingProtocol();
 
   void startPriorFetches().catch(error => {
     console.error(error);

--- a/platform/app/src/routes/Mode/defaultRouteInit.ts
+++ b/platform/app/src/routes/Mode/defaultRouteInit.ts
@@ -228,7 +228,7 @@ export async function defaultRouteInit(
     remainingPromises.forEach(p => p.forEach(promise => promise.start()));
   }
 
-  async function collectSeriesPromises(retrieves) {
+  async function collectSeriesPromises(retrieves, { includeDisplaySetFromUrl = false } = {}) {
     const settledRetrieves = await Promise.allSettled(retrieves);
     const requiredSeriesPromises = [];
     const remainingPromises = [];
@@ -238,7 +238,7 @@ export async function defaultRouteInit(
         return;
       }
 
-      if (displaySetFromUrl) {
+      if (includeDisplaySetFromUrl && displaySetFromUrl) {
         requiredSeriesPromises.push(...retrieve.value.map(promise => promise.start()));
         return;
       }
@@ -279,15 +279,18 @@ export async function defaultRouteInit(
       });
     });
 
-    const { requiredSeriesPromises, remainingPromises } =
-      await collectSeriesPromises(priorRetrieves);
+    const { requiredSeriesPromises, remainingPromises } = await collectSeriesPromises(
+      priorRetrieves
+    );
 
     await Promise.allSettled(requiredSeriesPromises);
     applyHangingProtocol();
     startRemainingPromises(remainingPromises);
   }
 
-  const { requiredSeriesPromises, remainingPromises } = await collectSeriesPromises(allRetrieves);
+  const { requiredSeriesPromises, remainingPromises } = await collectSeriesPromises(allRetrieves, {
+    includeDisplaySetFromUrl: true,
+  });
 
   log.timeEnd(Enums.TimingEnum.STUDY_TO_DISPLAY_SETS);
   log.time(Enums.TimingEnum.DISPLAY_SETS_TO_FIRST_IMAGE);

--- a/platform/app/src/routes/Mode/defaultRouteInit.ts
+++ b/platform/app/src/routes/Mode/defaultRouteInit.ts
@@ -5,6 +5,105 @@ import isSeriesFilterUsed from '../../utils/isSeriesFilterUsed';
 const { getSplitParam } = utils;
 
 /**
+ * Gets all studies for a patient by MRN from the first study.
+ */
+async function getStudiesForPatientByMRN(dataSource, qidoForStudyUID) {
+  const mrn = qidoForStudyUID[0]?.mrn;
+  if (!mrn) {
+    return qidoForStudyUID;
+  }
+
+  return dataSource.query.studies.search({ patientId: mrn, disableWildcard: true });
+}
+
+function normalizeModalities(modalities) {
+  if (Array.isArray(modalities)) {
+    return modalities.filter(Boolean);
+  }
+
+  if (typeof modalities === 'string') {
+    return modalities.split('\\').filter(Boolean);
+  }
+
+  return [];
+}
+
+function upsertStudyMetadata(studyMetadata) {
+  const existingStudy = DicomMetadataStore.getStudy(studyMetadata.StudyInstanceUID);
+
+  if (!existingStudy) {
+    DicomMetadataStore.addStudy(studyMetadata);
+    return;
+  }
+
+  const mergedModalities = Array.from(
+    new Set([
+      ...normalizeModalities(existingStudy.ModalitiesInStudy),
+      ...normalizeModalities(studyMetadata.ModalitiesInStudy),
+    ])
+  );
+
+  Object.assign(existingStudy, {
+    PatientID: studyMetadata.PatientID ?? existingStudy.PatientID,
+    PatientName: studyMetadata.PatientName ?? existingStudy.PatientName,
+    StudyDate: studyMetadata.StudyDate ?? existingStudy.StudyDate,
+    StudyTime: studyMetadata.StudyTime ?? existingStudy.StudyTime,
+    StudyDescription: studyMetadata.StudyDescription ?? existingStudy.StudyDescription,
+    ModalitiesInStudy: mergedModalities,
+    AccessionNumber: studyMetadata.AccessionNumber ?? existingStudy.AccessionNumber,
+    NumInstances: studyMetadata.NumInstances ?? existingStudy.NumInstances,
+  });
+}
+
+/**
+ * Fetches all studies for a patient by MRN from the first study
+ * and adds them to the DICOM metadata store.
+ */
+async function fetchAndStorePatientStudies(studyInstanceUID: string, dataSource) {
+  try {
+    const qidoForStudyUID = await dataSource.query.studies.search({
+      studyInstanceUid: studyInstanceUID,
+    });
+
+    if (!qidoForStudyUID?.length) {
+      console.warn('Could not find study:', studyInstanceUID);
+      return [];
+    }
+
+    let qidoStudiesForPatient = qidoForStudyUID;
+    try {
+      qidoStudiesForPatient = await getStudiesForPatientByMRN(dataSource, qidoForStudyUID);
+    } catch (error) {
+      console.warn('Could not fetch patient studies by MRN:', error);
+    }
+
+    const storedStudyUIDs = [];
+
+    qidoStudiesForPatient.forEach(study => {
+      const studyMetadata = {
+        StudyInstanceUID: study.studyInstanceUid,
+        PatientID: study.mrn,
+        PatientName: study.patientName,
+        StudyDate: study.date,
+        StudyTime: study.time,
+        StudyDescription: study.description,
+        ModalitiesInStudy: normalizeModalities(study.modalities),
+        AccessionNumber: study.accession,
+        NumInstances: study.instances,
+      };
+
+      upsertStudyMetadata(studyMetadata);
+      storedStudyUIDs.push(studyMetadata.StudyInstanceUID);
+    });
+
+    return storedStudyUIDs;
+  } catch (error) {
+    console.error('Error fetching patient studies:', error);
+    return [];
+  }
+}
+
+/**
  * Initialize the route.
  *
  * @param props.servicesManager to read services from
@@ -87,10 +186,20 @@ export async function defaultRouteInit(
 
   unsubscriptions.push(instanceAddedUnsubscribe);
 
+  const firstStudyUID = studyInstanceUIDs?.[0];
+  const activeStudyUIDs = studyInstanceUIDs?.length
+    ? studyInstanceUIDs
+    : firstStudyUID
+      ? [firstStudyUID]
+      : [];
+  const patientStudiesPromise = firstStudyUID
+    ? fetchAndStorePatientStudies(firstStudyUID, dataSource)
+    : Promise.resolve([]);
+
   log.time(Enums.TimingEnum.STUDY_TO_DISPLAY_SETS);
   log.time(Enums.TimingEnum.STUDY_TO_FIRST_IMAGE);
 
-  const allRetrieves = studyInstanceUIDs.map(StudyInstanceUID =>
+  const allRetrieves = activeStudyUIDs.map(StudyInstanceUID =>
     dataSource.retrieve.series.metadata({
       StudyInstanceUID,
       filters,
@@ -118,43 +227,84 @@ export async function defaultRouteInit(
     displaySetFromUrl = true;
   }
 
-  await Promise.allSettled(allRetrieves).then(async promises => {
-    log.timeEnd(Enums.TimingEnum.STUDY_TO_DISPLAY_SETS);
-    log.time(Enums.TimingEnum.DISPLAY_SETS_TO_FIRST_IMAGE);
-    log.time(Enums.TimingEnum.DISPLAY_SETS_TO_ALL_IMAGES);
+  function startRemainingPromises(remainingPromises) {
+    remainingPromises.forEach(p => p.forEach(promise => promise.start()));
+  }
 
-    const allPromises = [];
+  async function collectSeriesPromises(retrieves) {
+    const settledRetrieves = await Promise.allSettled(retrieves);
+    const requiredSeriesPromises = [];
     const remainingPromises = [];
 
-    function startRemainingPromises(remainingPromises) {
-      remainingPromises.forEach(p => p.forEach(p => p.start()));
-    }
-
-    promises.forEach(promise => {
-      const retrieveSeriesMetadataPromise = promise.value;
-      if (!Array.isArray(retrieveSeriesMetadataPromise)) {
+    settledRetrieves.forEach(retrieve => {
+      if (retrieve.status !== 'fulfilled' || !Array.isArray(retrieve.value)) {
         return;
       }
 
       if (displaySetFromUrl) {
-        const requiredSeriesPromises = retrieveSeriesMetadataPromise.map(promise =>
-          promise.start()
-        );
-        allPromises.push(Promise.allSettled(requiredSeriesPromises));
-      } else {
-        const { requiredSeries, remaining } = hangingProtocolService.filterSeriesRequiredForRun(
-          hangingProtocolId,
-          retrieveSeriesMetadataPromise
-        );
-        const requiredSeriesPromises = requiredSeries.map(promise => promise.start());
-        allPromises.push(Promise.allSettled(requiredSeriesPromises));
-        remainingPromises.push(remaining);
+        requiredSeriesPromises.push(...retrieve.value.map(promise => promise.start()));
+        return;
       }
+
+      const { requiredSeries, remaining } = hangingProtocolService.filterSeriesRequiredForRun(
+        hangingProtocolId,
+        retrieve.value
+      );
+
+      requiredSeriesPromises.push(...requiredSeries.map(promise => promise.start()));
+      remainingPromises.push(remaining);
     });
 
-    await Promise.allSettled(allPromises).then(applyHangingProtocol);
+    return { requiredSeriesPromises, remainingPromises };
+  }
+
+  async function startPriorFetches() {
+    const patientStudyUIDs = Array.from(new Set(await patientStudiesPromise));
+    const activeStudyUIDSet = new Set(activeStudyUIDs);
+    const priorStudyUIDs = patientStudyUIDs.filter(uid => uid && !activeStudyUIDSet.has(uid));
+
+    if (!priorStudyUIDs.length) {
+      return;
+    }
+
+    const priorRetrieves = priorStudyUIDs.map(StudyInstanceUID =>
+      dataSource.retrieve.series.metadata({
+        StudyInstanceUID,
+        filters,
+        returnPromises: true,
+        sortCriteria: customizationService.getCustomization('sortingCriteria'),
+      })
+    );
+
+    priorRetrieves.forEach(retrieve => {
+      retrieve.catch(error => {
+        console.error(error);
+      });
+    });
+
+    const { requiredSeriesPromises, remainingPromises } =
+      await collectSeriesPromises(priorRetrieves);
+
+    await Promise.allSettled(requiredSeriesPromises);
+    applyHangingProtocol();
     startRemainingPromises(remainingPromises);
     applyHangingProtocol();
+  }
+
+  const { requiredSeriesPromises, remainingPromises } = await collectSeriesPromises(allRetrieves);
+
+  log.timeEnd(Enums.TimingEnum.STUDY_TO_DISPLAY_SETS);
+  log.time(Enums.TimingEnum.DISPLAY_SETS_TO_FIRST_IMAGE);
+  log.time(Enums.TimingEnum.DISPLAY_SETS_TO_ALL_IMAGES);
+
+  await Promise.allSettled(requiredSeriesPromises);
+  await patientStudiesPromise;
+  applyHangingProtocol();
+  startRemainingPromises(remainingPromises);
+  applyHangingProtocol();
+
+  void startPriorFetches().catch(error => {
+    console.error(error);
   });
 
   return unsubscriptions;


### PR DESCRIPTION
### Context

This ports a downstream loading fix that improves the first hanging-protocol application while still pulling prior studies in the background.

The downstream issue had two parts:

- active and prior study retrievals were mixed too early during route initialization, which made the first HP run less predictable
- the Study Browser could throw when a display set had no usable thumbnail image ids

### Changes

- fetch and store patient studies up front, but keep the initial metadata retrieval focused on the active study set
- start prior-study series retrieval only after the first required series have loaded and the initial hanging protocol has been applied
- upsert study metadata in `DicomMetadataStore` instead of assuming a fresh entry every time
- guard Study Browser thumbnail selection for display sets without image ids or dynamic timepoints

### Result

- more stable initial study loading
- priors still get prefetched, but they no longer interfere with the first layout decision
- no Study Browser crash when SR/SEG/RT or other non-thumbnail-ready display sets are present

### Notes

- Opened as a draft because `defaultRouteInit` has been evolving quickly on upstream and I expect architecture-level feedback on the prefetch timing.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restructures `defaultRouteInit` to separate active-study metadata retrieval from patient-history/prior-study fetching, deferring prior retrieves until after the first HP application, and adds defensive null guards to `getImageIdForThumbnail` for display sets that have no image IDs (SR/SEG/RT). The Study Browser guard is clean. The `defaultRouteInit` refactor is directionally correct but has two P2 concerns around prior-study filter leakage and missing cleanup on navigation.

<h3>Confidence Score: 4/5</h3>

Safe to merge with awareness of two P2 concerns; active-study loading and initial HP application are not regressed.

No P0/P1 findings. Two P2 issues: active-study `seriesInstanceUID` filter leaking into prior-study retrieval (silent suppression of prior series when a series filter is set), and a fire-and-forget `startPriorFetches` that lacks a cancellation path on route change.

platform/app/src/routes/Mode/defaultRouteInit.ts — specifically `startPriorFetches` and the `filters` forwarded to prior retrieves.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| platform/app/src/routes/Mode/defaultRouteInit.ts | Introduces `fetchAndStorePatientStudies`, `upsertStudyMetadata`, `collectSeriesPromises`, and `startPriorFetches` to defer prior-study fetching after initial HP application; fire-and-forget prior fetches lack cancellation and the active-study `filters` are forwarded to prior-study retrieval without stripping `seriesInstanceUID`. |
| extensions/default/src/Panels/StudyBrowser/PanelStudyBrowser.tsx | Adds null/empty guards for `imageIds`, `timePoints`, and `middleTimePointImageIds` in `getImageIdForThumbnail`; both call sites already handle an `undefined` return value, so the guards are safe and correct. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
platform/app/src/routes/Mode/defaultRouteInit.ts:267-274
**`filters` applied to prior-study retrieval may suppress all prior series**

`startPriorFetches` passes the same `filters` object as the active-study retrieval. If `filters.seriesInstanceUID` is set (e.g., `?SeriesInstanceUID=1.2.3`), the data source will only try to retrieve that specific series UID from every prior study — UIDs that won't exist in those studies — so each prior study returns zero series. The `collectSeriesPromises` loop then finds nothing, `requiredSeriesPromises` stays empty, and the prior studies silently load no display sets.

Since `seriesInstanceUID` filtering is meaningful only for the active study, passing a separate `filters` object (or stripping `seriesInstanceUID`) for prior retrieves would avoid this silent suppression.

```typescript
const priorFilters = filters
  ? { ...filters, seriesInstanceUID: undefined }
  : filters;

const priorRetrieves = priorStudyUIDs.map(StudyInstanceUID =>
  dataSource.retrieve.series.metadata({
    StudyInstanceUID,
    filters: priorFilters,
    returnPromises: true,
    sortCriteria: customizationService.getCustomization('sortingCriteria'),
  })
);
```

### Issue 2 of 2
platform/app/src/routes/Mode/defaultRouteInit.ts:303-305
**`startPriorFetches` has no cancellation / cleanup on route change**

`startPriorFetches` is fired as a fire-and-forget and is never added to `unsubscriptions`. If the user navigates to a new study before it completes, it continues running in the old closure and will call `applyHangingProtocol()` (line 287) against the shared `hangingProtocolService`/`displaySetService` singletons, potentially re-applying the prior route's HP ID over the new study's layout, and may add stale study metadata to `DicomMetadataStore`.

A cancellation token or an `AbortController`-style flag checked before each `applyHangingProtocol()` call and before each metadata upsert would prevent this cross-route interference.

`````

</details>

<sub>Reviews (4): Last reviewed commit: ["fix(app): limit URL display-set loading ..."](https://github.com/ohif/viewers/commit/65c763d654fbe89032387681c3a07466155c9dac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28947893)</sub>

<!-- /greptile_comment -->