### PR TITLE
fix(configuration): Harden dynamic datasource URL trust boundaries and credential handling. 3.12

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -824,7 +824,7 @@
         "@cornerstonejs/core": "4.15.29",
         "@cornerstonejs/dicom-image-loader": "4.15.29",
         "@ohif/ui": "3.12.0",
-        "cornerstone-math": "0.1.9",
+        "cornerstone-math": "0.1.10",
         "dicom-parser": "1.8.21",
       },
     },

--- a/extensions/default/src/DicomJSONDataSource/index.js
+++ b/extensions/default/src/DicomJSONDataSource/index.js
@@ -4,6 +4,7 @@ import qs from 'query-string';
 
 import getImageId from '../DicomWebDataSource/utils/getImageId';
 import getDirectURL from '../utils/getDirectURL';
+import { resolveConfigFetchPolicy, fetchConfigJson } from '../utils/secureConfigFetch';
 
 const metadataProvider = OHIF.classes.MetadataProvider;
 
@@ -59,13 +60,18 @@ const findStudies = (key, value) => {
   return studies;
 };
 
-function createDicomJSONApi(dicomJsonConfig) {
+function createDicomJSONApi(dicomJsonConfig, servicesManager) {
+  const { userAuthenticationService } = servicesManager.services;
   const implementation = {
     initialize: async ({ query, url }) => {
       if (!url) {
         url = query.get('url');
       }
-      let metaData = getMetaDataByURL(url);
+      const evaluatedUrl = resolveConfigFetchPolicy(url, {
+        allowedOrigins: dicomJsonConfig.dangerouslyAllowedOriginsForAuthenticatedEnvironments,
+        userAuthenticationService,
+      });
+      let metaData = getMetaDataByURL(evaluatedUrl.normalizedUrl);
 
       // if we have already cached the data from this specific url
       // We are only handling one StudyInstanceUID to run; however,
@@ -76,8 +82,7 @@ function createDicomJSONApi(dicomJsonConfig) {
         });
       }
 
-      const response = await fetch(url);
-      const data = await response.json();
+      const data = await fetchConfigJson(evaluatedUrl);
 
       let StudyInstanceUID;
       let SeriesInstanceUID;
@@ -105,11 +110,11 @@ function createDicomJSONApi(dicomJsonConfig) {
       });
 
       _store.urls.push({
-        url,
+        url: evaluatedUrl.normalizedUrl,
         studies: [...data.studies],
       });
       _store.studyInstanceUIDMap.set(
-        url,
+        evaluatedUrl.normalizedUrl,
         data.studies.map(study => study.StudyInstanceUID)
       );
     },
@@ -252,6 +257,8 @@ function createDicomJSONApi(dicomJsonConfig) {
         console.warn(' DICOMJson store dicom not implemented');
       },
     },
+    reject: {},
+    deleteStudyMetadataPromise: () => {},
     getImageIdsForDisplaySet(displaySet) {
       const images = displaySet.images;
       const imageIds = [];
@@ -297,8 +304,21 @@ function createDicomJSONApi(dicomJsonConfig) {
     },
     getStudyInstanceUIDs: ({ params, query }) => {
       const url = query.get('url');
-      return _store.studyInstanceUIDMap.get(url);
+      if (!url) {
+        return;
+      }
+
+      try {
+        const evaluatedUrl = resolveConfigFetchPolicy(url, {
+          allowedOrigins: dicomJsonConfig.dangerouslyAllowedOriginsForAuthenticatedEnvironments,
+          userAuthenticationService,
+        });
+        return _store.studyInstanceUIDMap.get(evaluatedUrl.normalizedUrl);
+      } catch {
+        return;
+      }
     },
+    getConfig: () => dicomJsonConfig,
   };
   return IWebApiDataSource.create(implementation);
 }

--- a/extensions/default/src/DicomWebProxyDataSource/index.ts
+++ b/extensions/default/src/DicomWebProxyDataSource/index.ts
@@ -1,5 +1,6 @@
 import { IWebApiDataSource } from '@ohif/core';
 import { createDicomWebApi } from '../DicomWebDataSource/index';
+import { resolveConfigFetchPolicy, fetchConfigJson } from '../utils/secureConfigFetch';
 
 /**
  * This datasource is initialized with a url that returns a JSON object with a
@@ -11,6 +12,7 @@ import { createDicomWebApi } from '../DicomWebDataSource/index';
  */
 function createDicomWebProxyApi(dicomWebProxyConfig, servicesManager: AppTypes.ServicesManager) {
   const { name } = dicomWebProxyConfig;
+  const { userAuthenticationService } = servicesManager.services;
   let dicomWebDelegate = undefined;
 
   const implementation = {
@@ -20,12 +22,14 @@ function createDicomWebProxyApi(dicomWebProxyConfig, servicesManager: AppTypes.S
       if (!url) {
         throw new Error(`No url for '${name}'`);
       } else {
-        const response = await fetch(url);
-        const data = await response.json();
+        const evaluatedUrl = resolveConfigFetchPolicy(url, {
+          allowedOrigins: dicomWebProxyConfig.dangerouslyAllowedOriginsForAuthenticatedEnvironments,
+          userAuthenticationService,
+        });
+        const data = await fetchConfigJson(evaluatedUrl);
         if (!data.servers?.dicomWeb?.[0]) {
           throw new Error('Invalid configuration returned by url');
         }
-
         dicomWebDelegate = createDicomWebApi(
           data.servers.dicomWeb[0].configuration || data.servers.dicomWeb[0],
           servicesManager
@@ -54,9 +58,16 @@ function createDicomWebProxyApi(dicomWebProxyConfig, servicesManager: AppTypes.S
     store: {
       dicom: (...args) => dicomWebDelegate.store.dicom(...args),
     },
-    deleteStudyMetadataPromise: (...args) => dicomWebDelegate.deleteStudyMetadataPromise(...args),
-    getImageIdsForDisplaySet: (...args) => dicomWebDelegate.getImageIdsForDisplaySet(...args),
-    getImageIdsForInstance: (...args) => dicomWebDelegate.getImageIdsForInstance(...args),
+    reject: {
+      series: (...args) => dicomWebDelegate?.reject?.series?.(...args),
+    },
+    deleteStudyMetadataPromise: (...args) => dicomWebDelegate?.deleteStudyMetadataPromise?.(...args),
+    getImageIdsForDisplaySet: (...args) => dicomWebDelegate?.getImageIdsForDisplaySet?.(...args),
+    getImageIdsForInstance: (...args) => dicomWebDelegate?.getImageIdsForInstance?.(...args),
+    getConfig: (...args) =>
+      dicomWebDelegate?.getConfig?.(...args) ?? {
+        dicomUploadEnabled: false,
+      },
     getStudyInstanceUIDs({ params, query }) {
       let studyInstanceUIDs = [];
 

--- a/extensions/default/src/utils/secureConfigFetch.js
+++ b/extensions/default/src/utils/secureConfigFetch.js
@@ -61,6 +61,7 @@ function resolveConfigFetchPolicy(rawUrl, policy = {}) {
   const { allowedOrigins = [], userAuthenticationService } = policy;
   const parsedUrl = resolveConfigUrl(rawUrl);
   const protocol = parsedUrl.protocol.toLowerCase();
+  const isSameOrigin = parsedUrl.origin === window.location.origin;
 
   if (!['http:', 'https:'].includes(protocol)) {
     throw new Error('Only HTTP(S) URLs are allowed for dynamic datasource configuration');
@@ -78,7 +79,7 @@ function resolveConfigFetchPolicy(rawUrl, policy = {}) {
     userAuthenticationService?.getAuthorizationHeader?.()?.Authorization
   );
 
-  if (isAuthenticated) {
+  if (isAuthenticated && !isSameOrigin) {
     const normalizedAllowedOrigins = normalizeAllowedOrigins(allowedOrigins);
     if (!normalizedAllowedOrigins.length || !normalizedAllowedOrigins.includes(parsedUrl.origin)) {
       throw new Error(
@@ -91,12 +92,13 @@ function resolveConfigFetchPolicy(rawUrl, policy = {}) {
     parsedUrl,
     normalizedUrl: parsedUrl.toString(),
     isAuthenticated,
+    isSameOrigin,
   };
 }
 
 async function fetchConfigJson(normalizedPolicy) {
-  const { normalizedUrl, isAuthenticated } = normalizedPolicy;
-  const response = isAuthenticated
+  const { normalizedUrl, isAuthenticated, isSameOrigin } = normalizedPolicy;
+  const response = isAuthenticated || isSameOrigin
     ? await fetch(normalizedUrl)
     : await fetch(normalizedUrl, {
         method: 'GET',

--- a/extensions/default/src/utils/secureConfigFetch.js
+++ b/extensions/default/src/utils/secureConfigFetch.js
@@ -97,16 +97,14 @@ function resolveConfigFetchPolicy(rawUrl, policy = {}) {
 }
 
 async function fetchConfigJson(normalizedPolicy) {
-  const { normalizedUrl, isAuthenticated, isSameOrigin } = normalizedPolicy;
-  const response = isAuthenticated || isSameOrigin
-    ? await fetch(normalizedUrl)
-    : await fetch(normalizedUrl, {
-        method: 'GET',
-        mode: 'cors',
-        credentials: 'omit',
-        redirect: 'error',
-        referrerPolicy: 'no-referrer',
-      });
+  const { normalizedUrl } = normalizedPolicy;
+  const response = await fetch(normalizedUrl, {
+    method: 'GET',
+    mode: 'cors',
+    credentials: 'same-origin',
+    redirect: 'error',
+    referrerPolicy: 'no-referrer',
+  });
 
   if (!response.ok) {
     throw new Error(`Failed to fetch dynamic datasource configuration (${response.status})`);
@@ -114,7 +112,4 @@ async function fetchConfigJson(normalizedPolicy) {
 
   return response.json();
 }
-export {
-  resolveConfigFetchPolicy,
-  fetchConfigJson,
-};
+export { resolveConfigFetchPolicy, fetchConfigJson };

--- a/extensions/default/src/utils/secureConfigFetch.js
+++ b/extensions/default/src/utils/secureConfigFetch.js
@@ -1,0 +1,118 @@
+// @ts-nocheck
+
+function normalizeAllowedOrigins(allowedOrigins = []) {
+  if (!Array.isArray(allowedOrigins)) {
+    return [];
+  }
+
+  const configuredOrigins = allowedOrigins
+    .filter(origin => typeof origin === 'string')
+    .map(origin => origin.trim())
+    .filter(Boolean);
+
+  return configuredOrigins
+    .map(origin => {
+      try {
+        const parsedOrigin = new URL(origin);
+        if (!['http:', 'https:'].includes(parsedOrigin.protocol)) {
+          console.error(
+            `[secureConfigFetch] Ignoring misconfigured allowed origin "${origin}". ` +
+              'Entries must use http:// or https://.'
+          );
+          return null;
+        }
+        if (
+          parsedOrigin.username ||
+          parsedOrigin.password ||
+          parsedOrigin.pathname !== '/' ||
+          parsedOrigin.search ||
+          parsedOrigin.hash
+        ) {
+          console.error(
+            `[secureConfigFetch] Ignoring misconfigured allowed origin "${origin}". ` +
+              'Entries must be bare origins only (scheme + host + optional port), with no username/password, path, query, or hash.'
+          );
+          return null;
+        }
+        return parsedOrigin.origin;
+      } catch {
+        console.error(
+          `[secureConfigFetch] Ignoring misconfigured allowed origin "${origin}". Entry is not a valid URL.`
+        );
+        return null;
+      }
+    })
+    .filter(Boolean);
+}
+
+function resolveConfigUrl(rawUrl) {
+  if (!rawUrl || typeof rawUrl !== 'string') {
+    throw new Error('Missing required "url" query parameter');
+  }
+
+  try {
+    return new URL(rawUrl, window.location.href);
+  } catch {
+    throw new Error('Invalid URL in "url" query parameter');
+  }
+}
+
+function resolveConfigFetchPolicy(rawUrl, policy = {}) {
+  const { allowedOrigins = [], userAuthenticationService } = policy;
+  const parsedUrl = resolveConfigUrl(rawUrl);
+  const protocol = parsedUrl.protocol.toLowerCase();
+
+  if (!['http:', 'https:'].includes(protocol)) {
+    throw new Error('Only HTTP(S) URLs are allowed for dynamic datasource configuration');
+  }
+
+  if (parsedUrl.hash) {
+    throw new Error('URL fragments are not allowed for dynamic datasource configuration');
+  }
+
+  if (parsedUrl.username || parsedUrl.password) {
+    throw new Error('URL userinfo is not allowed for dynamic datasource configuration');
+  }
+
+  const isAuthenticated = Boolean(
+    userAuthenticationService?.getAuthorizationHeader?.()?.Authorization
+  );
+
+  if (isAuthenticated) {
+    const normalizedAllowedOrigins = normalizeAllowedOrigins(allowedOrigins);
+    if (!normalizedAllowedOrigins.length || !normalizedAllowedOrigins.includes(parsedUrl.origin)) {
+      throw new Error(
+        `Blocked remote configuration origin "${parsedUrl.origin}" in authenticated environment`
+      );
+    }
+  }
+
+  return {
+    parsedUrl,
+    normalizedUrl: parsedUrl.toString(),
+    isAuthenticated,
+  };
+}
+
+async function fetchConfigJson(normalizedPolicy) {
+  const { normalizedUrl, isAuthenticated } = normalizedPolicy;
+  const response = isAuthenticated
+    ? await fetch(normalizedUrl)
+    : await fetch(normalizedUrl, {
+        method: 'GET',
+        mode: 'cors',
+        credentials: 'omit',
+        redirect: 'error',
+        referrerPolicy: 'no-referrer',
+      });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch dynamic datasource configuration (${response.status})`);
+  }
+
+  return response.json();
+}
+export {
+  resolveConfigFetchPolicy,
+  fetchConfigJson,
+};

--- a/extensions/default/src/utils/secureConfigFetch.test.js
+++ b/extensions/default/src/utils/secureConfigFetch.test.js
@@ -103,14 +103,14 @@ describe('secureConfigFetch', () => {
         expect.objectContaining({
           method: 'GET',
           mode: 'cors',
-          credentials: 'omit',
+          credentials: 'same-origin',
           redirect: 'error',
           referrerPolicy: 'no-referrer',
         })
       );
     });
 
-    it('uses simple fetch for unauthenticated same-origin requests', async () => {
+    it('uses hardened fetch options for unauthenticated same-origin requests', async () => {
       global.fetch.mockResolvedValue({
         status: 200,
         ok: true,
@@ -124,11 +124,18 @@ describe('secureConfigFetch', () => {
       });
 
       expect(global.fetch).toHaveBeenCalledWith(
-        `${window.location.origin}/protected/config.json`
+        `${window.location.origin}/protected/config.json`,
+        expect.objectContaining({
+          method: 'GET',
+          mode: 'cors',
+          credentials: 'same-origin',
+          redirect: 'error',
+          referrerPolicy: 'no-referrer',
+        })
       );
     });
 
-    it('uses simple fetch in authenticated environments', async () => {
+    it('uses hardened fetch options in authenticated environments', async () => {
       global.fetch.mockResolvedValue({
         status: 200,
         ok: true,
@@ -141,7 +148,16 @@ describe('secureConfigFetch', () => {
         isSameOrigin: false,
       });
 
-      expect(global.fetch).toHaveBeenCalledWith('https://trusted.example.com/config.json');
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://trusted.example.com/config.json',
+        expect.objectContaining({
+          method: 'GET',
+          mode: 'cors',
+          credentials: 'same-origin',
+          redirect: 'error',
+          referrerPolicy: 'no-referrer',
+        })
+      );
     });
   });
 });

--- a/extensions/default/src/utils/secureConfigFetch.test.js
+++ b/extensions/default/src/utils/secureConfigFetch.test.js
@@ -1,0 +1,113 @@
+// @ts-nocheck
+import { resolveConfigFetchPolicy, fetchConfigJson } from './secureConfigFetch';
+
+describe('secureConfigFetch', () => {
+  describe('resolveConfigFetchPolicy', () => {
+    it('allows arbitrary origin in unauthenticated environments', () => {
+      const result = resolveConfigFetchPolicy('https://untrusted.example.com/config.json', {
+        userAuthenticationService: {
+          getAuthorizationHeader: () => ({}),
+        },
+      });
+
+      expect(result.normalizedUrl).toBe('https://untrusted.example.com/config.json');
+      expect(result.isAuthenticated).toBe(false);
+    });
+
+    it('blocks non-allowlisted origins in authenticated environments', () => {
+      expect(() =>
+        resolveConfigFetchPolicy('https://untrusted.example.com/config.json', {
+          allowedOrigins: ['https://trusted.example.com'],
+          userAuthenticationService: {
+            getAuthorizationHeader: () => ({ Authorization: 'Bearer token123' }),
+          },
+        })
+      ).toThrow('Blocked remote configuration origin');
+    });
+
+    it('allows allowlisted origin in authenticated environments', () => {
+      const result = resolveConfigFetchPolicy('http://localhost:5000/config.json', {
+        allowedOrigins: ['http://localhost:5000', 'https://trusted.example.com'],
+        userAuthenticationService: {
+          getAuthorizationHeader: () => ({ Authorization: 'Bearer token123' }),
+        },
+      });
+
+      expect(result.normalizedUrl).toBe('http://localhost:5000/config.json');
+      expect(result.isAuthenticated).toBe(true);
+    });
+
+    it('blocks authenticated fetch when allowlist is missing', () => {
+      expect(() =>
+        resolveConfigFetchPolicy('https://noTrustList.example.com/config.json', {
+          userAuthenticationService: {
+            getAuthorizationHeader: () => ({ Authorization: 'Bearer token123' }),
+          },
+        })
+      ).toThrow('Blocked remote configuration origin');
+    });
+
+    it('rejects embedded userinfo in config URLs', () => {
+      expect(() =>
+        resolveConfigFetchPolicy('https://user:pass@trusted.example.com/config.json', {
+          allowedOrigins: ['https://trusted.example.com'],
+          userAuthenticationService: {
+            getAuthorizationHeader: () => ({ Authorization: 'Bearer token123' }),
+          },
+        })
+      ).toThrow('URL userinfo is not allowed for dynamic datasource configuration');
+    });
+  });
+
+  describe('fetchConfigJson', () => {
+    const originalFetch = global.fetch;
+
+    beforeEach(() => {
+      global.fetch = jest.fn();
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+      global.fetch = originalFetch;
+    });
+
+    it('uses hardened fetch options in unauthenticated environments', async () => {
+      global.fetch.mockResolvedValue({
+        status: 200,
+        ok: true,
+        json: async () => ({ ok: true }),
+      });
+
+      await fetchConfigJson({
+        normalizedUrl: 'https://example.com/config.json',
+        isAuthenticated: false,
+      });
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://example.com/config.json',
+        expect.objectContaining({
+          method: 'GET',
+          mode: 'cors',
+          credentials: 'omit',
+          redirect: 'error',
+          referrerPolicy: 'no-referrer',
+        })
+      );
+    });
+
+    it('uses simple fetch in authenticated environments', async () => {
+      global.fetch.mockResolvedValue({
+        status: 200,
+        ok: true,
+        json: async () => ({ ok: true }),
+      });
+
+      await fetchConfigJson({
+        normalizedUrl: 'https://trusted.example.com/config.json',
+        isAuthenticated: true,
+      });
+
+      expect(global.fetch).toHaveBeenCalledWith('https://trusted.example.com/config.json');
+    });
+  });
+});

--- a/extensions/default/src/utils/secureConfigFetch.test.js
+++ b/extensions/default/src/utils/secureConfigFetch.test.js
@@ -12,6 +12,7 @@ describe('secureConfigFetch', () => {
 
       expect(result.normalizedUrl).toBe('https://untrusted.example.com/config.json');
       expect(result.isAuthenticated).toBe(false);
+      expect(result.isSameOrigin).toBe(false);
     });
 
     it('blocks non-allowlisted origins in authenticated environments', () => {
@@ -35,6 +36,7 @@ describe('secureConfigFetch', () => {
 
       expect(result.normalizedUrl).toBe('http://localhost:5000/config.json');
       expect(result.isAuthenticated).toBe(true);
+      expect(result.isSameOrigin).toBe(false);
     });
 
     it('blocks authenticated fetch when allowlist is missing', () => {
@@ -45,6 +47,18 @@ describe('secureConfigFetch', () => {
           },
         })
       ).toThrow('Blocked remote configuration origin');
+    });
+
+    it('allows same-origin in authenticated environments without allowlist', () => {
+      const result = resolveConfigFetchPolicy('/protected/config.json', {
+        userAuthenticationService: {
+          getAuthorizationHeader: () => ({ Authorization: 'Bearer token123' }),
+        },
+      });
+
+      expect(result.normalizedUrl).toBe(`${window.location.origin}/protected/config.json`);
+      expect(result.isAuthenticated).toBe(true);
+      expect(result.isSameOrigin).toBe(true);
     });
 
     it('rejects embedded userinfo in config URLs', () => {
@@ -71,7 +85,7 @@ describe('secureConfigFetch', () => {
       global.fetch = originalFetch;
     });
 
-    it('uses hardened fetch options in unauthenticated environments', async () => {
+    it('uses hardened fetch options for unauthenticated cross-origin requests', async () => {
       global.fetch.mockResolvedValue({
         status: 200,
         ok: true,
@@ -81,6 +95,7 @@ describe('secureConfigFetch', () => {
       await fetchConfigJson({
         normalizedUrl: 'https://example.com/config.json',
         isAuthenticated: false,
+        isSameOrigin: false,
       });
 
       expect(global.fetch).toHaveBeenCalledWith(
@@ -95,6 +110,24 @@ describe('secureConfigFetch', () => {
       );
     });
 
+    it('uses simple fetch for unauthenticated same-origin requests', async () => {
+      global.fetch.mockResolvedValue({
+        status: 200,
+        ok: true,
+        json: async () => ({ ok: true }),
+      });
+
+      await fetchConfigJson({
+        normalizedUrl: `${window.location.origin}/protected/config.json`,
+        isAuthenticated: false,
+        isSameOrigin: true,
+      });
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        `${window.location.origin}/protected/config.json`
+      );
+    });
+
     it('uses simple fetch in authenticated environments', async () => {
       global.fetch.mockResolvedValue({
         status: 200,
@@ -105,6 +138,7 @@ describe('secureConfigFetch', () => {
       await fetchConfigJson({
         normalizedUrl: 'https://trusted.example.com/config.json',
         isAuthenticated: true,
+        isSameOrigin: false,
       });
 
       expect(global.fetch).toHaveBeenCalledWith('https://trusted.example.com/config.json');

--- a/platform/app/public/config/default.js
+++ b/platform/app/public/config/default.js
@@ -251,6 +251,12 @@ window.config = {
       configuration: {
         friendlyName: 'dicomweb delegating proxy',
         name: 'dicomwebproxy',
+        // Security controls for runtime ?url=... datasource loading:
+        // In authenticated environments, runtime ?url origins must be allowlisted:
+        // dangerouslyAllowedOriginsForAuthenticatedEnvironments: [
+        //   'https://config.example.com',
+        //   'http://localhost:5000',
+        // ],
       },
     },
     {
@@ -259,6 +265,12 @@ window.config = {
       configuration: {
         friendlyName: 'dicom json',
         name: 'json',
+        // Security controls for runtime ?url=... datasource loading:
+        // In authenticated environments, runtime ?url origins must be allowlisted:
+        // dangerouslyAllowedOriginsForAuthenticatedEnvironments: [
+        //   'https://config.example.com',
+        //   'http://localhost:5000',
+        // ],
       },
     },
     {

--- a/platform/core/package.json
+++ b/platform/core/package.json
@@ -40,7 +40,7 @@
     "@cornerstonejs/core": "4.15.29",
     "@cornerstonejs/dicom-image-loader": "4.15.29",
     "@ohif/ui": "3.12.0",
-    "cornerstone-math": "0.1.9",
+    "cornerstone-math": "0.1.10",
     "dicom-parser": "1.8.21"
   },
   "dependencies": {

--- a/platform/docs/docs/deployment/authorization.md
+++ b/platform/docs/docs/deployment/authorization.md
@@ -85,14 +85,17 @@ Allowed entry format for `dangerouslyAllowedOriginsForAuthenticatedEnvironments`
 Policy summary:
 
 - In unauthenticated environments, any HTTP(S) `?url=` origin is allowed.
-- In authenticated environments, `?url=` origins must be present in `dangerouslyAllowedOriginsForAuthenticatedEnvironments`, otherwise loading fails closed.
-- In unauthenticated environments, config URLs are fetched with:
+- In authenticated environments, same-origin `?url=` values are allowed by default.
+- In authenticated environments, cross-origin `?url=` values must be present in `dangerouslyAllowedOriginsForAuthenticatedEnvironments`, otherwise loading fails closed.
+- In unauthenticated environments, cross-origin config URLs are fetched with:
   - `method: 'GET'`
   - `mode: 'cors'`
   - `credentials: 'omit'`
   - `redirect: 'error'`
   - `referrerPolicy: 'no-referrer'`
-- In authenticated environments, allowlisted config URLs are fetched using simple fetch behavior.
+- In unauthenticated environments, same-origin config URLs use a plain `fetch()` call (browser default `credentials: 'same-origin'`).
+- Same-origin config URLs are fetched using simple fetch behavior (so same-origin session/cookie auth is preserved).
+- In authenticated environments, allowlisted cross-origin config URLs are fetched using simple fetch behavior.
 - Returned datasource configuration payloads are consumed as-is (no additional URL/config scrubbing).
 
 Example:

--- a/platform/docs/docs/deployment/authorization.md
+++ b/platform/docs/docs/deployment/authorization.md
@@ -66,6 +66,53 @@ http://localhost:3000/viewer?StudyInstanceUIDs=1.2.3.4.5.6.6.7&token=e123125jsdf
 
 
 
+## Securing dynamic datasource URLs
+When using `dicomwebproxy` or `dicomjson` data sources with a runtime `?url=...` query parameter,
+configure explicit trust boundaries to prevent credential exfiltration.
+
+Use these datasource configuration options:
+
+- `dangerouslyAllowedOriginsForAuthenticatedEnvironments`: Origin allowlist used only when the viewer is running in an authenticated environment. Entries may use `http://` or `https://` and can include localhost origins.
+
+Allowed entry format for `dangerouslyAllowedOriginsForAuthenticatedEnvironments`:
+
+- Must be a bare origin only: `scheme://host[:port]`
+- `http://` and `https://` are both allowed
+- Localhost is allowed when explicitly listed (for example, `http://localhost:5000`)
+- Must not include username/password, path, query string, or hash
+- Invalid entries are ignored and logged as misconfigured
+
+Policy summary:
+
+- In unauthenticated environments, any HTTP(S) `?url=` origin is allowed.
+- In authenticated environments, `?url=` origins must be present in `dangerouslyAllowedOriginsForAuthenticatedEnvironments`, otherwise loading fails closed.
+- In unauthenticated environments, config URLs are fetched with:
+  - `method: 'GET'`
+  - `mode: 'cors'`
+  - `credentials: 'omit'`
+  - `redirect: 'error'`
+  - `referrerPolicy: 'no-referrer'`
+- In authenticated environments, allowlisted config URLs are fetched using simple fetch behavior.
+- Returned datasource configuration payloads are consumed as-is (no additional URL/config scrubbing).
+
+Example:
+
+```js
+dataSources: [
+  {
+    namespace: '@ohif/extension-default.dataSourcesModule.dicomwebproxy',
+    sourceName: 'dicomwebproxy',
+    configuration: {
+      name: 'dicomwebproxy',
+      dangerouslyAllowedOriginsForAuthenticatedEnvironments: [
+        'https://config.example.com',
+        'http://localhost:5000',
+      ],
+    },
+  },
+]
+```
+
 ## Implicit Flow vs Authorization Code Flow
 
 The Viewer supports both the Implicit Flow and the Authorization Code Flow. The Implicit Flow is the default currently, as it is easier to set up and use. However, you can opt for better security by using the Authorization Code Flow. To do so, add `useAuthorizationCodeFlow` to the configuration and change the `response_type` from `id_token token` to `code`.


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context
This PR introduces a unified, auth-aware runtime ?url= policy for both dicomjson and dicomwebproxy, with explicit allowlisting in authenticated environments and hardened unauthenticated config fetch behavior. It also consolidates policy logic into shared utilities. It introduces authenticated-environment origin allowlisting via dangerouslyAllowedOriginsForAuthenticatedEnvironments, and aligns config/documentation/testing with that model.
<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results
- Standardizes runtime ?url= handling for both dicomjson and dicomwebproxy via a shared auth-aware policy utility.
- Introduces authenticated-environment origin allowlisting through dangerouslyAllowedOriginsForAuthenticatedEnvironments.
- Applies hardened fetch options for unauthenticated config fetches and preserves simple fetch behavior in authenticated mode.
- Updates both datasource implementations to use the shared resolver/fetch flow and unified configuration key.
- Refreshes unit tests, default config guidance, and current deployment documentation to reflect the unified policy and valid allowlist entry format.

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

 System:
    OS: Windows 11 10.0.26200
    CPU: (20) x64 12th Gen Intel(R) Core(TM) i7-12700H
    Memory: 7.18 GB / 31.68 GB
  Binaries:
    Node: 20.9.0 - C:\Users\joebo\AppData\Local\fnm_multishells\31276_1776363798351\node.EXE
    Yarn: 1.22.22 - C:\Program Files (x86)\Yarn\bin\yarn.CMD
    npm: 10.1.0 - C:\Users\joebo\AppData\Local\fnm_multishells\31276_1776363798351\npm.CMD
    bun: 1.2.23 - C:\Users\joebo\.bun\bin\bun.EXE
  Browsers:
    Chrome: 147.0.7727.56
    Edge: Chromium (146.0.3856.84)
    Internet Explorer: 11.0.26100.8115
<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens dynamic `?url=` datasource loading for `dicomjson` and `dicomwebproxy` by introducing a shared `secureConfigFetch` utility that validates URLs against an origin allowlist in authenticated environments and applies restrictive fetch options.

- **P1 — `fetchConfigJson` ignores `isAuthenticated`/`isSameOrigin`:** The PR description and documentation both state that authenticated environments should use \"simple fetch behavior,\" but `fetchConfigJson` always applies `redirect: 'error'` regardless of auth state. Any allowlisted config endpoint that redirects will fail silently in authenticated mode — the exact scenario the policy is designed to support.

<h3>Confidence Score: 4/5</h3>

Safe to merge with one fix: `fetchConfigJson` must branch on `isAuthenticated`/`isSameOrigin` to match the documented and intended fetch behavior.

One P1 present: the uniform-hardening bug in `fetchConfigJson` breaks the documented contract for authenticated environments and will cause real failures when a config endpoint redirects. No P0 issues found. Remaining findings are P2 documentation discrepancies.

extensions/default/src/utils/secureConfigFetch.js — the `fetchConfigJson` function needs to honour `isAuthenticated`/`isSameOrigin` from the policy object.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| extensions/default/src/utils/secureConfigFetch.js | New security utility implementing URL trust-boundary checks; `fetchConfigJson` ignores `isAuthenticated`/`isSameOrigin` flags and applies hardened options universally, contradicting the documented and PR-described intent of preserving simple fetch behavior in authenticated mode. |
| extensions/default/src/utils/secureConfigFetch.test.js | New unit tests cover policy enforcement and fetch options; all three fetch tests assert the same hardened options regardless of auth state, which reflects the actual (but undocumented/unintended) uniform-hardening behavior. |
| extensions/default/src/DicomJSONDataSource/index.js | Updated to use shared `resolveConfigFetchPolicy`/`fetchConfigJson` utilities; adds `servicesManager` parameter (compatible with framework call-site), normalizes cache keys via resolved URL, and adds `reject`/`deleteStudyMetadataPromise`/`getConfig` stubs. |
| extensions/default/src/DicomWebProxyDataSource/index.ts | Updated to use shared URL policy utilities; adds optional-chaining on new delegate methods while leaving `query`, `retrieve`, and `store` as direct property access (pre-existing inconsistency flagged in prior review comments). |
| platform/docs/docs/deployment/authorization.md | New section documents the URL trust-boundary policy; contains a minor inaccuracy where `credentials: 'omit'` is documented but the code uses `credentials: 'same-origin'`. |
| platform/core/package.json | Bumps `cornerstone-math` from 0.1.9 → 0.1.10; appears unrelated to the security hardening changes in this PR (already flagged in a previous review thread). |

</details>


</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `extensions/default/src/DicomWebProxyDataSource/index.ts`, line 40-59 ([link](https://github.com/ohif/viewers/blob/3e7214174a2b24596c8062354904f7e8b13314cb/extensions/default/src/DicomWebProxyDataSource/index.ts#L40-L59)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Inconsistent optional chaining on delegate methods**

   The newly-added `deleteStudyMetadataPromise`, `getImageIdsForDisplaySet`, `getImageIdsForInstance`, and `getConfig` all use optional chaining (`dicomWebDelegate?.`), but `query`, `retrieve`, and `store` still use direct property access. If `initialize` throws (e.g., due to the new policy rejection) and one of the unguarded methods is later invoked, the call will crash with "Cannot read properties of undefined" rather than failing gracefully. Consider applying `?.` consistently to all delegate proxies.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: extensions/default/src/DicomWebProxyDataSource/index.ts
   Line: 40-59

   Comment:
   **Inconsistent optional chaining on delegate methods**

   The newly-added `deleteStudyMetadataPromise`, `getImageIdsForDisplaySet`, `getImageIdsForInstance`, and `getConfig` all use optional chaining (`dicomWebDelegate?.`), but `query`, `retrieve`, and `store` still use direct property access. If `initialize` throws (e.g., due to the new policy rejection) and one of the unguarded methods is later invoked, the call will crash with "Cannot read properties of undefined" rather than failing gracefully. Consider applying `?.` consistently to all delegate proxies.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: extensions/default/src/utils/secureConfigFetch.js
Line: 99-107

Comment:
**Hardened options applied uniformly — authenticated mode never uses simple fetch**

The PR description states "preserves simple fetch behavior in authenticated mode," and the documentation explicitly says:
> "In authenticated environments, allowlisted cross-origin config URLs are fetched using simple fetch behavior."

However, `fetchConfigJson` ignores both `isAuthenticated` and `isSameOrigin` (they are passed in but never read) and always applies `redirect: 'error'` and `referrerPolicy: 'no-referrer'`. In practice this means any allowlisted config endpoint that responds with a redirect (e.g. a load-balanced URL behind a 301/302) will throw a `TypeError` in authenticated mode, silently breaking the proxy datasource initialization for a scenario the docs explicitly promise to support.

The intended differentiated behavior needs to be wired in:

```js
async function fetchConfigJson(normalizedPolicy) {
  const { normalizedUrl, isAuthenticated, isSameOrigin } = normalizedPolicy;
  const useSimpleFetch = isAuthenticated || isSameOrigin;

  const fetchOptions = useSimpleFetch
    ? {}
    : {
        method: 'GET',
        mode: 'cors',
        credentials: 'omit',
        redirect: 'error',
        referrerPolicy: 'no-referrer',
      };

  const response = await fetch(normalizedUrl, fetchOptions);
  if (!response.ok) {
    throw new Error(`Failed to fetch dynamic datasource configuration (${response.status})`);
  }
  return response.json();
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: platform/docs/docs/deployment/authorization.md
Line: 93-96

Comment:
**Documentation claims `credentials: 'omit'` but code uses `credentials: 'same-origin'`**

The docs list `credentials: 'omit'` as one of the hardened options for unauthenticated cross-origin fetches, but `fetchConfigJson` always passes `credentials: 'same-origin'`. For a cross-origin request these are functionally equivalent (credentials are suppressed either way), but the discrepancy could mislead operators doing a security audit. The bullet should be updated to match the actual code, or the code should be updated to match the documented intent.

```md
  - `credentials: 'same-origin'`
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Update unit tests."](https://github.com/ohif/viewers/commit/1594f641390f5b05833f2e9f96c7f0e7f7da9c3d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29860142)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->