### PR TITLE
fix(configuration): Harden dynamic datasource URL trust boundaries and credential handling. 3.11

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -52,7 +52,7 @@
     },
     "addOns/externals/devDependencies": {
       "name": "@externals/devDependencies",
-      "version": "3.11.0",
+      "version": "3.11.1",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "@kitware/vtk.js": "32.12.0",
@@ -137,14 +137,14 @@
     },
     "addOns/externals/dicom-microscopy-viewer": {
       "name": "@externals/dicom-microscopy-viewer",
-      "version": "3.11.0",
+      "version": "3.11.1",
       "dependencies": {
         "dicom-microscopy-viewer": "0.46.1",
       },
     },
     "extensions/cornerstone": {
       "name": "@ohif/extension-cornerstone",
-      "version": "3.11.0",
+      "version": "3.11.1",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "@cornerstonejs/adapters": "4.5.13",
@@ -170,8 +170,8 @@
         "@cornerstonejs/codec-openjpeg": "1.2.4",
         "@cornerstonejs/codec-openjph": "2.4.7",
         "@cornerstonejs/dicom-image-loader": "4.5.13",
-        "@ohif/core": "3.11.0",
-        "@ohif/ui": "3.11.0",
+        "@ohif/core": "3.11.1",
+        "@ohif/ui": "3.11.1",
         "dcmjs": "0.43.1",
         "dicom-parser": "1.8.21",
         "hammerjs": "2.0.8",
@@ -183,7 +183,7 @@
     },
     "extensions/cornerstone-dicom-pmap": {
       "name": "@ohif/extension-cornerstone-dicom-pmap",
-      "version": "3.11.0",
+      "version": "3.11.1",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "@cornerstonejs/adapters": "4.5.13",
@@ -206,7 +206,7 @@
     },
     "extensions/cornerstone-dicom-rt": {
       "name": "@ohif/extension-cornerstone-dicom-rt",
-      "version": "3.11.0",
+      "version": "3.11.1",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "react-color": "2.19.3",
@@ -226,7 +226,7 @@
     },
     "extensions/cornerstone-dicom-seg": {
       "name": "@ohif/extension-cornerstone-dicom-seg",
-      "version": "3.11.0",
+      "version": "3.11.1",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "@cornerstonejs/adapters": "4.5.13",
@@ -249,7 +249,7 @@
     },
     "extensions/cornerstone-dicom-sr": {
       "name": "@ohif/extension-cornerstone-dicom-sr",
-      "version": "3.11.0",
+      "version": "3.11.1",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "@cornerstonejs/adapters": "4.5.13",
@@ -258,10 +258,10 @@
         "classnames": "2.5.1",
       },
       "peerDependencies": {
-        "@ohif/core": "3.11.0",
-        "@ohif/extension-cornerstone": "3.11.0",
-        "@ohif/extension-measurement-tracking": "3.11.0",
-        "@ohif/ui": "3.11.0",
+        "@ohif/core": "3.11.1",
+        "@ohif/extension-cornerstone": "3.11.1",
+        "@ohif/extension-measurement-tracking": "3.11.1",
+        "@ohif/ui": "3.11.1",
         "dcmjs": "0.43.1",
         "dicom-parser": "1.8.21",
         "hammerjs": "2.0.8",
@@ -271,7 +271,7 @@
     },
     "extensions/cornerstone-dynamic-volume": {
       "name": "@ohif/extension-cornerstone-dynamic-volume",
-      "version": "3.11.0",
+      "version": "3.11.1",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "@cornerstonejs/core": "4.5.13",
@@ -293,7 +293,7 @@
     },
     "extensions/default": {
       "name": "@ohif/extension-default",
-      "version": "3.11.0",
+      "version": "3.11.1",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "@cornerstonejs/calculate-suv": "1.1.0",
@@ -301,8 +301,8 @@
         "lodash.uniqby": "4.7.0",
       },
       "peerDependencies": {
-        "@ohif/core": "3.11.0",
-        "@ohif/i18n": "3.11.0",
+        "@ohif/core": "3.11.1",
+        "@ohif/i18n": "3.11.1",
         "dcmjs": "0.43.1",
         "dicomweb-client": "0.10.4",
         "prop-types": "15.8.1",
@@ -310,13 +310,13 @@
         "react-dom": "18.3.1",
         "react-i18next": "12.3.1",
         "react-window": "1.8.11",
-        "webpack": "5.89.0",
+        "webpack": "5.95.0",
         "webpack-merge": "5.10.0",
       },
     },
     "extensions/dicom-microscopy": {
       "name": "@ohif/extension-dicom-microscopy",
-      "version": "3.11.0",
+      "version": "3.11.1",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "@cornerstonejs/codec-charls": "1.2.3",
@@ -341,7 +341,7 @@
     },
     "extensions/dicom-pdf": {
       "name": "@ohif/extension-dicom-pdf",
-      "version": "3.11.0",
+      "version": "3.11.1",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "classnames": "2.5.1",
@@ -358,7 +358,7 @@
     },
     "extensions/dicom-video": {
       "name": "@ohif/extension-dicom-video",
-      "version": "3.11.0",
+      "version": "3.11.1",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "classnames": "2.5.1",
@@ -375,33 +375,33 @@
     },
     "extensions/measurement-tracking": {
       "name": "@ohif/extension-measurement-tracking",
-      "version": "3.11.0",
+      "version": "3.11.1",
       "dependencies": {
         "@babel/runtime": "7.28.2",
-        "@ohif/ui": "3.11.0",
+        "@ohif/ui": "3.11.1",
         "@xstate/react": "3.2.2",
         "xstate": "4.38.3",
       },
       "peerDependencies": {
         "@cornerstonejs/core": "4.5.13",
         "@cornerstonejs/tools": "4.5.13",
-        "@ohif/core": "3.11.0",
-        "@ohif/extension-cornerstone-dicom-sr": "3.11.0",
-        "@ohif/extension-default": "3.11.0",
-        "@ohif/ui": "3.11.0",
+        "@ohif/core": "3.11.1",
+        "@ohif/extension-cornerstone-dicom-sr": "3.11.1",
+        "@ohif/extension-default": "3.11.1",
+        "@ohif/ui": "3.11.1",
         "classnames": "2.5.1",
         "dcmjs": "0.43.1",
         "lodash.debounce": "4.0.8",
         "prop-types": "15.8.1",
         "react": "18.3.1",
         "react-dom": "18.3.1",
-        "webpack": "5.89.0",
+        "webpack": "5.95.0",
         "webpack-merge": "5.10.0",
       },
     },
     "extensions/test-extension": {
       "name": "@ohif/extension-test",
-      "version": "3.11.0",
+      "version": "3.11.1",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "classnames": "2.5.1",
@@ -418,7 +418,7 @@
     },
     "extensions/tmtv": {
       "name": "@ohif/extension-tmtv",
-      "version": "3.11.0",
+      "version": "3.11.1",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "classnames": "2.5.1",
@@ -435,7 +435,7 @@
     },
     "extensions/usAnnotation": {
       "name": "@ohif/extension-ultrasound-pleura-bline",
-      "version": "3.11.0",
+      "version": "3.11.1",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "@cornerstonejs/core": "4.5.13",
@@ -487,7 +487,7 @@
     },
     "modes/basic-dev-mode": {
       "name": "@ohif/mode-basic-dev-mode",
-      "version": "3.11.0",
+      "version": "3.11.1",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "i18next": "17.3.1",
@@ -507,7 +507,7 @@
     },
     "modes/basic-test-mode": {
       "name": "@ohif/mode-test",
-      "version": "3.11.0",
+      "version": "3.11.1",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "i18next": "17.3.1",
@@ -529,7 +529,7 @@
     },
     "modes/longitudinal": {
       "name": "@ohif/mode-longitudinal",
-      "version": "3.11.0",
+      "version": "3.11.1",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "i18next": "17.3.1",
@@ -552,7 +552,7 @@
     },
     "modes/microscopy": {
       "name": "@ohif/mode-microscopy",
-      "version": "3.11.0",
+      "version": "3.11.1",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "i18next": "17.3.1",
@@ -564,7 +564,7 @@
     },
     "modes/preclinical-4d": {
       "name": "@ohif/mode-preclinical-4d",
-      "version": "3.11.0",
+      "version": "3.11.1",
       "dependencies": {
         "@babel/runtime": "7.28.2",
       },
@@ -583,7 +583,7 @@
     },
     "modes/segmentation": {
       "name": "@ohif/mode-segmentation",
-      "version": "3.11.0",
+      "version": "3.11.1",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "i18next": "17.3.1",
@@ -627,7 +627,7 @@
     },
     "modes/tmtv": {
       "name": "@ohif/mode-tmtv",
-      "version": "3.11.0",
+      "version": "3.11.1",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "i18next": "17.3.1",
@@ -648,7 +648,7 @@
     },
     "modes/usAnnotation": {
       "name": "@ohif/mode-ultrasound-pleura-bline",
-      "version": "3.11.0",
+      "version": "3.11.1",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "@cornerstonejs/core": "4.5.13",
@@ -687,7 +687,7 @@
     },
     "platform/app": {
       "name": "@ohif/app",
-      "version": "3.11.0",
+      "version": "3.11.1",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "@cornerstonejs/codec-charls": "1.2.3",
@@ -766,7 +766,7 @@
     },
     "platform/cli": {
       "name": "@ohif/cli",
-      "version": "3.11.0",
+      "version": "3.11.1",
       "bin": {
         "ohif-cli": "src/index.js",
       },
@@ -790,7 +790,7 @@
     },
     "platform/core": {
       "name": "@ohif/core",
-      "version": "3.11.0",
+      "version": "3.11.1",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "dcmjs": "0.43.1",
@@ -817,14 +817,14 @@
         "@cornerstonejs/codec-openjph": "2.4.7",
         "@cornerstonejs/core": "4.5.13",
         "@cornerstonejs/dicom-image-loader": "4.5.13",
-        "@ohif/ui": "3.11.0",
-        "cornerstone-math": "0.1.9",
+        "@ohif/ui": "3.11.1",
+        "cornerstone-math": "0.1.10",
         "dicom-parser": "1.8.21",
       },
     },
     "platform/i18n": {
       "name": "@ohif/i18n",
-      "version": "3.11.0",
+      "version": "3.11.1",
       "dependencies": {
         "@babel/runtime": "7.28.2",
         "i18next-locize-backend": "2.2.2",
@@ -849,7 +849,7 @@
     },
     "platform/ui": {
       "name": "@ohif/ui",
-      "version": "3.11.0",
+      "version": "3.11.1",
       "dependencies": {
         "@testing-library/react": "13.4.0",
         "browser-detect": "0.2.28",
@@ -900,7 +900,7 @@
     },
     "platform/ui-next": {
       "name": "@ohif/ui-next",
-      "version": "3.11.0",
+      "version": "3.11.1",
       "dependencies": {
         "@radix-ui/react-accordion": "1.2.11",
         "@radix-ui/react-checkbox": "1.3.2",
@@ -5371,10 +5371,6 @@
 
     "@ohif/app/copy-webpack-plugin": ["copy-webpack-plugin@10.2.4", "", { "dependencies": { "fast-glob": "^3.2.7", "glob-parent": "^6.0.1", "globby": "^12.0.2", "normalize-path": "^3.0.0", "schema-utils": "^4.0.0", "serialize-javascript": "^6.0.0" }, "peerDependencies": { "webpack": "^5.1.0" } }, "sha512-xFVltahqlsRcyyJqQbDY6EYTtyQZF9rf+JPjwHObLdPFMEISqkFkr7mFoVOC6BfYS/dNThyoQKvziugm+OnwBg=="],
 
-    "@ohif/extension-default/webpack": ["webpack@5.101.0", "", { "dependencies": { "@types/eslint-scope": "^3.7.7", "@types/estree": "^1.0.8", "@types/json-schema": "^7.0.15", "@webassemblyjs/ast": "^1.14.1", "@webassemblyjs/wasm-edit": "^1.14.1", "@webassemblyjs/wasm-parser": "^1.14.1", "acorn": "^8.15.0", "acorn-import-phases": "^1.0.3", "browserslist": "^4.24.0", "chrome-trace-event": "^1.0.2", "enhanced-resolve": "^5.17.2", "es-module-lexer": "^1.2.1", "eslint-scope": "5.1.1", "events": "^3.2.0", "glob-to-regexp": "^0.4.1", "graceful-fs": "^4.2.11", "json-parse-even-better-errors": "^2.3.1", "loader-runner": "^4.2.0", "mime-types": "^2.1.27", "neo-async": "^2.6.2", "schema-utils": "^4.3.2", "tapable": "^2.1.1", "terser-webpack-plugin": "^5.3.11", "watchpack": "^2.4.1", "webpack-sources": "^3.3.3" }, "bin": { "webpack": "bin/webpack.js" } }, "sha512-B4t+nJqytPeuZlHuIKTbalhljIFXeNRqrUGAQgTGlfOl2lXXKXw+yZu6bicycP+PUlM44CxBjCFD6aciKFT3LQ=="],
-
-    "@ohif/extension-measurement-tracking/webpack": ["webpack@5.101.0", "", { "dependencies": { "@types/eslint-scope": "^3.7.7", "@types/estree": "^1.0.8", "@types/json-schema": "^7.0.15", "@webassemblyjs/ast": "^1.14.1", "@webassemblyjs/wasm-edit": "^1.14.1", "@webassemblyjs/wasm-parser": "^1.14.1", "acorn": "^8.15.0", "acorn-import-phases": "^1.0.3", "browserslist": "^4.24.0", "chrome-trace-event": "^1.0.2", "enhanced-resolve": "^5.17.2", "es-module-lexer": "^1.2.1", "eslint-scope": "5.1.1", "events": "^3.2.0", "glob-to-regexp": "^0.4.1", "graceful-fs": "^4.2.11", "json-parse-even-better-errors": "^2.3.1", "loader-runner": "^4.2.0", "mime-types": "^2.1.27", "neo-async": "^2.6.2", "schema-utils": "^4.3.2", "tapable": "^2.1.1", "terser-webpack-plugin": "^5.3.11", "watchpack": "^2.4.1", "webpack-sources": "^3.3.3" }, "bin": { "webpack": "bin/webpack.js" } }, "sha512-B4t+nJqytPeuZlHuIKTbalhljIFXeNRqrUGAQgTGlfOl2lXXKXw+yZu6bicycP+PUlM44CxBjCFD6aciKFT3LQ=="],
-
     "@rollup/plugin-node-resolve/deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
 
     "@rollup/plugin-node-resolve/resolve": ["resolve@1.22.10", "", { "dependencies": { "is-core-module": "^2.16.0", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w=="],
@@ -6415,14 +6411,6 @@
 
     "@ohif/app/copy-webpack-plugin/globby": ["globby@12.2.0", "", { "dependencies": { "array-union": "^3.0.1", "dir-glob": "^3.0.1", "fast-glob": "^3.2.7", "ignore": "^5.1.9", "merge2": "^1.4.1", "slash": "^4.0.0" } }, "sha512-wiSuFQLZ+urS9x2gGPl1H5drc5twabmm4m2gTR27XDFyjUHJUNsS8o/2aKyIF6IoBaR630atdher0XJ5g6OMmA=="],
 
-    "@ohif/extension-default/webpack/eslint-scope": ["eslint-scope@5.1.1", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^4.1.1" } }, "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw=="],
-
-    "@ohif/extension-default/webpack/webpack-sources": ["webpack-sources@3.3.3", "", {}, "sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg=="],
-
-    "@ohif/extension-measurement-tracking/webpack/eslint-scope": ["eslint-scope@5.1.1", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^4.1.1" } }, "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw=="],
-
-    "@ohif/extension-measurement-tracking/webpack/webpack-sources": ["webpack-sources@3.3.3", "", {}, "sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg=="],
-
     "@svgr/core/cosmiconfig/js-yaml": ["js-yaml@4.1.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA=="],
 
     "@svgr/plugin-svgo/cosmiconfig/js-yaml": ["js-yaml@4.1.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA=="],
@@ -7000,10 +6988,6 @@
     "@ohif/app/copy-webpack-plugin/globby/array-union": ["array-union@3.0.1", "", {}, "sha512-1OvF9IbWwaeiM9VhzYXVQacMibxpXOMYVNIvMtKRyX9SImBXpKcFr8XvFDeEslCyuH/t6KRt7HEO94AlP8Iatw=="],
 
     "@ohif/app/copy-webpack-plugin/globby/slash": ["slash@4.0.0", "", {}, "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew=="],
-
-    "@ohif/extension-default/webpack/eslint-scope/estraverse": ["estraverse@4.3.0", "", {}, "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="],
-
-    "@ohif/extension-measurement-tracking/webpack/eslint-scope/estraverse": ["estraverse@4.3.0", "", {}, "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="],
 
     "@svgr/core/cosmiconfig/js-yaml/argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 

--- a/extensions/default/package.json
+++ b/extensions/default/package.json
@@ -43,7 +43,7 @@
     "react-dom": "18.3.1",
     "react-i18next": "12.3.1",
     "react-window": "1.8.11",
-    "webpack": "5.89.0",
+    "webpack": "5.95.0",
     "webpack-merge": "5.10.0"
   },
   "dependencies": {

--- a/extensions/default/src/DicomJSONDataSource/index.js
+++ b/extensions/default/src/DicomJSONDataSource/index.js
@@ -4,6 +4,7 @@ import qs from 'query-string';
 
 import getImageId from '../DicomWebDataSource/utils/getImageId';
 import getDirectURL from '../utils/getDirectURL';
+import { resolveConfigFetchPolicy, fetchConfigJson } from '../utils/secureConfigFetch';
 
 const metadataProvider = OHIF.classes.MetadataProvider;
 
@@ -59,13 +60,18 @@ const findStudies = (key, value) => {
   return studies;
 };
 
-function createDicomJSONApi(dicomJsonConfig) {
+function createDicomJSONApi(dicomJsonConfig, servicesManager) {
+  const { userAuthenticationService } = servicesManager.services;
   const implementation = {
     initialize: async ({ query, url }) => {
       if (!url) {
         url = query.get('url');
       }
-      let metaData = getMetaDataByURL(url);
+      const evaluatedUrl = resolveConfigFetchPolicy(url, {
+        allowedOrigins: dicomJsonConfig.dangerouslyAllowedOriginsForAuthenticatedEnvironments,
+        userAuthenticationService,
+      });
+      let metaData = getMetaDataByURL(evaluatedUrl.normalizedUrl);
 
       // if we have already cached the data from this specific url
       // We are only handling one StudyInstanceUID to run; however,
@@ -76,8 +82,7 @@ function createDicomJSONApi(dicomJsonConfig) {
         });
       }
 
-      const response = await fetch(url);
-      const data = await response.json();
+      const data = await fetchConfigJson(evaluatedUrl);
 
       let StudyInstanceUID;
       let SeriesInstanceUID;
@@ -105,11 +110,11 @@ function createDicomJSONApi(dicomJsonConfig) {
       });
 
       _store.urls.push({
-        url,
+        url: evaluatedUrl.normalizedUrl,
         studies: [...data.studies],
       });
       _store.studyInstanceUIDMap.set(
-        url,
+        evaluatedUrl.normalizedUrl,
         data.studies.map(study => study.StudyInstanceUID)
       );
     },
@@ -252,6 +257,8 @@ function createDicomJSONApi(dicomJsonConfig) {
         console.warn(' DICOMJson store dicom not implemented');
       },
     },
+    reject: {},
+    deleteStudyMetadataPromise: () => {},
     getImageIdsForDisplaySet(displaySet) {
       const images = displaySet.images;
       const imageIds = [];
@@ -297,8 +304,21 @@ function createDicomJSONApi(dicomJsonConfig) {
     },
     getStudyInstanceUIDs: ({ params, query }) => {
       const url = query.get('url');
-      return _store.studyInstanceUIDMap.get(url);
+      if (!url) {
+        return;
+      }
+
+      try {
+        const evaluatedUrl = resolveConfigFetchPolicy(url, {
+          allowedOrigins: dicomJsonConfig.dangerouslyAllowedOriginsForAuthenticatedEnvironments,
+          userAuthenticationService,
+        });
+        return _store.studyInstanceUIDMap.get(evaluatedUrl.normalizedUrl);
+      } catch {
+        return;
+      }
     },
+    getConfig: () => dicomJsonConfig,
   };
   return IWebApiDataSource.create(implementation);
 }

--- a/extensions/default/src/DicomWebProxyDataSource/index.ts
+++ b/extensions/default/src/DicomWebProxyDataSource/index.ts
@@ -1,5 +1,6 @@
 import { IWebApiDataSource } from '@ohif/core';
 import { createDicomWebApi } from '../DicomWebDataSource/index';
+import { resolveConfigFetchPolicy, fetchConfigJson } from '../utils/secureConfigFetch';
 
 /**
  * This datasource is initialized with a url that returns a JSON object with a
@@ -11,6 +12,7 @@ import { createDicomWebApi } from '../DicomWebDataSource/index';
  */
 function createDicomWebProxyApi(dicomWebProxyConfig, servicesManager: AppTypes.ServicesManager) {
   const { name } = dicomWebProxyConfig;
+  const { userAuthenticationService } = servicesManager.services;
   let dicomWebDelegate = undefined;
 
   const implementation = {
@@ -20,12 +22,14 @@ function createDicomWebProxyApi(dicomWebProxyConfig, servicesManager: AppTypes.S
       if (!url) {
         throw new Error(`No url for '${name}'`);
       } else {
-        const response = await fetch(url);
-        const data = await response.json();
+        const evaluatedUrl = resolveConfigFetchPolicy(url, {
+          allowedOrigins: dicomWebProxyConfig.dangerouslyAllowedOriginsForAuthenticatedEnvironments,
+          userAuthenticationService,
+        });
+        const data = await fetchConfigJson(evaluatedUrl);
         if (!data.servers?.dicomWeb?.[0]) {
           throw new Error('Invalid configuration returned by url');
         }
-
         dicomWebDelegate = createDicomWebApi(
           data.servers.dicomWeb[0].configuration || data.servers.dicomWeb[0],
           servicesManager
@@ -54,9 +58,16 @@ function createDicomWebProxyApi(dicomWebProxyConfig, servicesManager: AppTypes.S
     store: {
       dicom: (...args) => dicomWebDelegate.store.dicom(...args),
     },
-    deleteStudyMetadataPromise: (...args) => dicomWebDelegate.deleteStudyMetadataPromise(...args),
-    getImageIdsForDisplaySet: (...args) => dicomWebDelegate.getImageIdsForDisplaySet(...args),
-    getImageIdsForInstance: (...args) => dicomWebDelegate.getImageIdsForInstance(...args),
+    reject: {
+      series: (...args) => dicomWebDelegate?.reject?.series?.(...args),
+    },
+    deleteStudyMetadataPromise: (...args) => dicomWebDelegate?.deleteStudyMetadataPromise?.(...args),
+    getImageIdsForDisplaySet: (...args) => dicomWebDelegate?.getImageIdsForDisplaySet?.(...args),
+    getImageIdsForInstance: (...args) => dicomWebDelegate?.getImageIdsForInstance?.(...args),
+    getConfig: (...args) =>
+      dicomWebDelegate?.getConfig?.(...args) ?? {
+        dicomUploadEnabled: false,
+      },
     getStudyInstanceUIDs({ params, query }) {
       let studyInstanceUIDs = [];
 

--- a/extensions/default/src/utils/secureConfigFetch.js
+++ b/extensions/default/src/utils/secureConfigFetch.js
@@ -61,6 +61,7 @@ function resolveConfigFetchPolicy(rawUrl, policy = {}) {
   const { allowedOrigins = [], userAuthenticationService } = policy;
   const parsedUrl = resolveConfigUrl(rawUrl);
   const protocol = parsedUrl.protocol.toLowerCase();
+  const isSameOrigin = parsedUrl.origin === window.location.origin;
 
   if (!['http:', 'https:'].includes(protocol)) {
     throw new Error('Only HTTP(S) URLs are allowed for dynamic datasource configuration');
@@ -78,7 +79,7 @@ function resolveConfigFetchPolicy(rawUrl, policy = {}) {
     userAuthenticationService?.getAuthorizationHeader?.()?.Authorization
   );
 
-  if (isAuthenticated) {
+  if (isAuthenticated && !isSameOrigin) {
     const normalizedAllowedOrigins = normalizeAllowedOrigins(allowedOrigins);
     if (!normalizedAllowedOrigins.length || !normalizedAllowedOrigins.includes(parsedUrl.origin)) {
       throw new Error(
@@ -91,12 +92,13 @@ function resolveConfigFetchPolicy(rawUrl, policy = {}) {
     parsedUrl,
     normalizedUrl: parsedUrl.toString(),
     isAuthenticated,
+    isSameOrigin,
   };
 }
 
 async function fetchConfigJson(normalizedPolicy) {
-  const { normalizedUrl, isAuthenticated } = normalizedPolicy;
-  const response = isAuthenticated
+  const { normalizedUrl, isAuthenticated, isSameOrigin } = normalizedPolicy;
+  const response = isAuthenticated || isSameOrigin
     ? await fetch(normalizedUrl)
     : await fetch(normalizedUrl, {
         method: 'GET',

--- a/extensions/default/src/utils/secureConfigFetch.js
+++ b/extensions/default/src/utils/secureConfigFetch.js
@@ -1,0 +1,118 @@
+// @ts-nocheck
+
+function normalizeAllowedOrigins(allowedOrigins = []) {
+  if (!Array.isArray(allowedOrigins)) {
+    return [];
+  }
+
+  const configuredOrigins = allowedOrigins
+    .filter(origin => typeof origin === 'string')
+    .map(origin => origin.trim())
+    .filter(Boolean);
+
+  return configuredOrigins
+    .map(origin => {
+      try {
+        const parsedOrigin = new URL(origin);
+        if (!['http:', 'https:'].includes(parsedOrigin.protocol)) {
+          console.error(
+            `[secureConfigFetch] Ignoring misconfigured allowed origin "${origin}". ` +
+              'Entries must use http:// or https://.'
+          );
+          return null;
+        }
+        if (
+          parsedOrigin.username ||
+          parsedOrigin.password ||
+          parsedOrigin.pathname !== '/' ||
+          parsedOrigin.search ||
+          parsedOrigin.hash
+        ) {
+          console.error(
+            `[secureConfigFetch] Ignoring misconfigured allowed origin "${origin}". ` +
+              'Entries must be bare origins only (scheme + host + optional port), with no username/password, path, query, or hash.'
+          );
+          return null;
+        }
+        return parsedOrigin.origin;
+      } catch {
+        console.error(
+          `[secureConfigFetch] Ignoring misconfigured allowed origin "${origin}". Entry is not a valid URL.`
+        );
+        return null;
+      }
+    })
+    .filter(Boolean);
+}
+
+function resolveConfigUrl(rawUrl) {
+  if (!rawUrl || typeof rawUrl !== 'string') {
+    throw new Error('Missing required "url" query parameter');
+  }
+
+  try {
+    return new URL(rawUrl, window.location.href);
+  } catch {
+    throw new Error('Invalid URL in "url" query parameter');
+  }
+}
+
+function resolveConfigFetchPolicy(rawUrl, policy = {}) {
+  const { allowedOrigins = [], userAuthenticationService } = policy;
+  const parsedUrl = resolveConfigUrl(rawUrl);
+  const protocol = parsedUrl.protocol.toLowerCase();
+
+  if (!['http:', 'https:'].includes(protocol)) {
+    throw new Error('Only HTTP(S) URLs are allowed for dynamic datasource configuration');
+  }
+
+  if (parsedUrl.hash) {
+    throw new Error('URL fragments are not allowed for dynamic datasource configuration');
+  }
+
+  if (parsedUrl.username || parsedUrl.password) {
+    throw new Error('URL userinfo is not allowed for dynamic datasource configuration');
+  }
+
+  const isAuthenticated = Boolean(
+    userAuthenticationService?.getAuthorizationHeader?.()?.Authorization
+  );
+
+  if (isAuthenticated) {
+    const normalizedAllowedOrigins = normalizeAllowedOrigins(allowedOrigins);
+    if (!normalizedAllowedOrigins.length || !normalizedAllowedOrigins.includes(parsedUrl.origin)) {
+      throw new Error(
+        `Blocked remote configuration origin "${parsedUrl.origin}" in authenticated environment`
+      );
+    }
+  }
+
+  return {
+    parsedUrl,
+    normalizedUrl: parsedUrl.toString(),
+    isAuthenticated,
+  };
+}
+
+async function fetchConfigJson(normalizedPolicy) {
+  const { normalizedUrl, isAuthenticated } = normalizedPolicy;
+  const response = isAuthenticated
+    ? await fetch(normalizedUrl)
+    : await fetch(normalizedUrl, {
+        method: 'GET',
+        mode: 'cors',
+        credentials: 'omit',
+        redirect: 'error',
+        referrerPolicy: 'no-referrer',
+      });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch dynamic datasource configuration (${response.status})`);
+  }
+
+  return response.json();
+}
+export {
+  resolveConfigFetchPolicy,
+  fetchConfigJson,
+};

--- a/extensions/default/src/utils/secureConfigFetch.test.js
+++ b/extensions/default/src/utils/secureConfigFetch.test.js
@@ -1,0 +1,113 @@
+// @ts-nocheck
+import { resolveConfigFetchPolicy, fetchConfigJson } from './secureConfigFetch';
+
+describe('secureConfigFetch', () => {
+  describe('resolveConfigFetchPolicy', () => {
+    it('allows arbitrary origin in unauthenticated environments', () => {
+      const result = resolveConfigFetchPolicy('https://untrusted.example.com/config.json', {
+        userAuthenticationService: {
+          getAuthorizationHeader: () => ({}),
+        },
+      });
+
+      expect(result.normalizedUrl).toBe('https://untrusted.example.com/config.json');
+      expect(result.isAuthenticated).toBe(false);
+    });
+
+    it('blocks non-allowlisted origins in authenticated environments', () => {
+      expect(() =>
+        resolveConfigFetchPolicy('https://untrusted.example.com/config.json', {
+          allowedOrigins: ['https://trusted.example.com'],
+          userAuthenticationService: {
+            getAuthorizationHeader: () => ({ Authorization: 'Bearer token123' }),
+          },
+        })
+      ).toThrow('Blocked remote configuration origin');
+    });
+
+    it('allows allowlisted origin in authenticated environments', () => {
+      const result = resolveConfigFetchPolicy('http://localhost:5000/config.json', {
+        allowedOrigins: ['http://localhost:5000', 'https://trusted.example.com'],
+        userAuthenticationService: {
+          getAuthorizationHeader: () => ({ Authorization: 'Bearer token123' }),
+        },
+      });
+
+      expect(result.normalizedUrl).toBe('http://localhost:5000/config.json');
+      expect(result.isAuthenticated).toBe(true);
+    });
+
+    it('blocks authenticated fetch when allowlist is missing', () => {
+      expect(() =>
+        resolveConfigFetchPolicy('https://noTrustList.example.com/config.json', {
+          userAuthenticationService: {
+            getAuthorizationHeader: () => ({ Authorization: 'Bearer token123' }),
+          },
+        })
+      ).toThrow('Blocked remote configuration origin');
+    });
+
+    it('rejects embedded userinfo in config URLs', () => {
+      expect(() =>
+        resolveConfigFetchPolicy('https://user:pass@trusted.example.com/config.json', {
+          allowedOrigins: ['https://trusted.example.com'],
+          userAuthenticationService: {
+            getAuthorizationHeader: () => ({ Authorization: 'Bearer token123' }),
+          },
+        })
+      ).toThrow('URL userinfo is not allowed for dynamic datasource configuration');
+    });
+  });
+
+  describe('fetchConfigJson', () => {
+    const originalFetch = global.fetch;
+
+    beforeEach(() => {
+      global.fetch = jest.fn();
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+      global.fetch = originalFetch;
+    });
+
+    it('uses hardened fetch options in unauthenticated environments', async () => {
+      global.fetch.mockResolvedValue({
+        status: 200,
+        ok: true,
+        json: async () => ({ ok: true }),
+      });
+
+      await fetchConfigJson({
+        normalizedUrl: 'https://example.com/config.json',
+        isAuthenticated: false,
+      });
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://example.com/config.json',
+        expect.objectContaining({
+          method: 'GET',
+          mode: 'cors',
+          credentials: 'omit',
+          redirect: 'error',
+          referrerPolicy: 'no-referrer',
+        })
+      );
+    });
+
+    it('uses simple fetch in authenticated environments', async () => {
+      global.fetch.mockResolvedValue({
+        status: 200,
+        ok: true,
+        json: async () => ({ ok: true }),
+      });
+
+      await fetchConfigJson({
+        normalizedUrl: 'https://trusted.example.com/config.json',
+        isAuthenticated: true,
+      });
+
+      expect(global.fetch).toHaveBeenCalledWith('https://trusted.example.com/config.json');
+    });
+  });
+});

--- a/extensions/default/src/utils/secureConfigFetch.test.js
+++ b/extensions/default/src/utils/secureConfigFetch.test.js
@@ -12,6 +12,7 @@ describe('secureConfigFetch', () => {
 
       expect(result.normalizedUrl).toBe('https://untrusted.example.com/config.json');
       expect(result.isAuthenticated).toBe(false);
+      expect(result.isSameOrigin).toBe(false);
     });
 
     it('blocks non-allowlisted origins in authenticated environments', () => {
@@ -35,6 +36,7 @@ describe('secureConfigFetch', () => {
 
       expect(result.normalizedUrl).toBe('http://localhost:5000/config.json');
       expect(result.isAuthenticated).toBe(true);
+      expect(result.isSameOrigin).toBe(false);
     });
 
     it('blocks authenticated fetch when allowlist is missing', () => {
@@ -45,6 +47,18 @@ describe('secureConfigFetch', () => {
           },
         })
       ).toThrow('Blocked remote configuration origin');
+    });
+
+    it('allows same-origin in authenticated environments without allowlist', () => {
+      const result = resolveConfigFetchPolicy('/protected/config.json', {
+        userAuthenticationService: {
+          getAuthorizationHeader: () => ({ Authorization: 'Bearer token123' }),
+        },
+      });
+
+      expect(result.normalizedUrl).toBe(`${window.location.origin}/protected/config.json`);
+      expect(result.isAuthenticated).toBe(true);
+      expect(result.isSameOrigin).toBe(true);
     });
 
     it('rejects embedded userinfo in config URLs', () => {
@@ -71,7 +85,7 @@ describe('secureConfigFetch', () => {
       global.fetch = originalFetch;
     });
 
-    it('uses hardened fetch options in unauthenticated environments', async () => {
+    it('uses hardened fetch options for unauthenticated cross-origin requests', async () => {
       global.fetch.mockResolvedValue({
         status: 200,
         ok: true,
@@ -81,6 +95,7 @@ describe('secureConfigFetch', () => {
       await fetchConfigJson({
         normalizedUrl: 'https://example.com/config.json',
         isAuthenticated: false,
+        isSameOrigin: false,
       });
 
       expect(global.fetch).toHaveBeenCalledWith(
@@ -95,6 +110,24 @@ describe('secureConfigFetch', () => {
       );
     });
 
+    it('uses simple fetch for unauthenticated same-origin requests', async () => {
+      global.fetch.mockResolvedValue({
+        status: 200,
+        ok: true,
+        json: async () => ({ ok: true }),
+      });
+
+      await fetchConfigJson({
+        normalizedUrl: `${window.location.origin}/protected/config.json`,
+        isAuthenticated: false,
+        isSameOrigin: true,
+      });
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        `${window.location.origin}/protected/config.json`
+      );
+    });
+
     it('uses simple fetch in authenticated environments', async () => {
       global.fetch.mockResolvedValue({
         status: 200,
@@ -105,6 +138,7 @@ describe('secureConfigFetch', () => {
       await fetchConfigJson({
         normalizedUrl: 'https://trusted.example.com/config.json',
         isAuthenticated: true,
+        isSameOrigin: false,
       });
 
       expect(global.fetch).toHaveBeenCalledWith('https://trusted.example.com/config.json');

--- a/extensions/measurement-tracking/package.json
+++ b/extensions/measurement-tracking/package.json
@@ -44,7 +44,7 @@
     "prop-types": "15.8.1",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "webpack": "5.89.0",
+    "webpack": "5.95.0",
     "webpack-merge": "5.10.0"
   },
   "dependencies": {

--- a/platform/app/public/config/default.js
+++ b/platform/app/public/config/default.js
@@ -251,6 +251,12 @@ window.config = {
       configuration: {
         friendlyName: 'dicomweb delegating proxy',
         name: 'dicomwebproxy',
+        // Security controls for runtime ?url=... datasource loading:
+        // In authenticated environments, runtime ?url origins must be allowlisted:
+        // dangerouslyAllowedOriginsForAuthenticatedEnvironments: [
+        //   'https://config.example.com',
+        //   'http://localhost:5000',
+        // ],
       },
     },
     {
@@ -259,6 +265,12 @@ window.config = {
       configuration: {
         friendlyName: 'dicom json',
         name: 'json',
+        // Security controls for runtime ?url=... datasource loading:
+        // In authenticated environments, runtime ?url origins must be allowlisted:
+        // dangerouslyAllowedOriginsForAuthenticatedEnvironments: [
+        //   'https://config.example.com',
+        //   'http://localhost:5000',
+        // ],
       },
     },
     {

--- a/platform/core/package.json
+++ b/platform/core/package.json
@@ -40,7 +40,7 @@
     "@cornerstonejs/core": "4.5.13",
     "@cornerstonejs/dicom-image-loader": "4.5.13",
     "@ohif/ui": "3.11.1",
-    "cornerstone-math": "0.1.9",
+    "cornerstone-math": "0.1.10",
     "dicom-parser": "1.8.21"
   },
   "dependencies": {

--- a/platform/docs/docs/deployment/authorization.md
+++ b/platform/docs/docs/deployment/authorization.md
@@ -85,14 +85,17 @@ Allowed entry format for `dangerouslyAllowedOriginsForAuthenticatedEnvironments`
 Policy summary:
 
 - In unauthenticated environments, any HTTP(S) `?url=` origin is allowed.
-- In authenticated environments, `?url=` origins must be present in `dangerouslyAllowedOriginsForAuthenticatedEnvironments`, otherwise loading fails closed.
-- In unauthenticated environments, config URLs are fetched with:
+- In authenticated environments, same-origin `?url=` values are allowed by default.
+- In authenticated environments, cross-origin `?url=` values must be present in `dangerouslyAllowedOriginsForAuthenticatedEnvironments`, otherwise loading fails closed.
+- In unauthenticated environments, cross-origin config URLs are fetched with:
   - `method: 'GET'`
   - `mode: 'cors'`
   - `credentials: 'omit'`
   - `redirect: 'error'`
   - `referrerPolicy: 'no-referrer'`
-- In authenticated environments, allowlisted config URLs are fetched using simple fetch behavior.
+- In unauthenticated environments, same-origin config URLs use a plain `fetch()` call (browser default `credentials: 'same-origin'`).
+- Same-origin config URLs are fetched using simple fetch behavior (so same-origin session/cookie auth is preserved).
+- In authenticated environments, allowlisted cross-origin config URLs are fetched using simple fetch behavior.
 - Returned datasource configuration payloads are consumed as-is (no additional URL/config scrubbing).
 
 Example:

--- a/platform/docs/docs/deployment/authorization.md
+++ b/platform/docs/docs/deployment/authorization.md
@@ -66,6 +66,53 @@ http://localhost:3000/viewer?StudyInstanceUIDs=1.2.3.4.5.6.6.7&token=e123125jsdf
 
 
 
+## Securing dynamic datasource URLs
+When using `dicomwebproxy` or `dicomjson` data sources with a runtime `?url=...` query parameter,
+configure explicit trust boundaries to prevent credential exfiltration.
+
+Use these datasource configuration options:
+
+- `dangerouslyAllowedOriginsForAuthenticatedEnvironments`: Origin allowlist used only when the viewer is running in an authenticated environment. Entries may use `http://` or `https://` and can include localhost origins.
+
+Allowed entry format for `dangerouslyAllowedOriginsForAuthenticatedEnvironments`:
+
+- Must be a bare origin only: `scheme://host[:port]`
+- `http://` and `https://` are both allowed
+- Localhost is allowed when explicitly listed (for example, `http://localhost:5000`)
+- Must not include username/password, path, query string, or hash
+- Invalid entries are ignored and logged as misconfigured
+
+Policy summary:
+
+- In unauthenticated environments, any HTTP(S) `?url=` origin is allowed.
+- In authenticated environments, `?url=` origins must be present in `dangerouslyAllowedOriginsForAuthenticatedEnvironments`, otherwise loading fails closed.
+- In unauthenticated environments, config URLs are fetched with:
+  - `method: 'GET'`
+  - `mode: 'cors'`
+  - `credentials: 'omit'`
+  - `redirect: 'error'`
+  - `referrerPolicy: 'no-referrer'`
+- In authenticated environments, allowlisted config URLs are fetched using simple fetch behavior.
+- Returned datasource configuration payloads are consumed as-is (no additional URL/config scrubbing).
+
+Example:
+
+```js
+dataSources: [
+  {
+    namespace: '@ohif/extension-default.dataSourcesModule.dicomwebproxy',
+    sourceName: 'dicomwebproxy',
+    configuration: {
+      name: 'dicomwebproxy',
+      dangerouslyAllowedOriginsForAuthenticatedEnvironments: [
+        'https://config.example.com',
+        'http://localhost:5000',
+      ],
+    },
+  },
+]
+```
+
 ## Implicit Flow vs Authorization Code Flow
 
 The Viewer supports both the Implicit Flow and the Authorization Code Flow. The Implicit Flow is the default currently, as it is easier to set up and use. However, you can opt for better security by using the Authorization Code Flow. To do so, add `useAuthorizationCodeFlow` to the configuration and change the `response_type` from `id_token token` to `code`.


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context
This PR introduces a unified, auth-aware runtime ?url= policy for both dicomjson and dicomwebproxy, with explicit allowlisting in authenticated environments and hardened unauthenticated config fetch behavior. It also consolidates policy logic into shared utilities. It introduces authenticated-environment origin allowlisting via dangerouslyAllowedOriginsForAuthenticatedEnvironments, and aligns config/documentation/testing with that model.
<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results
- Standardizes runtime ?url= handling for both dicomjson and dicomwebproxy via a shared auth-aware policy utility.
- Introduces authenticated-environment origin allowlisting through dangerouslyAllowedOriginsForAuthenticatedEnvironments.
- Applies hardened fetch options for unauthenticated config fetches and preserves simple fetch behavior in authenticated mode.
- Updates both datasource implementations to use the shared resolver/fetch flow and unified configuration key.
- Refreshes unit tests, default config guidance, and current deployment documentation to reflect the unified policy and valid allowlist entry format.

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

 System:
    OS: Windows 11 10.0.26200
    CPU: (20) x64 12th Gen Intel(R) Core(TM) i7-12700H
    Memory: 7.18 GB / 31.68 GB
  Binaries:
    Node: 20.9.0 - C:\Users\joebo\AppData\Local\fnm_multishells\31276_1776363798351\node.EXE
    Yarn: 1.22.22 - C:\Program Files (x86)\Yarn\bin\yarn.CMD
    npm: 10.1.0 - C:\Users\joebo\AppData\Local\fnm_multishells\31276_1776363798351\npm.CMD
    bun: 1.2.23 - C:\Users\joebo\.bun\bin\bun.EXE
  Browsers:
    Chrome: 147.0.7727.56
    Edge: Chromium (146.0.3856.84)
    Internet Explorer: 11.0.26100.8115
<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a shared `secureConfigFetch` utility that enforces an auth-aware origin allowlist (`dangerouslyAllowedOriginsForAuthenticatedEnvironments`) for runtime `?url=` parameters in both `dicomjson` and `dicomwebproxy` datasources, and applies hardened fetch options for unauthenticated cross-origin config fetches.

- **Redirect bypass in allowlist enforcement**: `fetchConfigJson` uses the default `redirect: 'follow'` for authenticated (and same-origin) fetches. Because `resolveConfigFetchPolicy` only validates the *initial* URL's origin, an allowlisted server can issue a `302` redirect to any unallowlisted origin — including the OHIF app's own origin where session cookies would be forwarded — effectively circumventing the allowlist. The unauthenticated cross-origin path already sets `redirect: 'error'`; the same protection should be applied to the authenticated cross-origin path.

<h3>Confidence Score: 3/5</h3>

The PR introduces a real redirect-bypass gap in the core security control it adds — the allowlist can be circumvented via a server-side redirect in authenticated mode.

A P1 security finding exists in the primary new feature (secureConfigFetch.js): the hardened redirect: 'error' protection is applied only to unauthenticated cross-origin fetches, leaving the authenticated cross-origin path — which is exactly what the allowlist is designed to protect — vulnerable to redirect-based bypass.

extensions/default/src/utils/secureConfigFetch.js — the fetchConfigJson function needs redirect: 'error' on the authenticated cross-origin fetch branch.

<details open><summary><h3>Security Review</h3></summary>

- **Redirect bypass / allowlist circumvention** (`secureConfigFetch.js` lines 101-109): In authenticated (or same-origin) mode the fetch uses the default `redirect: 'follow'`. An allowlisted origin can return a `3xx` redirect to any unallowlisted origin, bypassing the `resolveConfigFetchPolicy` check. A redirect to the OHIF app's own origin also carries session cookies (`credentials: 'same-origin'`). The unauthenticated path already applies `redirect: 'error'`; the authenticated cross-origin path should do the same.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| extensions/default/src/utils/secureConfigFetch.js | New security utility implementing auth-aware fetch policy; the unauthenticated cross-origin path is well-hardened but the authenticated path omits `redirect: 'error'`, creating a redirect-bypass gap in the allowlist enforcement. |
| extensions/default/src/utils/secureConfigFetch.test.js | Good unit test coverage for policy cases; no test covers the redirect-bypass scenario (authenticated allowlisted server issuing a 3xx to an unallowlisted origin). |
| extensions/default/src/DicomJSONDataSource/index.js | Integrates shared policy utility correctly; `getStudyInstanceUIDs` silently swallows policy errors without logging, which can obscure auth-state related failures. |
| extensions/default/src/DicomWebProxyDataSource/index.ts | Integrates shared policy utility and adds optional chaining on delegate methods; `query`, `retrieve`, and `store` forwarding still dereferences the uninitialized delegate without optional chaining (pre-existing issue, unchanged). |
| platform/docs/docs/deployment/authorization.md | New documentation section accurately describes the policy; correctly documents the asymmetry between unauthenticated (hardened fetch) and authenticated (simple fetch) behaviour. |
| platform/app/public/config/default.js | Adds commented-out allowlist configuration guidance for both proxy and JSON datasources; no functional change. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: extensions/default/src/utils/secureConfigFetch.js
Line: 99-109

Comment:
**Redirect bypass voids allowlist protection in authenticated path**

When `isAuthenticated || isSameOrigin` is true the fetch uses browser-default `redirect: 'follow'`, but the origin validation in `resolveConfigFetchPolicy` only checks the *initial* URL. An allowlisted server (`https://trusted.example.com`) can respond with `302 Location: https://attacker.example.com/exfil` and the fetch will follow it silently—bypassing the allowlist entirely. The unauthenticated cross-origin path correctly uses `redirect: 'error'`; that protection must be extended to the authenticated cross-origin path as well.

A same-origin redirect (`Location: https://ohif.hospital.com/api/studies`) is the higher-impact variant: `credentials: 'same-origin'` means session cookies are forwarded to that redirect target, and if the OHIF API sets permissive CORS headers the response body becomes readable to JavaScript.

```js
// Suggested fix: use 'error' for authenticated cross-origin fetches too
const response = isSameOrigin
  ? await fetch(normalizedUrl)
  : await fetch(normalizedUrl, {
      method: 'GET',
      mode: 'cors',
      credentials: isAuthenticated ? 'include' : 'omit',
      redirect: 'error',
      referrerPolicy: 'no-referrer',
    });
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: extensions/default/src/DicomJSONDataSource/index.js
Line: 311-319

Comment:
**Silent catch hides policy violations**

`resolveConfigFetchPolicy` throws a descriptive error (e.g., "Blocked remote configuration origin …") when an authenticated cross-origin URL fails allowlist validation. The bare `catch { return; }` here swallows that error entirely, so if auth state has changed between `initialize` and `getStudyInstanceUIDs` the caller just receives `undefined` with no diagnostic. Adding at least a `console.warn` preserves debuggability.

```suggestion
      } catch (e) {
        console.warn('[DicomJSONDataSource] getStudyInstanceUIDs policy check failed:', e?.message);
        return;
      }
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Update dependencies."](https://github.com/ohif/viewers/commit/06e10b47c9d93ee64034f176b392c49fa4601044) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29860322)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->