### PR TITLE
fix(config url): Hardening fetch options.

### DIFF
--- a/extensions/default/src/utils/secureConfigFetch.js
+++ b/extensions/default/src/utils/secureConfigFetch.js
@@ -97,16 +97,14 @@ function resolveConfigFetchPolicy(rawUrl, policy = {}) {
 }
 
 async function fetchConfigJson(normalizedPolicy) {
-  const { normalizedUrl, isAuthenticated, isSameOrigin } = normalizedPolicy;
-  const response = isAuthenticated || isSameOrigin
-    ? await fetch(normalizedUrl)
-    : await fetch(normalizedUrl, {
-        method: 'GET',
-        mode: 'cors',
-        credentials: 'omit',
-        redirect: 'error',
-        referrerPolicy: 'no-referrer',
-      });
+  const { normalizedUrl } = normalizedPolicy;
+  const response = await fetch(normalizedUrl, {
+    method: 'GET',
+    mode: 'cors',
+    credentials: 'same-origin',
+    redirect: 'error',
+    referrerPolicy: 'no-referrer',
+  });
 
   if (!response.ok) {
     throw new Error(`Failed to fetch dynamic datasource configuration (${response.status})`);
@@ -114,7 +112,4 @@ async function fetchConfigJson(normalizedPolicy) {
 
   return response.json();
 }
-export {
-  resolveConfigFetchPolicy,
-  fetchConfigJson,
-};
+export { resolveConfigFetchPolicy, fetchConfigJson };

--- a/extensions/default/src/utils/secureConfigFetch.test.js
+++ b/extensions/default/src/utils/secureConfigFetch.test.js
@@ -103,14 +103,14 @@ describe('secureConfigFetch', () => {
         expect.objectContaining({
           method: 'GET',
           mode: 'cors',
-          credentials: 'omit',
+          credentials: 'same-origin',
           redirect: 'error',
           referrerPolicy: 'no-referrer',
         })
       );
     });
 
-    it('uses simple fetch for unauthenticated same-origin requests', async () => {
+    it('uses hardened fetch options for unauthenticated same-origin requests', async () => {
       global.fetch.mockResolvedValue({
         status: 200,
         ok: true,
@@ -124,11 +124,18 @@ describe('secureConfigFetch', () => {
       });
 
       expect(global.fetch).toHaveBeenCalledWith(
-        `${window.location.origin}/protected/config.json`
+        `${window.location.origin}/protected/config.json`,
+        expect.objectContaining({
+          method: 'GET',
+          mode: 'cors',
+          credentials: 'same-origin',
+          redirect: 'error',
+          referrerPolicy: 'no-referrer',
+        })
       );
     });
 
-    it('uses simple fetch in authenticated environments', async () => {
+    it('uses hardened fetch options in authenticated environments', async () => {
       global.fetch.mockResolvedValue({
         status: 200,
         ok: true,
@@ -141,7 +148,16 @@ describe('secureConfigFetch', () => {
         isSameOrigin: false,
       });
 
-      expect(global.fetch).toHaveBeenCalledWith('https://trusted.example.com/config.json');
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://trusted.example.com/config.json',
+        expect.objectContaining({
+          method: 'GET',
+          mode: 'cors',
+          credentials: 'same-origin',
+          redirect: 'error',
+          referrerPolicy: 'no-referrer',
+        })
+      );
     });
   });
 });


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context
Hardened fetch of `DicomJSON` and `DicomWebProxy` config url fetching.

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results
Use stricter fetch options.

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

  System:
    OS: Windows 11 10.0.26200
    CPU: (20) x64 12th Gen Intel(R) Core(TM) i7-12700H
    Memory: 3.86 GB / 31.68 GB
  Binaries:
    Node: 22.17.0 - C:\Users\joebo\AppData\Local\fnm_multishells\7300_1777381936598\node.EXE
    Yarn: 1.22.22 - C:\Program Files (x86)\Yarn\bin\yarn.CMD
    npm: 11.6.2 - C:\Users\joebo\AppData\Local\fnm_multishells\7300_1777381936598\npm.CMD
    bun: 1.2.23 - C:\Users\joebo\.bun\bin\bun.EXE
  Browsers:
    Chrome: 147.0.7727.117
    Edge: Chromium (146.0.3856.84)
    Internet Explorer: 11.0.26100.8115
<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR simplifies `fetchConfigJson` to apply a single set of hardened fetch options (`credentials: 'same-origin'`, `redirect: 'error'`, `referrerPolicy: 'no-referrer'`) to all config URL fetches instead of branching on `isAuthenticated`/`isSameOrigin`. Tests are updated accordingly.

- The unified `redirect: 'error'` is a behavioural change: authenticated and same-origin requests previously used bare `fetch()` (i.e. `redirect: 'follow'`), so any deployment whose config URL involves a redirect on those paths will now fail.

<h3>Confidence Score: 4/5</h3>

Safe to merge with the awareness that `redirect: 'error'` now covers previously unrestricted paths.

One P2 finding: extending `redirect: 'error'` to authenticated/same-origin requests is an intentional hardening but could silently break deployments using redirecting config URLs. No P0/P1 issues found; tests are correctly updated.

extensions/default/src/utils/secureConfigFetch.js — review the redirect behaviour change for authenticated/same-origin paths.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| extensions/default/src/utils/secureConfigFetch.js | Unified fetch options applied to all requests; `redirect: 'error'` now also covers authenticated/same-origin paths (previously `redirect: 'follow'`), which is a breaking change for redirecting config URLs. `isAuthenticated`/`isSameOrigin` still returned but unused in `fetchConfigJson`. |
| extensions/default/src/utils/secureConfigFetch.test.js | Test cases correctly updated to match new unified fetch options with `credentials: 'same-origin'`; all three `fetchConfigJson` test paths now assert the hardened options object. |

</details>


</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `extensions/default/src/utils/secureConfigFetch.js`, line 91-96 ([link](https://github.com/ohif/viewers/blob/e025f2100c9fc90a9c52822fe5ca80cc4aa6abae/extensions/default/src/utils/secureConfigFetch.js#L91-L96)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Dead return fields in `resolveConfigFetchPolicy`**

   `isAuthenticated` (line 94) and `isSameOrigin` (line 95) are still computed and returned by `resolveConfigFetchPolicy`, but `fetchConfigJson` no longer destructures or uses them. These two fields in the returned object are now unused dead code. Consider removing them from the return value (the variables themselves are still needed internally for the origin-check guard at line 82).

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: extensions/default/src/utils/secureConfigFetch.js
   Line: 91-96

   Comment:
   **Dead return fields in `resolveConfigFetchPolicy`**

   `isAuthenticated` (line 94) and `isSameOrigin` (line 95) are still computed and returned by `resolveConfigFetchPolicy`, but `fetchConfigJson` no longer destructures or uses them. These two fields in the returned object are now unused dead code. Consider removing them from the return value (the variables themselves are still needed internally for the origin-check guard at line 82).

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: extensions/default/src/utils/secureConfigFetch.js
Line: 101-107

Comment:
**`redirect: 'error'` now blocks previously-allowed redirects**

Before this change, authenticated and same-origin requests used bare `fetch(url)` which defaults to `redirect: 'follow'`. Only unauthenticated cross-origin requests had `redirect: 'error'`. Now all requests reject on any redirect, including HTTP→HTTPS or path-normalizing redirects for same-origin config URLs. Any deployment that currently relies on a redirecting config URL in an authenticated or same-origin context will silently break with a network error after this change. If this tightening is intentional, it's worth documenting as a breaking change for operators.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Update unit tests."](https://github.com/ohif/viewers/commit/366a816a2402b63b421b5d2aa777fcb33be06f23) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30073573)</sub>

<!-- /greptile_comment -->