### PR TITLE
fix(ToolGroupService): Centralize tool binding persistence and provide API to add and remove persisted bindings.

### DIFF
--- a/extensions/cornerstone/src/services/ToolGroupService/ToolGroupService.ts
+++ b/extensions/cornerstone/src/services/ToolGroupService/ToolGroupService.ts
@@ -23,6 +23,12 @@ type Tools = {
   disabled?: Tool[];
 };
 
+type ToolBindings = Array<Record<string, unknown>>;
+type PersistedToolBindings = Record<string, Record<string, ToolBindings>>;
+type ApplyToolBindingsOptions = {
+  replaceExisting?: boolean;
+};
+
 export default class ToolGroupService {
   public static REGISTRATION = {
     name: 'toolGroupService',
@@ -255,22 +261,50 @@ export default class ToolGroupService {
   public getToolBindings(
     toolGroupId: string,
     toolName: string
-  ): Array<Record<string, unknown>> | undefined {
+  ): ToolBindings | undefined {
     return this.toolBindingsMap.get(toolGroupId)?.get(toolName);
   }
 
-  public setToolBindings(
-    toolGroupId: string,
-    toolName: string,
-    bindings: Array<Record<string, unknown>>
-  ): void {
+  public setToolBindings(toolGroupId: string, toolName: string, bindings: ToolBindings): void {
     if (!this.toolBindingsMap.has(toolGroupId)) {
       this.toolBindingsMap.set(toolGroupId, new Map());
     }
     this.toolBindingsMap.get(toolGroupId).set(toolName, bindings);
   }
 
-  public applyToolBindings(toolGroupId: string, toolName: string): void {
+  public persistToolBindings(toolGroupId: string, toolName: string, bindings: ToolBindings): void {
+    const persistedBindings = this._readPersistedToolBindings();
+    if (!persistedBindings[toolGroupId]) {
+      persistedBindings[toolGroupId] = {};
+    }
+
+    persistedBindings[toolGroupId][toolName] = bindings;
+    this._writePersistedToolBindings(persistedBindings);
+  }
+
+  public removePersistedToolBindings(toolGroupId: string, toolName?: string): void {
+    const persistedBindings = this._readPersistedToolBindings();
+    if (!persistedBindings[toolGroupId]) {
+      return;
+    }
+
+    if (toolName) {
+      delete persistedBindings[toolGroupId][toolName];
+      if (!Object.keys(persistedBindings[toolGroupId]).length) {
+        delete persistedBindings[toolGroupId];
+      }
+    } else {
+      delete persistedBindings[toolGroupId];
+    }
+
+    this._writePersistedToolBindings(persistedBindings);
+  }
+
+  public applyToolBindings(
+    toolGroupId: string,
+    toolName: string,
+    options: ApplyToolBindingsOptions = {}
+  ): void {
     const toolGroup = ToolGroupManager.getToolGroup(toolGroupId);
     if (!toolGroup || !toolGroup.hasTool(toolName)) {
       return;
@@ -285,6 +319,10 @@ export default class ToolGroupService {
       mode === Enums.ToolModes.Passive ||
       mode === Enums.ToolModes.Enabled
     ) {
+      if (options.replaceExisting) {
+        // Opt-in behavior for callers that need replacement semantics.
+        toolGroup.setToolDisabled(toolName);
+      }
       toolGroup.setToolActive(toolName, { bindings });
     }
   }
@@ -374,22 +412,43 @@ export default class ToolGroupService {
   }
 
   private _loadPersistedBindings(toolGroupId: string): void {
+    const toolGroupBindings = this._readPersistedToolBindings()[toolGroupId];
+    if (!toolGroupBindings) {
+      return;
+    }
+
+    for (const [toolName, bindings] of Object.entries(toolGroupBindings)) {
+      this.setToolBindings(toolGroupId, toolName, bindings as ToolBindings);
+    }
+  }
+
+  private _readPersistedToolBindings(): PersistedToolBindings {
     try {
       const stored = localStorage.getItem(this._getToolBindingsStorageKey());
       if (!stored) {
-        return;
+        return {};
       }
+
       const parsed = JSON.parse(stored);
-      const toolGroupBindings = parsed[toolGroupId];
-      if (!toolGroupBindings) {
-        return;
+      if (!parsed || typeof parsed !== 'object') {
+        return {};
       }
-      for (const [toolName, bindings] of Object.entries(toolGroupBindings)) {
-        this.setToolBindings(toolGroupId, toolName, bindings as Array<Record<string, unknown>>);
-      }
+
+      return parsed as PersistedToolBindings;
     } catch {
       // ignore corrupt localStorage
+      return {};
     }
+  }
+
+  private _writePersistedToolBindings(bindings: PersistedToolBindings): void {
+    const storageKey = this._getToolBindingsStorageKey();
+    if (!Object.keys(bindings).length) {
+      localStorage.removeItem(storageKey);
+      return;
+    }
+
+    localStorage.setItem(storageKey, JSON.stringify(bindings));
   }
 
   private _getToolBindingsStorageKey(): string {

--- a/extensions/cornerstone/src/services/ToolGroupService/ToolGroupService.ts
+++ b/extensions/cornerstone/src/services/ToolGroupService/ToolGroupService.ts
@@ -45,6 +45,7 @@ export default class ToolGroupService {
   customizationService: any;
   private toolGroupIds: Set<string> = new Set();
   private toolBindingsMap: Map<string, Map<string, Array<Record<string, unknown>>>> = new Map();
+  private defaultToolBindingsMap: Map<string, Map<string, ToolBindings>> = new Map();
   /**
    * Service-specific
    */
@@ -137,6 +138,7 @@ export default class ToolGroupService {
     ToolGroupManager.destroy();
     this.toolGroupIds = new Set();
     this.toolBindingsMap.clear();
+    this.defaultToolBindingsMap.clear();
 
     eventTarget.removeEventListener(Enums.Events.TOOL_ACTIVATED, this._onToolActivated);
   }
@@ -269,7 +271,12 @@ export default class ToolGroupService {
     if (!this.toolBindingsMap.has(toolGroupId)) {
       this.toolBindingsMap.set(toolGroupId, new Map());
     }
-    this.toolBindingsMap.get(toolGroupId).set(toolName, bindings);
+    this.toolBindingsMap.get(toolGroupId).set(toolName, this._cloneToolBindings(bindings));
+  }
+
+  public getDefaultToolBindings(toolGroupId: string, toolName: string): ToolBindings | undefined {
+    const defaultBindings = this.defaultToolBindingsMap.get(toolGroupId)?.get(toolName);
+    return defaultBindings ? this._cloneToolBindings(defaultBindings) : undefined;
   }
 
   public persistToolBindings(toolGroupId: string, toolName: string, bindings: ToolBindings): void {
@@ -348,6 +355,7 @@ export default class ToolGroupService {
       active.forEach(({ toolName, bindings }) => {
         if (bindings) {
           this.setToolBindings(toolGroup.id, toolName, bindings);
+          this._setDefaultToolBindingsIfMissing(toolGroup.id, toolName, bindings);
         }
         toolGroup.setToolActive(toolName, { bindings });
       });
@@ -357,6 +365,7 @@ export default class ToolGroupService {
       passive.forEach(({ toolName, bindings }) => {
         if (bindings) {
           this.setToolBindings(toolGroup.id, toolName, bindings);
+          this._setDefaultToolBindingsIfMissing(toolGroup.id, toolName, bindings);
         }
         toolGroup.setToolPassive(toolName);
       });
@@ -366,6 +375,7 @@ export default class ToolGroupService {
       enabled.forEach(({ toolName, bindings }) => {
         if (bindings) {
           this.setToolBindings(toolGroup.id, toolName, bindings);
+          this._setDefaultToolBindingsIfMissing(toolGroup.id, toolName, bindings);
         }
         toolGroup.setToolEnabled(toolName);
       });
@@ -375,9 +385,25 @@ export default class ToolGroupService {
       disabled.forEach(({ toolName, bindings }) => {
         if (bindings) {
           this.setToolBindings(toolGroup.id, toolName, bindings);
+          this._setDefaultToolBindingsIfMissing(toolGroup.id, toolName, bindings);
         }
         toolGroup.setToolDisabled(toolName);
       });
+    }
+  }
+
+  private _setDefaultToolBindingsIfMissing(
+    toolGroupId: string,
+    toolName: string,
+    bindings: ToolBindings
+  ): void {
+    if (!this.defaultToolBindingsMap.has(toolGroupId)) {
+      this.defaultToolBindingsMap.set(toolGroupId, new Map());
+    }
+
+    const toolMap = this.defaultToolBindingsMap.get(toolGroupId);
+    if (!toolMap.has(toolName)) {
+      toolMap.set(toolName, this._cloneToolBindings(bindings));
     }
   }
 
@@ -449,6 +475,10 @@ export default class ToolGroupService {
     }
 
     localStorage.setItem(storageKey, JSON.stringify(bindings));
+  }
+
+  private _cloneToolBindings(bindings: ToolBindings): ToolBindings {
+    return bindings.map(binding => ({ ...binding }));
   }
 
   private _getToolBindingsStorageKey(): string {

--- a/extensions/cornerstone/src/services/ToolGroupService/ToolGroupService.ts
+++ b/extensions/cornerstone/src/services/ToolGroupService/ToolGroupService.ts
@@ -443,8 +443,19 @@ export default class ToolGroupService {
       return;
     }
 
+    const toolGroup = ToolGroupManager.getToolGroup(toolGroupId);
+
     for (const [toolName, bindings] of Object.entries(toolGroupBindings)) {
       this.setToolBindings(toolGroupId, toolName, bindings as ToolBindings);
+
+      if (!toolGroup || !toolGroup.hasTool(toolName)) {
+        continue;
+      }
+
+      const { mode } = toolGroup.getToolOptions(toolName);
+      if (mode === Enums.ToolModes.Active) {
+        this.applyToolBindings(toolGroupId, toolName, { replaceExisting: true });
+      }
     }
   }
 

--- a/extensions/cornerstone/src/services/ToolGroupService/ToolGroupService.ts
+++ b/extensions/cornerstone/src/services/ToolGroupService/ToolGroupService.ts
@@ -307,6 +307,12 @@ export default class ToolGroupService {
     this._writePersistedToolBindings(persistedBindings);
   }
 
+  /**
+   * Applies the currently tracked bindings to the runtime tool instance.
+   *
+   * Note: this method may activate tools that are currently Passive or Enabled.
+   * Assigning bindings is treated as making the tool interactable.
+   */
   public applyToolBindings(
     toolGroupId: string,
     toolName: string,

--- a/extensions/default/src/customizations/userPreferencesCustomization.tsx
+++ b/extensions/default/src/customizations/userPreferencesCustomization.tsx
@@ -26,16 +26,6 @@ const MODIFIER_OPTIONS = [
 
 const DEFAULT_TOOL_BINDINGS_STORAGE_KEY = 'user-preferred-tool-bindings';
 
-function getToolBindingsStorageKey(customizationService: any): string {
-  const customizationValue = customizationService?.getCustomization(
-    'ohif.userPreferences.toolBindingsStorageKey'
-  );
-
-  return typeof customizationValue === 'string' && customizationValue.length > 0
-    ? customizationValue
-    : DEFAULT_TOOL_BINDINGS_STORAGE_KEY;
-}
-
 function getToolModifier(toolGroupService: any, toolGroupId: string, toolName: string): string | null {
   if (!toolGroupService) {
     return null;
@@ -55,8 +45,6 @@ function UserPreferencesModalDefault({ hide }: { hide: () => void }) {
   const { hotkeysManager, servicesManager } = useSystem();
   const { t, i18n: i18nextInstance } = useTranslation('UserPreferencesModal');
   const toolGroupService = (servicesManager as any)?.services?.toolGroupService;
-  const customizationService = (servicesManager as any)?.services?.customizationService;
-  const toolBindingsStorageKey = getToolBindingsStorageKey(customizationService);
 
   const { hotkeyDefinitions = {}, hotkeyDefaults = {} } = hotkeysManager;
 
@@ -125,7 +113,7 @@ function UserPreferencesModalDefault({ hide }: { hide: () => void }) {
     }));
 
     hotkeysManager.restoreDefaultBindings();
-    localStorage.removeItem(toolBindingsStorageKey);
+    toolGroupService?.removePersistedToolBindings('mpr', 'Crosshairs');
   };
 
   const displayNames = React.useMemo(() => {
@@ -280,11 +268,10 @@ function UserPreferencesModalDefault({ hide }: { hide: () => void }) {
                   { mouseButton: 1, modifierKey: Number(state.crosshairModifier) },
                 ];
                 toolGroupService.setToolBindings('mpr', 'Crosshairs', bindings);
-                toolGroupService.applyToolBindings('mpr', 'Crosshairs');
-                localStorage.setItem(
-                  toolBindingsStorageKey,
-                  JSON.stringify({ mpr: { Crosshairs: bindings } })
-                );
+                toolGroupService.applyToolBindings('mpr', 'Crosshairs', {
+                  replaceExisting: true,
+                });
+                toolGroupService.persistToolBindings('mpr', 'Crosshairs', bindings);
               }
 
               hotkeysModule.stopRecord();

--- a/extensions/default/src/customizations/userPreferencesCustomization.tsx
+++ b/extensions/default/src/customizations/userPreferencesCustomization.tsx
@@ -26,7 +26,12 @@ const MODIFIER_OPTIONS = [
 
 const DEFAULT_TOOL_BINDINGS_STORAGE_KEY = 'user-preferred-tool-bindings';
 
-function getToolModifier(toolGroupService: any, toolGroupId: string, toolName: string): string | null {
+function getToolModifier(
+  toolGroupService: any,
+  toolGroupId: string,
+  toolName: string,
+  mouseButton: number
+): string | null {
   if (!toolGroupService) {
     return null;
   }
@@ -35,7 +40,28 @@ function getToolModifier(toolGroupService: any, toolGroupId: string, toolName: s
     return null;
   }
   const modifierBinding = bindings.find(
-    binding => binding.modifierKey != null && binding.numTouchPoints == null
+    binding =>
+      binding.mouseButton === mouseButton &&
+      binding.modifierKey != null &&
+      binding.numTouchPoints == null
+  );
+
+  return modifierBinding?.modifierKey != null ? String(modifierBinding.modifierKey) : null;
+}
+
+function getModifierFromBindings(
+  bindings: Array<Record<string, unknown>> | undefined,
+  mouseButton: number
+): string | null {
+  if (!bindings?.length) {
+    return null;
+  }
+
+  const modifierBinding = bindings.find(
+    binding =>
+      binding.mouseButton === mouseButton &&
+      binding.modifierKey != null &&
+      binding.numTouchPoints == null
   );
 
   return modifierBinding?.modifierKey != null ? String(modifierBinding.modifierKey) : null;
@@ -77,7 +103,11 @@ function UserPreferencesModalDefault({ hide }: { hide: () => void }) {
   const currentLanguage = currentLanguageFn();
 
   const initialCrosshairModifier = useMemo(
-    () => getToolModifier(toolGroupService, 'mpr', 'Crosshairs'),
+    () => getToolModifier(toolGroupService, 'mpr', 'Crosshairs', 1),
+    [toolGroupService]
+  );
+  const defaultCrosshairBindings = useMemo(
+    () => toolGroupService?.getDefaultToolBindings?.('mpr', 'Crosshairs'),
     [toolGroupService]
   );
 
@@ -109,10 +139,16 @@ function UserPreferencesModalDefault({ hide }: { hide: () => void }) {
       ...state,
       languageValue: defaultLanguage.value,
       hotkeyDefinitions: resolvedHotkeyDefaults,
-      crosshairModifier: initialCrosshairModifier,
+      crosshairModifier: getModifierFromBindings(defaultCrosshairBindings, 1),
     }));
 
     hotkeysManager.restoreDefaultBindings();
+    if (toolGroupService && defaultCrosshairBindings?.length) {
+      toolGroupService.setToolBindings('mpr', 'Crosshairs', defaultCrosshairBindings);
+      toolGroupService.applyToolBindings('mpr', 'Crosshairs', {
+        replaceExisting: true,
+      });
+    }
     toolGroupService?.removePersistedToolBindings('mpr', 'Crosshairs');
   };
 

--- a/platform/docs/docs/platform/services/data/ToolGroupService.md
+++ b/platform/docs/docs/platform/services/data/ToolGroupService.md
@@ -46,7 +46,7 @@ The `ToolGroupService` emits the following events:
 - `setToolBindings(toolGroupId, toolName, bindings)`: Updates the service's internal binding map for the specified tool in the given tool group. This does not change the tool's active runtime mode by itself.
 - `getAllToolBindings()`: Returns all bindings currently stored in the service's internal binding map across tool groups.
 - `getDefaultToolBindings(toolGroupId, toolName)`: Returns the default bindings captured when the tool group was initialized.
-- `applyToolBindings(toolGroupId, toolName, options?)`: Reads the currently tracked bindings for that tool and applies them to the underlying runtime tool instance (via tool activation). Use this after `setToolBindings` when you want runtime behavior to update. Set `options.replaceExisting` to `true` to clear previous active bindings before applying.
+- `applyToolBindings(toolGroupId, toolName, options?)`: Reads the currently tracked bindings for that tool and applies them to the underlying runtime tool instance (via tool activation). This can activate tools that are currently `Passive` or `Enabled`, since assigning bindings is treated as making the tool interactable. Use this after `setToolBindings` when you want runtime behavior to update. Set `options.replaceExisting` to `true` to clear previous active bindings before applying.
 - `persistToolBindings(toolGroupId, toolName, bindings)`: Persists tool bindings for a specific tool in a tool group to user preferences storage.
 - `removePersistedToolBindings(toolGroupId, toolName?)`: Removes persisted tool bindings for a specific tool, or for the whole tool group when `toolName` is omitted.
 

--- a/platform/docs/docs/platform/services/data/ToolGroupService.md
+++ b/platform/docs/docs/platform/services/data/ToolGroupService.md
@@ -45,6 +45,7 @@ The `ToolGroupService` emits the following events:
 - `getToolBindings(toolGroupId, toolName)`: Returns the bindings from the service's internal binding map for the specified tool in the given tool group.
 - `setToolBindings(toolGroupId, toolName, bindings)`: Updates the service's internal binding map for the specified tool in the given tool group. This does not change the tool's active runtime mode by itself.
 - `getAllToolBindings()`: Returns all bindings currently stored in the service's internal binding map across tool groups.
+- `getDefaultToolBindings(toolGroupId, toolName)`: Returns the default bindings captured when the tool group was initialized.
 - `applyToolBindings(toolGroupId, toolName, options?)`: Reads the currently tracked bindings for that tool and applies them to the underlying runtime tool instance (via tool activation). Use this after `setToolBindings` when you want runtime behavior to update. Set `options.replaceExisting` to `true` to clear previous active bindings before applying.
 - `persistToolBindings(toolGroupId, toolName, bindings)`: Persists tool bindings for a specific tool in a tool group to user preferences storage.
 - `removePersistedToolBindings(toolGroupId, toolName?)`: Removes persisted tool bindings for a specific tool, or for the whole tool group when `toolName` is omitted.

--- a/platform/docs/docs/platform/services/data/ToolGroupService.md
+++ b/platform/docs/docs/platform/services/data/ToolGroupService.md
@@ -41,6 +41,13 @@ The `ToolGroupService` emits the following events:
 - `createToolGroupAndAddTools(toolGroupId, tools)`: Creates a new tool group and adds the specified tools to it.
 - `getToolConfiguration(toolGroupId, toolName)`: Retrieves the configuration for the specified tool in the given tool group.
 - `setToolConfiguration(toolGroupId, toolName, config)`: Sets the configuration for the specified tool in the given tool group.
+- `getActivePrimaryMouseButtonTool(toolGroupId?)`: Returns the active primary mouse button tool for the specified tool group, or for the active viewport's tool group when omitted.
+- `getToolBindings(toolGroupId, toolName)`: Returns the bindings from the service's internal binding map for the specified tool in the given tool group.
+- `setToolBindings(toolGroupId, toolName, bindings)`: Updates the service's internal binding map for the specified tool in the given tool group. This does not change the tool's active runtime mode by itself.
+- `getAllToolBindings()`: Returns all bindings currently stored in the service's internal binding map across tool groups.
+- `applyToolBindings(toolGroupId, toolName, options?)`: Reads the currently tracked bindings for that tool and applies them to the underlying runtime tool instance (via tool activation). Use this after `setToolBindings` when you want runtime behavior to update. Set `options.replaceExisting` to `true` to clear previous active bindings before applying.
+- `persistToolBindings(toolGroupId, toolName, bindings)`: Persists tool bindings for a specific tool in a tool group to user preferences storage.
+- `removePersistedToolBindings(toolGroupId, toolName?)`: Removes persisted tool bindings for a specific tool, or for the whole tool group when `toolName` is omitted.
 
 ## Usage
 


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context
- It started as a result of this comment in another PR: https://github.com/OHIF/Viewers/pull/5914#discussion_r3162765384
- Previously, tool binding persistence logic was split between the user preferences customization and `ToolGroupService`, which duplicated storage-key resolution and made persistence behavior harder to reason about. 
- Also persisting Crosshair bindings was clobbering any other persisted bindings in localStorage. 
- Updating Crosshair modifier bindings could leave previous bindings active.
- Resetting the Crosshair modifier did not restore to the tool group default but the current modifier persisted for the rest of the session
- If the Crosshair tool were active by default (i.e. when entering MPR mode) and if there was a preference in localStorage different than the default, the localStorage was not applied.

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results
- Centralized tool-binding persistence in `ToolGroupService` by adding:
  - `persistToolBindings(toolGroupId, toolName, bindings)`
  - `removePersistedToolBindings(toolGroupId, toolName?)`
- Removed duplicated storage-key/localStorage logic from `userPreferencesCustomization.tsx` and routed persistence calls through `toolGroupService`.
- Updated Crosshairs preferences flow to:
  - persist via `toolGroupService.persistToolBindings(...)`
  - remove only Crosshairs persisted binding via `toolGroupService.removePersistedToolBindings('mpr', 'Crosshairs')`
- Added explicit runtime apply semantics in `ToolGroupService`:
  - `applyToolBindings(toolGroupId, toolName, options?)`
  - supports `options.replaceExisting` to reset existing active bindings before reapplying.
- Updated Crosshairs apply call to use replacement semantics:
  - `applyToolBindings('mpr', 'Crosshairs', { replaceExisting: true })`
- Updated `ToolGroupService` docs to:
  - document newly exposed public methods
  - clarify that `setToolBindings` updates internal service state, while `applyToolBindings` applies those bindings to runtime tool behavior.
- ToolGroupService._loadPersistedBindings still loads persisted bindings into the internal map (setToolBindings), but now also applies them immediately when the affected tool is already Active, via applyToolBindings(..., { replaceExisting: true }).
- ToolGroupService
  - Adds a defaultToolBindingsMap captured once during normal tool-group initialization (when bindings are provided).
  - Adds getDefaultToolBindings(toolGroupId, toolName) to read those defaults (cloned).
  - setToolBindings now stores cloned binding objects (_cloneToolBindings) to reduce accidental shared mutation.
  - Clears the defaults map on service destroy().
- userPreferencesCustomization.tsx
  - Uses getDefaultToolBindings('mpr','Crosshairs') (memoized once as defaultCrosshairBindings) to drive reset UI/runtime restore.
  - On reset: restores runtime Crosshairs bindings using defaults (setToolBindings + applyToolBindings with replace semantics), then clears persisted prefs (removePersistedToolBindings).
  - Makes modifier extraction explicit by requiring mouseButton match (passed 1 for Crosshairs).
<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing
#### Test A - Previous preferences removed
1. Launch OHIF in incognito mode.
2. Launch a study in MPR.
3. Activate the crosshairs tool.
4. Note that Shift+Left mouse button controls the crosshairs.
5. Open the user preferences and change the crosshairs binding to be something else (e.g. Ctrl+Left mouse button).
6. Ensure that the new binding takes effect and any previous binding is no longer present.

#### Test B - Reset preferences restores tool group binding
1. Launch OHIF in incognito mode.
2. Launch a study in MPR.
3. Activate the crosshairs tool.
4. Note that Shift+Left mouse button controls the crosshairs.*
5. Open the user preferences and change the crosshairs binding to be something else (e.g. Ctrl+Left mouse button).
6. Ensure that the new binding takes effect.
7. Refresh the browser.
8. The binding set on step 5 should be the one active for Crosshairs MPR
9. Open the user preferences and click reset to default.
10. Ensure that the default Shift+Left mouse button controls the crosshairs.*

* Note that if the tool group default is changed to something else, then that will be the default.

#### Test C - Preference binding applied when Crosshair tool is active by default
1. Set the Crosshair tool to be active by default for the MPR tool group.
2. Launch OHIF in incognito mode.
3. Open the user preferences and change the crosshairs binding to be something else (e.g. Ctrl+Left mouse button).
4. Refresh the browser.
5. Launch a study in MPR.
6. The Crosshair tool should be active and the key binding preference in step 3 should be the one that controls the crosshairs.

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

  System:
    OS: Windows 11 10.0.26200
    CPU: (20) x64 12th Gen Intel(R) Core(TM) i7-12700H
    Memory: 5.63 GB / 31.68 GB
  Binaries:
    Node: 20.9.0 - C:\Users\joebo\AppData\Local\fnm_multishells\24236_1777488400307\node.EXE
    Yarn: 1.22.22 - C:\Program Files (x86)\Yarn\bin\yarn.CMD
    npm: 10.1.0 - C:\Users\joebo\AppData\Local\fnm_multishells\24236_1777488400307\npm.CMD
    bun: 1.2.23 - C:\Users\joebo\.bun\bin\bun.EXE
  Browsers:
    Chrome: 147.0.7727.117
    Edge: Chromium (146.0.3856.84)
    Internet Explorer: 11.0.26100.8115
<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR centralises tool-binding persistence in `ToolGroupService`, replacing scattered `localStorage` calls in the UI layer with dedicated service methods (`persistToolBindings`, `removePersistedToolBindings`). It also captures default bindings at tool-group init time and applies persisted bindings immediately when a tool is already Active on load, closing several Crosshairs-specific regressions.

- **`ToolGroupService`**: adds `persistToolBindings`, `removePersistedToolBindings`, `getDefaultToolBindings`, `applyToolBindings` with `replaceExisting` semantics, and `_loadPersistedBindings` now applies bindings immediately for Active tools; `defaultToolBindingsMap` captures initial bindings once and survives the session until `destroy()`.
- **`userPreferencesCustomization.tsx`**: removes duplicated storage-key resolution; reset path now calls `setToolBindings` + `applyToolBindings({ replaceExisting: true })` with the captured defaults before clearing the persisted preference, ensuring the runtime is immediately consistent without requiring a page reload.
- **Docs**: all new public API surface is documented, including the `replaceExisting` flag and the semantic distinction between `setToolBindings` (map update) and `applyToolBindings` (runtime update).

<h3>Confidence Score: 5/5</h3>

Safe to merge — the refactor is well-scoped, the new API is internally consistent, and the previously reported runtime-restore gap on reset has been addressed.

All three changed files are in good shape. The persistence centralisation is correct, the default-bindings capture is guarded against re-initialisation, and the replaceExisting path correctly clears stale modifier bindings before applying new ones. No data-loss or incorrect-runtime-state paths were found.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| extensions/cornerstone/src/services/ToolGroupService/ToolGroupService.ts | Centralises localStorage read/write, adds `persistToolBindings`/`removePersistedToolBindings`, captures default bindings on init, and applies persisted bindings immediately when the affected tool is already Active. Logic is correct and well-guarded. |
| extensions/default/src/customizations/userPreferencesCustomization.tsx | Removes duplicated localStorage key logic, routes all persistence through `toolGroupService`, and properly restores default runtime bindings on reset. Minor: `getToolModifier` and `getModifierFromBindings` share identical predicate logic. |
| platform/docs/docs/platform/services/data/ToolGroupService.md | Documents all newly exposed public methods accurately, including the `replaceExisting` option and the distinction between `setToolBindings` (map update) and `applyToolBindings` (runtime update). |

</details>


</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `extensions/default/src/customizations/userPreferencesCustomization.tsx`, line 107-117 ([link](https://github.com/ohif/viewers/blob/9b3db9ef7548cae22f1b586719ba47571dc789f9/extensions/default/src/customizations/userPreferencesCustomization.tsx#L107-L117)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Reset removes persisted binding but leaves runtime binding active**

   `onResetHandler` removes the localStorage entry via `removePersistedToolBindings`, but neither calls `setToolBindings` with the default modifier nor calls `applyToolBindings` to push that default back to the Cornerstone runtime. The Crosshairs tool continues operating with the custom binding for the rest of the current session — only a full page reload would restore the default. The save path performs all three steps (set map → apply runtime → persist); reset should symmetrically reverse them (set map to default → apply runtime → remove persisted).

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: extensions/default/src/customizations/userPreferencesCustomization.tsx
   Line: 107-117

   Comment:
   **Reset removes persisted binding but leaves runtime binding active**

   `onResetHandler` removes the localStorage entry via `removePersistedToolBindings`, but neither calls `setToolBindings` with the default modifier nor calls `applyToolBindings` to push that default back to the Cornerstone runtime. The Crosshairs tool continues operating with the custom binding for the rest of the current session — only a full page reload would restore the default. The save path performs all three steps (set map → apply runtime → persist); reset should symmetrically reverse them (set map to default → apply runtime → remove persisted).

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
extensions/default/src/customizations/userPreferencesCustomization.tsx:29-50
`getToolModifier` and `getModifierFromBindings` share identical matching logic (same `mouseButton`, `modifierKey != null`, `numTouchPoints == null` predicate). The former could delegate to the latter, eliminating the duplication and making the code easier to maintain if the matching logic ever needs to change.

```suggestion
function getToolModifier(
  toolGroupService: any,
  toolGroupId: string,
  toolName: string,
  mouseButton: number
): string | null {
  if (!toolGroupService) {
    return null;
  }
  return getModifierFromBindings(toolGroupService.getToolBindings(toolGroupId, toolName), mouseButton);
}
```


`````

</details>

<sub>Reviews (3): Last reviewed commit: ["PR feedback."](https://github.com/ohif/viewers/commit/4acc4630ea8a69f7061c11972c612a3cc1702a1d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30375940)</sub>

<!-- /greptile_comment -->