### PR TITLE
fix(StaticWadoClient): make study filters case-insensitive

### DIFF
--- a/extensions/default/src/DicomWebDataSource/utils/StaticWadoClient.test.ts
+++ b/extensions/default/src/DicomWebDataSource/utils/StaticWadoClient.test.ts
@@ -1,0 +1,54 @@
+import StaticWadoClient from './StaticWadoClient';
+
+describe('StaticWadoClient', () => {
+  const client = Object.create(StaticWadoClient.prototype) as StaticWadoClient;
+  (client as any).config = {};
+
+  describe('compareValues', () => {
+    it('matches wildcard string filters case-insensitively', () => {
+      expect(client.compareValues('*brain*', 'BRAIN WO CONTRAST', {})).toBe(true);
+      expect(client.compareValues('abc*', 'ABC123', {})).toBe(true);
+      expect(client.compareValues('*xyz', 'ABCXYZ', {})).toBe(true);
+    });
+
+    it('matches exact string filters case-insensitively', () => {
+      expect(client.compareValues('mrn123', 'MRN123', {})).toBe(true);
+      expect(client.compareValues('acc-42', 'ACC-42', {})).toBe(true);
+    });
+  });
+
+  describe('filterItem', () => {
+    it('matches study text filters case-insensitively', () => {
+      const study = {
+        '00100020': { Value: ['MRN123'] },
+        '00081030': { Value: ['BRAIN WO CONTRAST'] },
+        '00080050': { Value: ['ACC-42'] },
+      };
+
+      expect(
+        client.filterItem(
+          '00100020',
+          { '00100020': '*mrn123*' },
+          study,
+          StaticWadoClient.studyFilterKeys
+        )
+      ).toBeTruthy();
+      expect(
+        client.filterItem(
+          'studydescription',
+          { studydescription: '*brain*' },
+          study,
+          StaticWadoClient.studyFilterKeys
+        )
+      ).toBeTruthy();
+      expect(
+        client.filterItem(
+          'accessionnumber',
+          { accessionnumber: '*acc-42*' },
+          study,
+          StaticWadoClient.studyFilterKeys
+        )
+      ).toBeTruthy();
+    });
+  });
+});

--- a/extensions/default/src/DicomWebDataSource/utils/StaticWadoClient.ts
+++ b/extensions/default/src/DicomWebDataSource/utils/StaticWadoClient.ts
@@ -190,21 +190,33 @@ export default class StaticWadoClient extends api.DICOMwebClient {
       );
     }
 
-    if (typeof actual == 'string') {
+    if (typeof actual === 'string' && typeof desired === 'string') {
+      const normalizedActual = actual.toLowerCase();
+      const normalizedDesired = desired.toLowerCase();
+
       if (actual.length === 0) {
         return true;
       }
       if (desired.length === 0 || desired === '*') {
         return true;
       }
-      if (desired[0] === '*' && desired[desired.length - 1] === '*') {
-        // console.log(`Comparing ${actual} to ${desired.substring(1, desired.length - 1)}`)
-        return actual.indexOf(desired.substring(1, desired.length - 1)) != -1;
-      } else if (desired[desired.length - 1] === '*') {
-        return actual.indexOf(desired.substring(0, desired.length - 1)) != -1;
-      } else if (desired[0] === '*') {
-        return actual.indexOf(desired.substring(1)) === actual.length - desired.length + 1;
+      if (normalizedDesired[0] === '*' && normalizedDesired[normalizedDesired.length - 1] === '*') {
+        return (
+          normalizedActual.indexOf(normalizedDesired.substring(1, normalizedDesired.length - 1)) !=
+          -1
+        );
+      } else if (normalizedDesired[normalizedDesired.length - 1] === '*') {
+        return (
+          normalizedActual.indexOf(normalizedDesired.substring(0, normalizedDesired.length - 1)) !=
+          -1
+        );
+      } else if (normalizedDesired[0] === '*') {
+        return (
+          normalizedActual.indexOf(normalizedDesired.substring(1)) ===
+          normalizedActual.length - normalizedDesired.length + 1
+        );
       }
+      return normalizedDesired === normalizedActual;
     }
     return desired === actual;
   }


### PR DESCRIPTION
### Context

Fixes #6029.

The issue reports that WorkList filtering works when MRN, Study Description, and Accession Number are typed with uppercase input, but does not return the expected studies when the same values are typed lowercase.

For static WADO searches, these fields flow through `StaticWadoClient.compareValues`. Patient-name fuzzy matching already normalizes casing, but the non-fuzzy wildcard/exact string path was using case-sensitive `indexOf` and equality checks.

Reproduction proof before the fix:

- I checked out clean `origin/master` in a temporary worktree and added only the regression test from this PR.
- Command:
  `../Viewers/node_modules/.bin/jest --config extensions/default/jest.config.js extensions/default/src/DicomWebDataSource/utils/StaticWadoClient.test.ts --runInBand`
- Result on `origin/master`: 3 failures.
  - `compareValues('*brain*', 'BRAIN WO CONTRAST', {})` returned `false`.
  - `compareValues('mrn123', 'MRN123', {})` returned `false`.
  - `filterItem` for lowercase MRN wildcard matching returned `undefined`.

### Changes & Results

- Normalize both desired and actual string values before wildcard and exact comparisons in `StaticWadoClient.compareValues`.
- Add regression coverage for lowercase wildcard and exact matching.
- Add a higher-level `filterItem` regression covering the study fields from the issue: MRN, Study Description, and Accession Number.

After the fix, lowercase filters match uppercase stored values for static WADO study filtering while preserving existing date/range and non-string comparison behavior.

### Testing

Ran the focused unit test:

```bash
./node_modules/.bin/jest --config extensions/default/jest.config.js extensions/default/src/DicomWebDataSource/utils/StaticWadoClient.test.ts --runInBand
```

Result:

```text
PASS extensions/default/src/DicomWebDataSource/utils/StaticWadoClient.test.ts
Test Suites: 1 passed, 1 total
Tests: 3 passed, 3 total
```

Also checked formatting and diff whitespace:

```bash
./node_modules/.bin/prettier --check extensions/default/src/DicomWebDataSource/utils/StaticWadoClient.ts extensions/default/src/DicomWebDataSource/utils/StaticWadoClient.test.ts
git diff --check
```

### Checklist

#### PR

- [x] My Pull Request title is descriptive, accurate and follows the semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments, etc.). No new public API was added; regression tests document the changed behavior.

#### Public Documentation Updates

- [x] The documentation page has been updated as necessary for any public API additions or removals. N/A: no public API additions or removals.

#### Tested Environment

- [x] OS: macOS
- [x] Node version: v25.6.1
- [x] Browser: N/A, focused unit test only

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes case-sensitive string matching in `StaticWadoClient.compareValues` so that WorkList filters for MRN, Study Description, and Accession Number correctly match stored values regardless of input casing.

- Both `actual` and `desired` string values are now lowercased before wildcard (`*word*`, `word*`, `*word`) and exact comparisons; the fuzzy-matching branch was already case-insensitive and is unchanged.
- The type guard was tightened from `typeof actual === 'string'` to `typeof actual === 'string' && typeof desired === 'string'`, which also fixes a subtle edge case where a non-string `desired` would previously enter the string-handling block.
- A new test file adds `compareValues` unit tests for all three wildcard forms plus exact matching, and a higher-level `filterItem` integration test covering the three affected DICOM fields.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is narrowly scoped to the non-fuzzy string comparison path and does not affect date/range, numeric, or fuzzy-matching logic.

The normalization is applied consistently across all three wildcard forms and the exact-match fallback. The tightened type guard improves correctness for non-string desired values. Regression tests cover every changed branch and the three real-world DICOM fields from the bug report. No existing behaviour outside the broken case-sensitive path is altered.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| extensions/default/src/DicomWebDataSource/utils/StaticWadoClient.ts | compareValues now normalizes both actual and desired strings to lowercase before wildcard and exact comparisons; also tightens the type guard to require both values be strings. |
| extensions/default/src/DicomWebDataSource/utils/StaticWadoClient.test.ts | New test file adding regression coverage for case-insensitive wildcard/exact compareValues and higher-level filterItem scenarios for MRN, Study Description, and Accession Number. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["Fix static WADO case-insensitive study f..."](https://github.com/ohif/viewers/commit/7c188a3e9c5692078e285145cef8a2687e8346bb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33683362)</sub>

<!-- /greptile_comment -->