### PR TITLE
fix(segmentation): restore navigation for duplicated contour segments

### DIFF
--- a/extensions/cornerstone/src/commandsModule.ts
+++ b/extensions/cornerstone/src/commandsModule.ts
@@ -2403,14 +2403,25 @@ function commandsModule({
       targetSegmentInfo?: SegmentInfo;
     }) => {
       if (!targetSegmentInfo) {
+        const sourceSegmentation = segmentationService.getSegmentation(
+          sourceSegmentInfo.segmentationId
+        );
+        const sourceCachedStats =
+          sourceSegmentation?.segments?.[sourceSegmentInfo.segmentIndex]?.cachedStats;
+
         targetSegmentInfo = {
           segmentationId: sourceSegmentInfo.segmentationId,
           segmentIndex: segmentationService.getNextAvailableSegmentIndex(
             sourceSegmentInfo.segmentationId
           ),
         };
+
+        // Copy source cachedStats so jump-to-segment navigation works on the duplicate segment.
         segmentationService.addSegment(targetSegmentInfo.segmentationId, {
           segmentIndex: targetSegmentInfo.segmentIndex,
+          ...(sourceCachedStats && {
+            cachedStats: csUtils.deepClone(sourceCachedStats) as Record<string, unknown>,
+          }),
         });
       }
 

--- a/extensions/cornerstone/src/services/SegmentationService/SegmentationService.ts
+++ b/extensions/cornerstone/src/services/SegmentationService/SegmentationService.ts
@@ -896,6 +896,7 @@ class SegmentationService extends PubSubService {
       active?: boolean;
       color?: csTypes.Color; // Add color type
       visibility?: boolean; // Add visibility option
+      cachedStats?: Record<string, unknown>;
     } = {}
   ): void {
     if (config?.segmentIndex === 0) {

--- a/tests/ContourSegmentDuplicate.spec.ts
+++ b/tests/ContourSegmentDuplicate.spec.ts
@@ -3,8 +3,8 @@ import {
   test,
   visitStudy,
   waitForViewportsRendered,
+  getSvgAttribute,
 } from './utils';
-import { getSvgAttribute } from './utils/getSvgAttribute';
 
 const studyInstanceUID = '1.2.840.113619.2.290.3.3767434740.226.1600859119.501';
 const defaultSegment0Name = 'Threshold';
@@ -26,7 +26,6 @@ test.beforeEach(async ({
 });
 
 test('should duplicate a contour segment and add a new row to the panel', async ({
-  page,
   rightPanelPageObject,
 }) => {
   const panel = rightPanelPageObject.contourSegmentationPanel.panel;
@@ -52,7 +51,6 @@ test('should duplicate a contour segment and add a new row to the panel', async 
 });
 
 test('should duplicate the same segment multiple times', async ({
-  page,
   rightPanelPageObject,
 }) => {
   const panel = rightPanelPageObject.contourSegmentationPanel.panel;
@@ -107,3 +105,53 @@ test('should render the duplicated contour on the viewport', async ({
     'Expected the duplicated segment to have the same SVG path as the source'
   ).toBe(sourceSvgPath);
 });
+
+test.skip('should navigate to the correct instance number when a duplicated contour segment is selected', async ({
+  rightPanelPageObject,
+  viewportPageObject,
+}) => {
+  const panel = rightPanelPageObject.contourSegmentationPanel.panel;
+
+  // get instance overlay of the contour segment at index 0
+  const originalSegment = panel.nthSegment(0);
+  await originalSegment.click();
+  const originalSegmentInstanceInfo = (await viewportPageObject.getById('default')).overlayText.bottomRight.instanceNumber;
+  expect(originalSegmentInstanceInfo, 'Expected instance information to be displayed in the viewport overlay').toBeVisible();
+  await expect(originalSegmentInstanceInfo, 'Expected instance information to be slice 46 for the Threshold segment').toHaveText('I:46 (46/47)');
+
+  // Duplicate segment so new segment is at index 4
+  await originalSegment.actions.duplicate();
+
+  //click another segment to ensure instance number changes accordingly
+  await panel.nthSegment(2).click();
+  const anotherSegmentInstanceInfo = (await viewportPageObject.getById('default')).overlayText.bottomRight.instanceNumber;
+  expect(anotherSegmentInstanceInfo, 'Expected instance information to be displayed in the viewport overlay').toBeVisible();
+  await expect(anotherSegmentInstanceInfo, 'Expected instance information to be different from original contour').not.toHaveText('I:46 (46/47)');
+
+  //click duplicated segment to ensure instance number is consistent with original segment
+  const duplicatedSegment = panel.nthSegment(4);
+  await duplicatedSegment.click();
+  const duplicatedSegmentInstanceInfoAfter = (await viewportPageObject.getById('default')).overlayText.bottomRight.instanceNumber;
+  expect(duplicatedSegmentInstanceInfoAfter, 'Expected instance information to be displayed in the viewport overlay').toBeVisible();
+  await expect(duplicatedSegmentInstanceInfoAfter, 'Expected instance information to be same as original contour after clicking duplicated segment').toHaveText('I:46 (46/47)');
+
+  //verify the svg paths are the same for the original and duplicated segments
+  await rightPanelPageObject.contourSegmentationPanel.segmentsVisibilityToggle.click();
+  await originalSegment.toggleVisibility();
+  await originalSegment.click();
+  const originalSegmentSvgPath = await getSvgAttribute({viewportPageObject, svgInnerElement: 'path', attributeName: 'd'});
+  expect(originalSegmentSvgPath, 'Expected a visible SVG path for the original segment').not.toBeNull();
+
+  // hide original segment to show duplicate only
+  await originalSegment.toggleVisibility();
+
+  await duplicatedSegment.toggleVisibility();
+  await duplicatedSegment.click();
+  const duplicatedSegmentSvgPath = await getSvgAttribute({viewportPageObject, svgInnerElement: 'path', attributeName: 'd'});
+  expect(duplicatedSegmentSvgPath, 'Expected a visible SVG path for the duplicated segment').not.toBeNull();
+
+  expect(
+    duplicatedSegmentSvgPath,
+    'Expected the duplicated segment to have the same SVG path as the original segment'
+  ).toBe(originalSegmentSvgPath);
+} );

--- a/tests/ContourSegmentDuplicate.spec.ts
+++ b/tests/ContourSegmentDuplicate.spec.ts
@@ -1,20 +1,10 @@
-import {
-  expect,
-  test,
-  visitStudy,
-  waitForViewportsRendered,
-  getSvgAttribute,
-} from './utils';
+import { expect, test, visitStudy, waitForViewportsRendered, getSvgAttribute } from './utils';
 
 const studyInstanceUID = '1.2.840.113619.2.290.3.3767434740.226.1600859119.501';
 const defaultSegment0Name = 'Threshold';
 const defaultSegment1Name = 'Big Sphere';
 
-test.beforeEach(async ({
-  page,
-  leftPanelPageObject,
-  DOMOverlayPageObject,
-}) => {
+test.beforeEach(async ({ page, leftPanelPageObject, DOMOverlayPageObject }) => {
   const mode = 'segmentation';
   await visitStudy(page, studyInstanceUID, mode, 2000);
 
@@ -43,31 +33,43 @@ test('should duplicate a contour segment and add a new row to the panel', async 
 
   //New segment's default name is formatted as "Segment {segmentCount}"
   const newSegmentLocator = panel.nthSegment(initialCount).title;
-  await expect(newSegmentLocator, 'Expected correct title for duplicated segment').toHaveText(`Segment 5`);
+  await expect(newSegmentLocator, 'Expected correct title for duplicated segment').toHaveText(
+    `Segment 5`
+  );
 
   // Original segment titles should be unchanged
   await expect(panel.nthSegment(0).title).toHaveText(defaultSegment0Name);
   await expect(panel.nthSegment(1).title).toHaveText(defaultSegment1Name);
 });
 
-test('should duplicate the same segment multiple times', async ({
-  rightPanelPageObject,
-}) => {
+test('should duplicate the same segment multiple times', async ({ rightPanelPageObject }) => {
   const panel = rightPanelPageObject.contourSegmentationPanel.panel;
 
   const segment0 = panel.nthSegment(0);
 
   await segment0.actions.duplicate();
-  expect(await panel.getSegmentCount(), 'Expected one additional segment row after duplicating').toBe(5);
+  expect(
+    await panel.getSegmentCount(),
+    'Expected one additional segment row after duplicating'
+  ).toBe(5);
 
   const firstDuplicateTitleLocator = panel.nthSegment(4).title;
-  await expect(firstDuplicateTitleLocator, 'Expected correct title for first duplicated segment').toHaveText(`Segment 5`);
+  await expect(
+    firstDuplicateTitleLocator,
+    'Expected correct title for first duplicated segment'
+  ).toHaveText(`Segment 5`);
 
   await segment0.actions.duplicate();
-  expect(await panel.getSegmentCount(), 'Expected another segment row after duplicating the same segment again').toBe(6);
+  expect(
+    await panel.getSegmentCount(),
+    'Expected another segment row after duplicating the same segment again'
+  ).toBe(6);
 
   const secondDuplicateTitleLocator = panel.nthSegment(5).title;
-  await expect(secondDuplicateTitleLocator, 'Expected correct title for second duplicated segment').toHaveText(`Segment 6`);
+  await expect(
+    secondDuplicateTitleLocator,
+    'Expected correct title for second duplicated segment'
+  ).toHaveText(`Segment 6`);
 });
 
 test('should render the duplicated contour on the viewport', async ({
@@ -82,10 +84,16 @@ test('should render the duplicated contour on the viewport', async ({
   await segment0.toggleVisibility();
   await segment0.click();
 
-  const sourceSvgPath = await getSvgAttribute({viewportPageObject, svgInnerElement: 'path', attributeName: 'd'});
+  const sourceSvgPath = await getSvgAttribute({
+    viewportPageObject,
+    svgInnerElement: 'path',
+    attributeName: 'd',
+  });
   expect(sourceSvgPath, 'Expected a visible SVG path for the source segment').not.toBeNull();
   const sourceSvgPaths = (await viewportPageObject.getById('default')).svg('path');
-  expect(sourceSvgPaths, 'Expected only one SVG path element for the original segment').toHaveCount(1);
+  expect(sourceSvgPaths, 'Expected only one SVG path element for the original segment').toHaveCount(
+    1
+  );
 
   // New segment is at index 4
   await segment0.actions.duplicate();
@@ -95,10 +103,20 @@ test('should render the duplicated contour on the viewport', async ({
   await segment0.toggleVisibility();
   await duplicatedSegment.click();
 
-  const duplicatedSvgPath = await getSvgAttribute({viewportPageObject, svgInnerElement: 'path', attributeName: 'd'});
-  expect(duplicatedSvgPath, 'Expected a visible SVG path for the duplicated segment').not.toBeNull();
+  const duplicatedSvgPath = await getSvgAttribute({
+    viewportPageObject,
+    svgInnerElement: 'path',
+    attributeName: 'd',
+  });
+  expect(
+    duplicatedSvgPath,
+    'Expected a visible SVG path for the duplicated segment'
+  ).not.toBeNull();
   const duplicatedSvgPaths = (await viewportPageObject.getById('default')).svg('path');
-  expect(duplicatedSvgPaths, 'Expected only one SVG path element for the duplicated segment').toHaveCount(1);
+  expect(
+    duplicatedSvgPaths,
+    'Expected only one SVG path element for the duplicated segment'
+  ).toHaveCount(1);
 
   expect(
     duplicatedSvgPath,
@@ -106,7 +124,7 @@ test('should render the duplicated contour on the viewport', async ({
   ).toBe(sourceSvgPath);
 });
 
-test.skip('should navigate to the correct instance number when a duplicated contour segment is selected', async ({
+test('should navigate to the correct instance number when a duplicated contour segment is selected', async ({
   rightPanelPageObject,
   viewportPageObject,
 }) => {
@@ -115,43 +133,78 @@ test.skip('should navigate to the correct instance number when a duplicated cont
   // get instance overlay of the contour segment at index 0
   const originalSegment = panel.nthSegment(0);
   await originalSegment.click();
-  const originalSegmentInstanceInfo = (await viewportPageObject.getById('default')).overlayText.bottomRight.instanceNumber;
-  expect(originalSegmentInstanceInfo, 'Expected instance information to be displayed in the viewport overlay').toBeVisible();
-  await expect(originalSegmentInstanceInfo, 'Expected instance information to be slice 46 for the Threshold segment').toHaveText('I:46 (46/47)');
+  const originalSegmentInstanceInfo = (await viewportPageObject.getById('default')).overlayText
+    .bottomRight.instanceNumber;
+  expect(
+    originalSegmentInstanceInfo,
+    'Expected instance information to be displayed in the viewport overlay'
+  ).toBeVisible();
+  await expect(
+    originalSegmentInstanceInfo,
+    'Expected instance information to be slice 46 for the Threshold segment'
+  ).toHaveText('I:46 (46/47)');
 
   // Duplicate segment so new segment is at index 4
   await originalSegment.actions.duplicate();
 
   //click another segment to ensure instance number changes accordingly
   await panel.nthSegment(2).click();
-  const anotherSegmentInstanceInfo = (await viewportPageObject.getById('default')).overlayText.bottomRight.instanceNumber;
-  expect(anotherSegmentInstanceInfo, 'Expected instance information to be displayed in the viewport overlay').toBeVisible();
-  await expect(anotherSegmentInstanceInfo, 'Expected instance information to be different from original contour').not.toHaveText('I:46 (46/47)');
+  const anotherSegmentInstanceInfo = (await viewportPageObject.getById('default')).overlayText
+    .bottomRight.instanceNumber;
+  expect(
+    anotherSegmentInstanceInfo,
+    'Expected instance information to be displayed in the viewport overlay'
+  ).toBeVisible();
+  await expect(
+    anotherSegmentInstanceInfo,
+    'Expected instance information to be different from original contour'
+  ).not.toHaveText('I:46 (46/47)');
 
   //click duplicated segment to ensure instance number is consistent with original segment
   const duplicatedSegment = panel.nthSegment(4);
   await duplicatedSegment.click();
-  const duplicatedSegmentInstanceInfoAfter = (await viewportPageObject.getById('default')).overlayText.bottomRight.instanceNumber;
-  expect(duplicatedSegmentInstanceInfoAfter, 'Expected instance information to be displayed in the viewport overlay').toBeVisible();
-  await expect(duplicatedSegmentInstanceInfoAfter, 'Expected instance information to be same as original contour after clicking duplicated segment').toHaveText('I:46 (46/47)');
+  const duplicatedSegmentInstanceInfoAfter = (await viewportPageObject.getById('default'))
+    .overlayText.bottomRight.instanceNumber;
+  expect(
+    duplicatedSegmentInstanceInfoAfter,
+    'Expected instance information to be displayed in the viewport overlay'
+  ).toBeVisible();
+  await expect(
+    duplicatedSegmentInstanceInfoAfter,
+    'Expected instance information to be same as original contour after clicking duplicated segment'
+  ).toHaveText('I:46 (46/47)');
 
   //verify the svg paths are the same for the original and duplicated segments
   await rightPanelPageObject.contourSegmentationPanel.segmentsVisibilityToggle.click();
   await originalSegment.toggleVisibility();
   await originalSegment.click();
-  const originalSegmentSvgPath = await getSvgAttribute({viewportPageObject, svgInnerElement: 'path', attributeName: 'd'});
-  expect(originalSegmentSvgPath, 'Expected a visible SVG path for the original segment').not.toBeNull();
+  const originalSegmentSvgPath = await getSvgAttribute({
+    viewportPageObject,
+    svgInnerElement: 'path',
+    attributeName: 'd',
+  });
+  expect(
+    originalSegmentSvgPath,
+    'Expected a visible SVG path for the original segment'
+  ).not.toBeNull();
 
   // hide original segment to show duplicate only
   await originalSegment.toggleVisibility();
 
   await duplicatedSegment.toggleVisibility();
   await duplicatedSegment.click();
-  const duplicatedSegmentSvgPath = await getSvgAttribute({viewportPageObject, svgInnerElement: 'path', attributeName: 'd'});
-  expect(duplicatedSegmentSvgPath, 'Expected a visible SVG path for the duplicated segment').not.toBeNull();
+  const duplicatedSegmentSvgPath = await getSvgAttribute({
+    viewportPageObject,
+    svgInnerElement: 'path',
+    attributeName: 'd',
+  });
+  expect(
+    duplicatedSegmentSvgPath,
+    'Expected a visible SVG path for the duplicated segment'
+  ).not.toBeNull();
 
   expect(
     duplicatedSegmentSvgPath,
     'Expected the duplicated segment to have the same SVG path as the original segment'
   ).toBe(originalSegmentSvgPath);
-} );
+});


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

Fixes #6030 

When duplicating a contour segment, clicking the duplicate in the segmentation panel did not navigate the viewport to the correct slice - the viewer just stayed on the current slice.

**Root cause:** `addSegment` creates the new segment with an empty `cachedStats: {}`. Navigation depends on `cachedStats.center` to jump to the correct slice. Without it, the slice-based fallback cannot resolve a target, so clicking the duplicate in the panel does not move the viewport.


<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes

- `commandsModule.ts` — in `copyContourSegment`, read `sourceCachedStats` from the source segment and pass it to `addSegment` for the new duplicate. `csUtils.deepClone` is used to avoid shared mutable state between the source and duplicate.
- `SegmentationService.ts` — extend the `addSegment` config type to accept an optional `cachedStats` field.

### Results 
Clicking a duplicated contour segment navigates the viewport to the same slice as the original segment
<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

1. Open an RTSTRUCT study in segmentation mode (e.g., `StudyInstanceUIDs=1.2.840.113619.2.290.3.3767434740.226.1600859119.501`)
2. Load and hydrate the RT series in the viewport
3. In the right panel, click `...` next to a segment then click `Duplicate`
4. Click on any segment - verify the navigation works correctly 
5. Click on the **duplicated** segment - verify the viewport navigates to the same slice as the original

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] OS: macOS 10.15.4
- [x] Node version: v22.13.0
- [x] Browser: Chrome 83.0.4103.116

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes missing slice navigation for duplicated contour segments by propagating `cachedStats` (which contains the `center` needed to resolve the target slice) from the source segment to its duplicate.

- `commandsModule.ts`: reads `cachedStats` from the source segment and passes a deep-cloned copy to `addSegment`, preventing shared mutable state between source and duplicate.
- `SegmentationService.ts`: adds `cachedStats` as an optional field in the `addSegment` config; the existing spread order (`cachedStats: {}` default followed by `...config`) ensures the passed value wins.
- `tests/ContourSegmentDuplicate.spec.ts`: adds a new E2E test (not skipped) that asserts the duplicate navigates to the same instance number as the original, plus reformats long assertion lines.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is minimal, well-scoped, and covered by a new E2E test.

The fix is a small, targeted addition: reading an existing value, deep-cloning it, and threading it through one config parameter. The spread order in addSegment already places ...config last, so the new field correctly overrides the {} default. The conditional spread (sourceCachedStats && {...}) also degrades gracefully when the source has no stats. No existing behaviour is altered for callers that don't pass cachedStats.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| extensions/cornerstone/src/commandsModule.ts | Reads cachedStats from the source segment and deep-clones it into the new duplicate segment so navigation can resolve the correct slice |
| extensions/cornerstone/src/services/SegmentationService/SegmentationService.ts | Extends the addSegment config type with an optional cachedStats field; the spread order correctly lets the passed value override the default empty object |
| tests/ContourSegmentDuplicate.spec.ts | Reformats long lines, adds a new E2E navigation test (not skipped) that verifies the duplicated segment navigates to the same instance as the original |

</details>

</details>

<sub>Reviews (3): Last reviewed commit: ["remove skip in duplicated contour test"](https://github.com/ohif/viewers/commit/6f9fa88aa7ac29a0ca977ed237a6ddf467b1b3b0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33821571)</sub>

<!-- /greptile_comment -->