### PR TITLE
feat(commands): add typed names for cornerstone

### DIFF
--- a/extensions/cornerstone/src/commandsModule.ts
+++ b/extensions/cornerstone/src/commandsModule.ts
@@ -117,7 +117,7 @@ function commandsModule({
   servicesManager,
   commandsManager,
   extensionManager,
-}: OhifTypes.Extensions.ExtensionParams): OhifTypes.Extensions.CommandsModule {
+}: OhifTypes.Extensions.ExtensionParams) {
   const {
     viewportGridService,
     toolbarService,
@@ -2829,7 +2829,9 @@ function commandsModule({
     actions,
     definitions,
     defaultContext: 'CORNERSTONE',
-  };
+  } satisfies OhifTypes.Extensions.CommandsModule;
 }
+
+export type CornerstoneCommandName = keyof ReturnType<typeof commandsModule>['definitions'];
 
 export default commandsModule;

--- a/extensions/cornerstone/src/components/ViewportOrientationMenu/ViewportOrientationMenu.tsx
+++ b/extensions/cornerstone/src/components/ViewportOrientationMenu/ViewportOrientationMenu.tsx
@@ -3,6 +3,7 @@ import { cn, Icons, useIconPresentation } from '@ohif/ui-next';
 import { useSystem } from '@ohif/core';
 import { Enums } from '@cornerstonejs/core';
 import { Popover, PopoverTrigger, PopoverContent, Button, useViewportGrid } from '@ohif/ui-next';
+import type { CornerstoneCommandName } from '../../commandsModule';
 
 function ViewportOrientationMenu({
   location,
@@ -91,7 +92,7 @@ function ViewportOrientationMenu({
       });
     } else {
       // Set the viewport orientation
-      commandsManager.runCommand('setViewportOrientation', {
+      commandsManager.runCommand<CornerstoneCommandName>('setViewportOrientation', {
         viewportId: viewportIdToUse,
         orientation: orientationEnum,
       });

--- a/extensions/cornerstone/src/index.tsx
+++ b/extensions/cornerstone/src/index.tsx
@@ -268,6 +268,7 @@ const cornerstoneExtension: Types.Extensions.Extension = {
 };
 
 export type { PublicViewportOptions };
+export type { CornerstoneCommandName } from './commandsModule';
 export {
   measurementMappingUtils,
   PlanarFreehandROI,

--- a/platform/core/src/classes/CommandsManager.ts
+++ b/platform/core/src/classes/CommandsManager.ts
@@ -146,11 +146,17 @@ export class CommandsManager {
   /**
    *
    * @method
-   * @param {String} commandName
+   * @param {String} commandName - Command to run. Accepts any string but can be
+   * parameterized with a command name union for autocomplete and type-checking on known commands.
    * @param {Object} [options={}] - Extra options to pass the command. Like a mousedown event
-   * @param {String} [contextName]
+   * @param {String} [contextName] Specific command to look in. Defaults to current activeContexts.
+   * Also allows an array of contexts to look in.
    */
-  public runCommand(commandName: string, options = {}, contextName?: string | string[]) {
+  public runCommand<CommandName extends string = string>(
+    commandName: CommandName | ((options?: Record<string, unknown>) => unknown),
+    options = {},
+    contextName?: string | string[]
+  ) {
     if (typeof commandName === 'function') {
       // If commandName is a function, run it directly
       return commandName(options);


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context
<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->
To address the feature request [#5025](https://github.com/OHIF/Viewers/issues/5025) this is an initial PR that establishes a pattern for typed commandNames, starting with the `cornerstone` extension and implementing a typed run command for viewportOrientationMenu. 

This change looks at making `runCommand` generic over a command-name union and has cornerstone export the union of its own command names, so callers can opt into compile-time checking and IDE autocomplete. Helps with autocomplete, typos, and general maintainability.

This intentionally starts with one extension to agree on the approach before rolling it out to the other extensions. 

Claude Opus 4.8 was used but never blindly, with all output being taken and refined instead of blindly trusted.

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->
- **`platform/core/src/classes/CommandsManager.ts`** — `runCommand` is now generic. The `commandName` parameter accepts the command name union (or a function, preserving existing runtime behavior). Default stays `string`, so the change is **fully backward- compatible**
- **`cornerstone/src/commandsModule.ts`** — return value now uses `satisfies OhifTypes.Extensions.CommandsModule`
- **`cornerstone/src/index.tsx`** — re-exports the `CornerstoneCommandName` type for cross-package consumption.
- **`viewportOrientationMenu.tsx`** —
  example usage: `commandsManager.runCommand<CornerstoneCommandName>('setViewportOrientation', ...)`.

<img width="1803" height="541" alt="Screenshot From 2026-05-31 18-28-04" src="https://github.com/user-attachments/assets/45f6a473-7e9e-4562-861b-7b78cbbe73a9" />
<img width="1202" height="323" alt="Screenshot From 2026-05-31 18-25-23" src="https://github.com/user-attachments/assets/cd19514e-c664-4799-a51c-8e54d70dcda3" />


### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

Run tests in repo 
Observed how typos would surface for typed command names
Locally deployed and checked viewportOrientation successfully (via included DICOM study http://127.0.0.1:3000/basic?StudyInstanceUIDs=2.16.840.1.114362.1.11972228.22789312658.616067305.306.2)

### Checklist


#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals. _changes haven't been made yet but potentially https://docs.ohif.org/platform/extensions/modules/commands/#commandsmanager-public-api should update now or on more full implementation on typed commandNames_

#### Tested Environment

- [x] OS: Debian GNU/Linux 13 (trixie)<!--[e.g. Windows 10, macOS 10.15.4]-->
- [x] Node version: v24.16.0 <!--[e.g. 18.16.1]--> 
- [x] Browser: Firefox 140.11.0esr
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type definitions and type safety throughout the command management system. Enhanced IDE autocomplete support and compile-time error detection for command execution. Strengthened type checking across Cornerstone extension components and core platform features, including viewport management and other command-based operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR establishes a typed command-name pattern for the `cornerstone` extension by (1) making `CommandsManager.runCommand` generic over a string union and (2) deriving `CornerstoneCommandName` from the inferred return type of `commandsModule` via `satisfies` instead of an explicit annotation. The switch from `: CommandsModule` to `satisfies CommandsModule` is the critical enabler — it preserves the literal-key union rather than widening `definitions` to `Record<string, unknown>`.

- **`CommandsManager.ts`** — `runCommand` is now `runCommand<CommandName extends string = string>`, defaulting to `string` for full backward compatibility; the pre-existing function-argument runtime path is now formally typed.
- **`commandsModule.ts`** — return value uses `satisfies`, unlocking `keyof ReturnType<typeof commandsModule>['definitions']` as a literal union; `CornerstoneCommandName` is exported from `index.tsx` for cross-package use.
- **`ViewportOrientationMenu.tsx`** — demonstrates the pattern with `runCommand<CornerstoneCommandName>('setViewportOrientation', ...)`.

<h3>Confidence Score: 4/5</h3>

The changes are purely additive type-level additions with no runtime behaviour changes; safe to merge.

All four changed files have no runtime impact. The derivation of `CornerstoneCommandName` via `ReturnType<typeof commandsModule>` on a ~2,800-line function is the one area worth monitoring for tsc performance as the pattern rolls out to other extensions.

extensions/cornerstone/src/commandsModule.ts — the `ReturnType<typeof commandsModule>` derivation should be monitored for tsc performance as the pattern expands.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| platform/core/src/classes/CommandsManager.ts | Makes `runCommand` generic over a string union (default `string`) and formally types the pre-existing function-argument path; fully backward compatible. |
| extensions/cornerstone/src/commandsModule.ts | Switches from an explicit `: CommandsModule` return-type annotation to `satisfies CommandsModule`, preserving the literal-key inferred type needed for `CornerstoneCommandName`. The derived type forces TypeScript to fully infer the return type of a ~2800-line function on every incremental build; compile-time cost should be monitored. |
| extensions/cornerstone/src/index.tsx | Adds a type-only re-export of `CornerstoneCommandName` for cross-package consumption; no runtime impact. |
| extensions/cornerstone/src/components/ViewportOrientationMenu/ViewportOrientationMenu.tsx | Demonstrates the typed pattern with `runCommand<CornerstoneCommandName>`. The adjacent `run('setDisplaySetsForViewports', ...)` call is intentionally untyped (different extension command). |

</details>


</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `platform/core/src/classes/CommandsManager.ts`, line 155-163 ([link](https://github.com/ohif/viewers/blob/5e0f7acec971f5ef865e66e6934001ef3ae66796/platform/core/src/classes/CommandsManager.ts#L155-L163)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`getCommand` still accepts only `string`, not `CommandName`**

   `getCommand` is typed as `(commandName: string, ...)`. When `runCommand<SomeUnion>` narrows `commandName` to a specific member of `SomeUnion`, passing it to `getCommand` implicitly widens it back to `string`. This is harmless today, but if `getCommand` is ever made generic too (e.g. to return a typed definition), the call site at line 165 would need updating. Consider aligning the signature now for consistency.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: platform/core/src/classes/CommandsManager.ts
   Line: 155-163

   Comment:
   **`getCommand` still accepts only `string`, not `CommandName`**

   `getCommand` is typed as `(commandName: string, ...)`. When `runCommand<SomeUnion>` narrows `commandName` to a specific member of `SomeUnion`, passing it to `getCommand` implicitly widens it back to `string`. This is harmless today, but if `getCommand` is ever made generic too (e.g. to return a typed definition), the call site at line 165 would need updating. Consider aligning the signature now for consistency.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
extensions/cornerstone/src/commandsModule.ts:2835
**TypeScript inference cost from large function return type**

`ReturnType<typeof commandsModule>` asks TypeScript to fully materialise the inferred return type of a ~2,800-line function on every incremental build that touches any file importing `CornerstoneCommandName`. Because `definitions` contains ~200+ entries, each typed through closures over the `actions` object, the structural type can be very wide. If this becomes noticeable, an explicit intermediate type alias for `definitions` (e.g. `const definitions = { ... } as const satisfies Record<string, unknown>`) or a manually-maintained `CornerstoneCommandName` string union would avoid the cost while preserving the literal-key benefit.

### Issue 2 of 2
platform/core/src/classes/CommandsManager.ts:155-163
**`getCommand` still accepts only `string`, not `CommandName`**

`getCommand` is typed as `(commandName: string, ...)`. When `runCommand<SomeUnion>` narrows `commandName` to a specific member of `SomeUnion`, passing it to `getCommand` implicitly widens it back to `string`. This is harmless today, but if `getCommand` is ever made generic too (e.g. to return a typed definition), the call site at line 165 would need updating. Consider aligning the signature now for consistency.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(commands): add typed names for corn..."](https://github.com/ohif/viewers/commit/5e0f7acec971f5ef865e66e6934001ef3ae66796) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34792847)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->