### PR TITLE
fix: Fix the deployment to viewer-dev caused by missing .npmrc

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -251,8 +251,11 @@ jobs:
             if [[ ! -e version.txt ]]; then
               exit 0
             else
-              # Remove npm config
-              rm -f ./.npmrc
+              # Restore the committed .npmrc (pnpm workspace config such as
+              # node-linker=hoisted). NPM_PUBLISH overwrote it with a publish
+              # auth token, but the Dockerfile COPYs .npmrc for the in-image
+              # pnpm install, so it needs the config file present and token-free.
+              git checkout -- .npmrc
               # Set our version number using vars
               export IMAGE_VERSION=$(cat version.txt)
               export IMAGE_VERSION_FULL=v$IMAGE_VERSION
@@ -285,8 +288,11 @@ jobs:
             if [[ ! -e version.txt ]]; then
               exit 0
             else
-              # Remove npm config
-              rm -f ./.npmrc
+              # Restore the committed .npmrc (pnpm workspace config such as
+              # node-linker=hoisted). NPM_PUBLISH overwrote it with a publish
+              # auth token, but the Dockerfile COPYs .npmrc for the in-image
+              # pnpm install, so it needs the config file present and token-free.
+              git checkout -- .npmrc
               # Set our version number using vars
               export IMAGE_VERSION=$(cat version.txt)
               export IMAGE_VERSION_FULL=v$IMAGE_VERSION
@@ -323,7 +329,11 @@ jobs:
               exit 0
             else
               echo "Building and pushing Docker image from the master branch (beta releases)"
-              rm -f ./.npmrc
+              # Restore the committed .npmrc (pnpm workspace config such as
+              # node-linker=hoisted). NPM_PUBLISH overwrote it with a publish
+              # auth token, but the Dockerfile COPYs .npmrc for the in-image
+              # pnpm install, so it needs the config file present and token-free.
+              git checkout -- .npmrc
 
               # Set our version number using vars
               export IMAGE_VERSION=$(cat version.txt)
@@ -357,7 +367,11 @@ jobs:
               exit 0
             else
               echo "Building and pushing ARM64 Docker image from the master branch (beta releases)"
-              rm -f ./.npmrc
+              # Restore the committed .npmrc (pnpm workspace config such as
+              # node-linker=hoisted). NPM_PUBLISH overwrote it with a publish
+              # auth token, but the Dockerfile COPYs .npmrc for the in-image
+              # pnpm install, so it needs the config file present and token-free.
+              git checkout -- .npmrc
               # Set our version number using vars
               export IMAGE_VERSION=$(cat version.txt)
               export IMAGE_VERSION_FULL=v$IMAGE_VERSION


### PR DESCRIPTION
fix(ci): restore committed .npmrc in Docker build jobs (pnpm migration)

The pnpm migration (#6031) made the Dockerfile COPY .npmrc into the builder stage because pnpm needs the workspace config it carries (node-linker=hoisted, link-workspace-packages). But the Docker jobs still ran `rm -f ./.npmrc` immediately before `docker build` -- a leftover from when .npmrc only held npm credentials. NPM_PUBLISH overwrites the tracked .npmrc with a publish auth token and persists it to the workspace, so the Docker jobs deleted the file the Dockerfile requires:

  ERROR [builder 6/13] COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
  failed to compute cache key: "/.npmrc": not found

DEPLOY_MASTER therefore failed at DOCKER_BETA_PUBLISH on every master build after the migration (NPM_PUBLISH still pushed the version bump first, so npm packages shipped but the latest-beta image never did -- leaving viewer-dev.ohif.org stuck on the prior beta).

Replace `rm -f ./.npmrc` with `git checkout -- .npmrc` in the four Docker *build* jobs so the committed, token-free workspace-config .npmrc is restored before the build. The two manifest jobs keep `rm` since they do not build from the Dockerfile.


@

<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] OS: <!--[e.g. Windows 10, macOS 10.15.4]-->
- [] Node version: <!--[e.g. 18.16.1]-->
- [] Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Docker build process configuration for improved reliability during release and beta deployment cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a broken Docker build pipeline caused by a `rm -f ./.npmrc` leftover from before the pnpm migration. `NPM_PUBLISH` overwrites `.npmrc` with a publish auth token, but the Dockerfile `COPY`s `.npmrc` for the in-image `pnpm install`, so deleting it caused every master build to fail after the token was written.

- Replaces `rm -f ./.npmrc` with `git checkout -- .npmrc` in the four Docker *build* jobs, restoring the committed pnpm workspace config (node-linker, link-workspace-packages) before `docker build` runs.
- The two manifest-only jobs (`DOCKER_MULTIARCH_MANIFEST`, `DOCKER_BETA_MULTIARCH_MANIFEST`) keep `rm -f ./.npmrc` since they never invoke `docker build` and do not require the file.

<h3>Confidence Score: 5/5</h3>

The change is safe to merge — it restores a broken CI pipeline with a minimal, targeted fix that has no impact on application code.

`git checkout -- .npmrc` correctly restores the committed file from the index in both normal and detached-HEAD CI checkouts. The four changed jobs all call `docker build` and genuinely need the file; the two manifest jobs that were intentionally left with `rm` never call `docker build`. The fix is complete and well-scoped.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .circleci/config.yml | Replaces `rm -f ./.npmrc` with `git checkout -- .npmrc` in the four Docker build jobs so the committed pnpm workspace config is restored after NPM_PUBLISH overwrites it; manifest-only jobs correctly retain the `rm`. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["@"](https://github.com/ohif/viewers/commit/325718e439330fb909a87452ec449d9b0bf3530e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37348946)</sub>

<!-- /greptile_comment -->