### PR TITLE
[WIP] test: Update the tolerance to match other 3d comparisons

### DIFF
--- a/tests/3DPrimary.spec.ts
+++ b/tests/3DPrimary.spec.ts
@@ -24,10 +24,13 @@ test.describe('3D primary Test', async () => {
 
     await attemptAction(() => reduce3DViewportSize(page), 10, 100);
     await waitForViewportsRendered(page);
-    await checkForScreenshot(
+    await checkForScreenshot({
       page,
-      viewportPageObject.grid,
-      screenShotPaths.threeDPrimary.threeDPrimaryDisplayedCorrectly
-    );
+      locator: viewportPageObject.grid,
+      // Volume-3D ray-cast output is GPU/driver-noisy run-to-run; match the
+      // tolerance already used by the sibling 3DOnly test.
+      maxDiffPixelRatio: 0.04,
+      screenshotPath: screenShotPaths.threeDPrimary.threeDPrimaryDisplayedCorrectly,
+    });
   });
 });


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] OS: <!--[e.g. Windows 10, macOS 10.15.4]-->
- [] Node version: <!--[e.g. 18.16.1]-->
- [] Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated screenshot assertion tests with improved tolerance for visual variations to account for GPU and driver-related differences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the screenshot comparison in `tests/3DPrimary.spec.ts` to use the object-based `checkForScreenshot` API and raises the pixel-diff tolerance from the default 2% to 4%, matching the approach already used by the `3DOnly` sibling test to account for GPU/driver noise in 3D ray-cast output.

- Migrates the call site from the old positional signature (`page, locator, screenshotPath`) to the `CheckForScreenshotProps` object form, which is consistent with `3DOnly.spec.ts`.
- Sets `maxDiffPixelRatio: 0.04` to reduce flakiness caused by per-run variation in volumetric rendering without widening tolerance beyond what the existing 3D tests already accept.

<h3>Confidence Score: 5/5</h3>

This is a one-line test-file change that adjusts a screenshot tolerance; it has no effect on production code.

The change correctly uses the object-based `checkForScreenshot` overload supported by the existing utility, and the chosen `maxDiffPixelRatio` of 0.04 is exactly the value already in use for the nearly identical `3DOnly` test. No logic, types, or imports are affected beyond this single call site.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tests/3DPrimary.spec.ts | Switches `checkForScreenshot` call from the positional API to the object-based API and sets `maxDiffPixelRatio: 0.04` to match the sibling `3DOnly` test's tolerance |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["Update the tolerance to match other 3d c..."](https://github.com/ohif/viewers/commit/964aff90cd425feb93fb2d7e502a30ac63e5c434) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37963833)</sub>

<!-- /greptile_comment -->