### PR TITLE
Dental mode

### DIFF
--- a/.webpack/resolveConfig.js
+++ b/.webpack/resolveConfig.js
@@ -6,15 +6,17 @@ const path = require('path');
 //     per-package webpack.prod.js / webpack.dev.js that merges webpack.base.js
 //   - the rsbuild build: rsbuild.config.ts (dev:fast)
 //
-// Plugin aliases (writePluginImportsFile.getPluginResolveAliases) are NOT
-// included here: they depend on pluginConfig.json and are merged in separately
-// by each config.
+const writePluginImportsFile = require('../platform/app/.webpack/writePluginImportsFile.js');
 //
 // All paths are anchored to this file's location (the repo-root `.webpack/`
 // directory), so the values are identical regardless of which package's build
 // is doing the resolving.
 
 const alias = {
+  // Resolve every extension/mode declared in pluginConfig.json to its workspace
+  // source. Keep this in the shared resolver so dev/build paths that only use
+  // webpack.base.js still resolve generated pluginImports.js bare specifiers.
+  ...writePluginImportsFile.getPluginResolveAliases(),
   // Some extensions import app-level utilities (e.g. history,
   // preserveQueryParameters) from '@ohif/app'. pnpm's isolated layout does not
   // expose the top-level app package to those extensions, and adding it as a

--- a/extensions/dental/.webpack/webpack.dev.js
+++ b/extensions/dental/.webpack/webpack.dev.js
@@ -1,0 +1,13 @@
+const path = require('path');
+const webpackCommon = require('./../../../.webpack/webpack.base.js');
+
+const SRC_DIR = path.join(__dirname, '../src');
+const DIST_DIR = path.join(__dirname, '../dist');
+
+const ENTRY = {
+  app: `${SRC_DIR}/index.ts`,
+};
+
+module.exports = (env, argv) => {
+  return webpackCommon(env, argv, { SRC_DIR, DIST_DIR, ENTRY });
+};

--- a/extensions/dental/.webpack/webpack.prod.js
+++ b/extensions/dental/.webpack/webpack.prod.js
@@ -1,0 +1,50 @@
+const webpack = require('@rspack/core');
+const { merge } = require('webpack-merge');
+const path = require('path');
+const webpackCommon = require('./../../../.webpack/webpack.base.js');
+const pkg = require('./../package.json');
+
+const ROOT_DIR = path.join(__dirname, './..');
+const SRC_DIR = path.join(__dirname, '../src');
+const DIST_DIR = path.join(__dirname, '../dist');
+
+const ENTRY = {
+  app: `${SRC_DIR}/index.ts`,
+};
+
+module.exports = (env, argv) => {
+  const commonConfig = webpackCommon(env, argv, { SRC_DIR, DIST_DIR, ENTRY });
+
+  return merge(commonConfig, {
+    stats: {
+      colors: true,
+      hash: true,
+      timings: true,
+      assets: true,
+      chunks: false,
+      chunkModules: false,
+      modules: false,
+      children: false,
+      warnings: true,
+    },
+    optimization: {
+      minimize: true,
+      sideEffects: false,
+    },
+    output: {
+      library: {
+        name: 'ohif-extension-dental',
+        type: 'umd',
+        export: 'default',
+      },
+      path: ROOT_DIR,
+      filename: pkg.main,
+    },
+    externals: [/\b(vtk.js)/, /\b(dcmjs)/, /\b(gl-matrix)/, /^@ohif/, /^@cornerstonejs/],
+    plugins: [
+      new webpack.optimize.LimitChunkCountPlugin({
+        maxChunks: 1,
+      }),
+    ],
+  });
+};

--- a/extensions/dental/babel.config.js
+++ b/extensions/dental/babel.config.js
@@ -1,0 +1,1 @@
+module.exports = require('../../babel.config.js');

--- a/extensions/dental/jest.config.js
+++ b/extensions/dental/jest.config.js
@@ -1,0 +1,9 @@
+const base = require('../../jest.config.base.js');
+
+module.exports = {
+  ...base,
+  moduleNameMapper: {
+    ...base.moduleNameMapper,
+    '@ohif/(.*)': '<rootDir>/../../platform/$1/src',
+  },
+};

--- a/extensions/dental/package.json
+++ b/extensions/dental/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@ohif/extension-dental",
+  "version": "3.13.0-beta.93",
+  "description": "Dental Mode UI extension for OHIF",
+  "author": "OHIF Contributors",
+  "license": "MIT",
+  "repository": "OHIF/Viewers",
+  "main": "dist/ohif-extension-dental.umd.js",
+  "module": "src/index.ts",
+  "engines": {
+    "node": ">=24"
+  },
+  "files": [
+    "dist/**",
+    "public/**",
+    "README.md"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "dev": "cross-env NODE_ENV=development rspack build --config .webpack/webpack.dev.js --watch",
+    "build": "cross-env NODE_ENV=production rspack build --config .webpack/webpack.prod.js",
+    "build:package": "pnpm run build",
+    "start": "pnpm run dev",
+    "test:unit": "jest --watchAll",
+    "test:unit:ci": "jest --ci --runInBand --collectCoverage --passWithNoTests"
+  },
+  "peerDependencies": {
+    "@ohif/core": "workspace:*",
+    "@ohif/extension-default": "workspace:*",
+    "@ohif/ui-next": "workspace:*",
+    "prop-types": "15.8.1",
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
+    "react-i18next": "12.3.1",
+    "react-router-dom": "6.30.3",
+    "webpack-merge": "5.10.0"
+  },
+  "dependencies": {
+    "@babel/runtime": "7.29.7"
+  },
+  "devDependencies": {
+    "webpack-merge": "5.10.0"
+  },
+  "keywords": [
+    "ohif-extension"
+  ]
+}

--- a/extensions/dental/src/customAttributes/sameAttributeAsDisplaySet.test.ts
+++ b/extensions/dental/src/customAttributes/sameAttributeAsDisplaySet.test.ts
@@ -1,0 +1,51 @@
+import sameAttributeAsDisplaySet from './sameAttributeAsDisplaySet';
+
+const context = {
+  attributeName: 'Modality',
+  displaySetSelectorId: 'currentDisplaySetId',
+};
+
+describe('sameAttributeAsDisplaySet', () => {
+  it('returns true when candidate matches the selected display set attribute', () => {
+    const result = sameAttributeAsDisplaySet.call(
+      context,
+      { displaySetInstanceUID: 'prior-cr', Modality: 'CR' },
+      {
+        displaySetMatchDetails: new Map([
+          ['currentDisplaySetId', { displaySetInstanceUID: 'current-cr' }],
+        ]),
+        displaySets: [{ displaySetInstanceUID: 'current-cr', Modality: 'CR' }],
+      }
+    );
+
+    expect(result).toBe(true);
+  });
+
+  it('returns false when candidate does not match the selected display set attribute', () => {
+    const result = sameAttributeAsDisplaySet.call(
+      context,
+      { displaySetInstanceUID: 'prior-ct', Modality: 'CT' },
+      {
+        displaySetMatchDetails: new Map([
+          ['currentDisplaySetId', { displaySetInstanceUID: 'current-cr' }],
+        ]),
+        displaySets: [{ displaySetInstanceUID: 'current-cr', Modality: 'CR' }],
+      }
+    );
+
+    expect(result).toBe(false);
+  });
+
+  it('returns false when there is no current display set match yet', () => {
+    const result = sameAttributeAsDisplaySet.call(
+      context,
+      { displaySetInstanceUID: 'prior-cr', Modality: 'CR' },
+      {
+        displaySetMatchDetails: new Map(),
+        displaySets: [{ displaySetInstanceUID: 'current-cr', Modality: 'CR' }],
+      }
+    );
+
+    expect(result).toBe(false);
+  });
+});

--- a/extensions/dental/src/customAttributes/sameAttributeAsDisplaySet.ts
+++ b/extensions/dental/src/customAttributes/sameAttributeAsDisplaySet.ts
@@ -1,0 +1,39 @@
+type DisplaySetLike = Record<string, unknown> & {
+  displaySetInstanceUID?: string;
+};
+
+type MatchOptions = {
+  displaySetMatchDetails?: Map<string, { displaySetInstanceUID?: string }>;
+  displaySets?: DisplaySetLike[];
+};
+
+type AttributeContext = {
+  attributeName?: string;
+  displaySetSelectorId?: string;
+  id?: string;
+};
+
+export default function sameAttributeAsDisplaySet(
+  this: AttributeContext,
+  displaySet: DisplaySetLike,
+  options: MatchOptions = {}
+): boolean {
+  const { attributeName, displaySetSelectorId } = this;
+
+  if (!attributeName || !displaySetSelectorId) {
+    return false;
+  }
+
+  const matchedDisplaySetUID = options.displaySetMatchDetails?.get(displaySetSelectorId)
+    ?.displaySetInstanceUID;
+
+  if (!matchedDisplaySetUID) {
+    return false;
+  }
+
+  const matchedDisplaySet = options.displaySets?.find(
+    candidate => candidate.displaySetInstanceUID === matchedDisplaySetUID
+  );
+
+  return matchedDisplaySet?.[attributeName] === displaySet[attributeName];
+}

--- a/extensions/dental/src/getHangingProtocolModule.ts
+++ b/extensions/dental/src/getHangingProtocolModule.ts
@@ -1,0 +1,12 @@
+import dental2x2Protocol from './hangingProtocols/dental2x2';
+
+function getHangingProtocolModule() {
+  return [
+    {
+      name: dental2x2Protocol.id,
+      protocol: dental2x2Protocol,
+    },
+  ];
+}
+
+export default getHangingProtocolModule;

--- a/extensions/dental/src/getLayoutTemplateModule.tsx
+++ b/extensions/dental/src/getLayoutTemplateModule.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+import DentalViewerLayout from './layout/DentalViewerLayout';
+
+export default function ({ servicesManager, extensionManager, commandsManager, hotkeysManager }) {
+  function DentalViewerLayoutWithServices(props) {
+    return (
+      <DentalViewerLayout
+        servicesManager={servicesManager}
+        extensionManager={extensionManager}
+        commandsManager={commandsManager}
+        hotkeysManager={hotkeysManager}
+        {...props}
+      />
+    );
+  }
+
+  return [
+    {
+      name: 'dentalViewerLayout',
+      id: 'dentalViewerLayout',
+      component: DentalViewerLayoutWithServices,
+    },
+  ];
+}

--- a/extensions/dental/src/getPanelModule.tsx
+++ b/extensions/dental/src/getPanelModule.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Types } from '@ohif/core';
+
+import DentalMeasurementsPanel from './measurements/DentalMeasurementsPanel';
+
+function getPanelModule({ servicesManager }): Types.Panel[] {
+  return [
+    {
+      name: 'dentalMeasurements',
+      iconName: 'tab-linear',
+      iconLabel: 'Dental measurements',
+      label: 'Dental Measurements',
+      component: () => <DentalMeasurementsPanel servicesManager={servicesManager} />,
+    },
+  ];
+}
+
+export default getPanelModule;

--- a/extensions/dental/src/hangingProtocols/dental2x2.test.ts
+++ b/extensions/dental/src/hangingProtocols/dental2x2.test.ts
@@ -1,0 +1,47 @@
+import dental2x2Protocol from './dental2x2';
+
+describe('dental2x2Protocol', () => {
+  it('defines a fixed 2x2 layout', () => {
+    const stage = dental2x2Protocol.stages[0];
+
+    expect(stage.viewportStructure.properties).toMatchObject({
+      rows: 2,
+      columns: 2,
+    });
+    expect(stage.viewports).toHaveLength(4);
+  });
+
+  it('places current, prior, and bitewing placeholders in stable viewport slots', () => {
+    const viewportIds = dental2x2Protocol.stages[0].viewports.map(
+      viewport => viewport.viewportOptions.viewportId
+    );
+
+    expect(viewportIds).toEqual([
+      'dental-current',
+      'dental-prior',
+      'dental-bitewing-left',
+      'dental-bitewing-right',
+    ]);
+  });
+
+  it('requires prior display sets to match current modality', () => {
+    const priorSelector =
+      dental2x2Protocol.displaySetSelectors.priorSameModalityDisplaySetId;
+
+    expect(priorSelector.seriesMatchingRules).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          attribute: 'sameAttributeAsDisplaySet',
+          required: true,
+        }),
+      ])
+    );
+  });
+
+  it('keeps bottom viewports as static placeholders without display set matching', () => {
+    const [, , bitewingLeft, bitewingRight] = dental2x2Protocol.stages[0].viewports;
+
+    expect(bitewingLeft.displaySets).toEqual([]);
+    expect(bitewingRight.displaySets).toEqual([]);
+  });
+});

--- a/extensions/dental/src/hangingProtocols/dental2x2.ts
+++ b/extensions/dental/src/hangingProtocols/dental2x2.ts
@@ -1,0 +1,178 @@
+import { Types } from '@ohif/core';
+
+const currentDisplaySetSelector = {
+  studyMatchingRules: [
+    {
+      attribute: 'studyInstanceUIDsIndex',
+      from: 'options',
+      required: true,
+      constraint: {
+        equals: { value: 0 },
+      },
+    },
+  ],
+  seriesMatchingRules: [
+    {
+      attribute: 'numImageFrames',
+      weight: 1,
+      required: true,
+      constraint: {
+        greaterThan: { value: 0 },
+      },
+    },
+    {
+      attribute: 'isDisplaySetFromUrl',
+      weight: 20,
+      constraint: {
+        equals: true,
+      },
+    },
+  ],
+};
+
+const priorSameModalityDisplaySetSelector = {
+  studyMatchingRules: [
+    {
+      attribute: 'studyInstanceUIDsIndex',
+      from: 'options',
+      required: true,
+      constraint: {
+        greaterThan: { value: 0 },
+      },
+    },
+  ],
+  seriesMatchingRules: [
+    {
+      attribute: 'numImageFrames',
+      weight: 1,
+      required: true,
+      constraint: {
+        greaterThan: { value: 0 },
+      },
+    },
+    {
+      attribute: 'sameAttributeAsDisplaySet',
+      required: true,
+      constraint: {
+        equals: true,
+      },
+    },
+  ],
+};
+
+const stackViewportOptions = {
+  viewportType: 'stack',
+  toolGroupId: 'default',
+  allowUnmatchedView: true,
+};
+
+const currentViewport = {
+  viewportOptions: {
+    ...stackViewportOptions,
+    viewportId: 'dental-current',
+    customViewportProps: {
+      dentalSlot: 'current',
+    },
+  },
+  displaySets: [
+    {
+      id: 'currentDisplaySetId',
+    },
+  ],
+};
+
+const priorViewport = {
+  viewportOptions: {
+    ...stackViewportOptions,
+    viewportId: 'dental-prior',
+    customViewportProps: {
+      dentalSlot: 'prior',
+    },
+  },
+  displaySets: [
+    {
+      id: 'priorSameModalityDisplaySetId',
+    },
+  ],
+};
+
+const bitewingPlaceholderLeft = {
+  viewportOptions: {
+    ...stackViewportOptions,
+    viewportId: 'dental-bitewing-left',
+    customViewportProps: {
+      dentalSlot: 'bitewing-left',
+    },
+  },
+  displaySets: [],
+};
+
+const bitewingPlaceholderRight = {
+  viewportOptions: {
+    ...stackViewportOptions,
+    viewportId: 'dental-bitewing-right',
+    customViewportProps: {
+      dentalSlot: 'bitewing-right',
+    },
+  },
+  displaySets: [],
+};
+
+export const dental2x2Protocol: Types.HangingProtocol.Protocol = {
+  id: '@ohif/extension-dental.hangingProtocolModule.dental2x2',
+  name: 'Dental 2x2',
+  description:
+    'Fixed Dental Mode 2x2 layout with current image, same-modality prior, and bitewing placeholders.',
+  locked: true,
+  numberOfPriorsReferenced: 0,
+  toolGroupIds: ['default'],
+  protocolMatchingRules: [
+    {
+      id: 'OneOrMoreSeries',
+      weight: 1000,
+      attribute: 'numberOfDisplaySetsWithImages',
+      constraint: {
+        greaterThan: 0,
+      },
+    },
+  ],
+  displaySetSelectors: {
+    currentDisplaySetId: currentDisplaySetSelector,
+    priorSameModalityDisplaySetId: priorSameModalityDisplaySetSelector,
+  },
+  defaultViewport: {
+    viewportOptions: stackViewportOptions,
+    displaySets: [
+      {
+        id: 'currentDisplaySetId',
+        matchedDisplaySetsIndex: -1,
+      },
+    ],
+  },
+  stages: [
+    {
+      id: 'dental-2x2',
+      name: 'Dental 2x2',
+      stageActivation: {
+        enabled: {
+          minViewportsMatched: 1,
+        },
+      },
+      viewportStructure: {
+        layoutType: 'grid',
+        properties: {
+          rows: 2,
+          columns: 2,
+        },
+      },
+      viewports: [
+        currentViewport,
+        priorViewport,
+        bitewingPlaceholderLeft,
+        bitewingPlaceholderRight,
+      ],
+    },
+  ],
+};
+
+export default dental2x2Protocol;

--- a/extensions/dental/src/id.js
+++ b/extensions/dental/src/id.js
@@ -1,0 +1,5 @@
+import packageJson from '../package.json';
+
+const id = packageJson.name;
+
+export { id };

--- a/extensions/dental/src/index.ts
+++ b/extensions/dental/src/index.ts
@@ -1,0 +1,11 @@
+import { Types } from '@ohif/core';
+
+import getLayoutTemplateModule from './getLayoutTemplateModule';
+import { id } from './id';
+
+const dentalExtension: Types.Extensions.Extension = {
+  id,
+  getLayoutTemplateModule,
+};
+
+export default dentalExtension;

--- a/extensions/dental/src/index.ts
+++ b/extensions/dental/src/index.ts
@@ -1,11 +1,27 @@
 import { Types } from '@ohif/core';
 
 import getLayoutTemplateModule from './getLayoutTemplateModule';
+import getHangingProtocolModule from './getHangingProtocolModule';
+import sameAttributeAsDisplaySet from './customAttributes/sameAttributeAsDisplaySet';
 import { id } from './id';
 
 const dentalExtension: Types.Extensions.Extension = {
   id,
+  preRegistration: ({ servicesManager }: Types.Extensions.ExtensionParams) => {
+    const { hangingProtocolService } = servicesManager.services;
+
+    hangingProtocolService.addCustomAttribute(
+      'sameAttributeAsDisplaySet',
+      'Match an attribute on an already selected display set',
+      sameAttributeAsDisplaySet,
+      {
+        attributeName: 'Modality',
+        displaySetSelectorId: 'currentDisplaySetId',
+      }
+    );
+  },
   getLayoutTemplateModule,
+  getHangingProtocolModule,
 };
 
 export default dentalExtension;

--- a/extensions/dental/src/index.ts
+++ b/extensions/dental/src/index.ts
@@ -2,13 +2,16 @@ import { Types } from '@ohif/core';
 
 import getLayoutTemplateModule from './getLayoutTemplateModule';
 import getHangingProtocolModule from './getHangingProtocolModule';
+import getPanelModule from './getPanelModule';
 import sameAttributeAsDisplaySet from './customAttributes/sameAttributeAsDisplaySet';
+import { DentalMeasurementsService } from './measurements/DentalMeasurementsService';
 import { id } from './id';
 
 const dentalExtension: Types.Extensions.Extension = {
   id,
   preRegistration: ({ servicesManager }: Types.Extensions.ExtensionParams) => {
     const { hangingProtocolService } = servicesManager.services;
+    servicesManager.registerService(DentalMeasurementsService.REGISTRATION);
 
     hangingProtocolService.addCustomAttribute(
       'sameAttributeAsDisplaySet',
@@ -22,6 +25,7 @@ const dentalExtension: Types.Extensions.Extension = {
   },
   getLayoutTemplateModule,
   getHangingProtocolModule,
+  getPanelModule,
 };
 
 export default dentalExtension;

--- a/extensions/dental/src/layout/DentalViewerLayout.tsx
+++ b/extensions/dental/src/layout/DentalViewerLayout.tsx
@@ -5,8 +5,19 @@ import { CommandsManager, HangingProtocolService } from '@ohif/core';
 import { InvestigationalUseDialog, Onboarding } from '@ohif/ui-next';
 import { useAppConfig } from '@state';
 
+import { useDentalPreferences } from '../preferences/useDentalPreferences';
 import PracticeHeader from './PracticeHeader';
 import SidePanelWithServices from './SidePanelWithServices';
+
+const LAYOUT_CLASS_BY_THEME = {
+  dental: 'min-h-screen bg-[#0d1715] font-sans text-[#e7fff9]',
+  standard: 'min-h-screen',
+};
+
+const VIEWER_BODY_CLASS_BY_THEME = {
+  dental: 'relative flex w-full flex-row flex-nowrap items-stretch overflow-hidden bg-[#0d1715]',
+  standard: 'relative flex w-full flex-row flex-nowrap items-stretch overflow-hidden bg-background',
+};
 
 function DentalViewerLayout({
   extensionManager,
@@ -23,6 +34,12 @@ function DentalViewerLayout({
   const [appConfig] = useAppConfig();
   const { panelService, hangingProtocolService, customizationService } = servicesManager.services;
   const [showLoadingIndicator, setShowLoadingIndicator] = useState(appConfig.showLoadingIndicator);
+  const {
+    preferences,
+    setSelectedToothId,
+    setNumberingSystem,
+    toggleTheme,
+  } = useDentalPreferences();
 
   const hasPanels = useCallback((side): boolean => !!panelService.getPanels(side).length, [
     panelService,
@@ -105,15 +122,23 @@ function DentalViewerLayout({
   const viewportComponents = viewports.map(getViewportComponentData);
 
   return (
-    <div data-cy="dental-viewer-layout">
+    <div
+      data-cy="dental-viewer-layout"
+      data-dental-theme={preferences.theme}
+      className={LAYOUT_CLASS_BY_THEME[preferences.theme]}
+    >
       <PracticeHeader
         hotkeysManager={hotkeysManager}
         extensionManager={extensionManager}
         servicesManager={servicesManager}
         appConfig={appConfig}
+        preferences={preferences}
+        onSelectedToothChange={setSelectedToothId}
+        onNumberingSystemChange={setNumberingSystem}
+        onThemeToggle={toggleTheme}
       />
       <div
-        className="relative flex w-full flex-row flex-nowrap items-stretch overflow-hidden bg-background"
+        className={VIEWER_BODY_CLASS_BY_THEME[preferences.theme]}
         style={{ height: 'calc(100vh - 56px)' }}
       >
         {showLoadingIndicator ? (

--- a/extensions/dental/src/layout/DentalViewerLayout.tsx
+++ b/extensions/dental/src/layout/DentalViewerLayout.tsx
@@ -1,0 +1,169 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+
+import { CommandsManager, HangingProtocolService } from '@ohif/core';
+import { InvestigationalUseDialog, Onboarding } from '@ohif/ui-next';
+import { useAppConfig } from '@state';
+
+import PracticeHeader from './PracticeHeader';
+import SidePanelWithServices from './SidePanelWithServices';
+
+function DentalViewerLayout({
+  extensionManager,
+  servicesManager,
+  hotkeysManager,
+  commandsManager,
+  viewports,
+  ViewportGridComp,
+  leftPanelClosed = false,
+  rightPanelClosed = false,
+  leftPanelInitialExpandedWidth,
+  rightPanelInitialExpandedWidth,
+}: withAppTypes): React.ReactElement {
+  const [appConfig] = useAppConfig();
+  const { panelService, hangingProtocolService, customizationService } = servicesManager.services;
+  const [showLoadingIndicator, setShowLoadingIndicator] = useState(appConfig.showLoadingIndicator);
+
+  const hasPanels = useCallback((side): boolean => !!panelService.getPanels(side).length, [
+    panelService,
+  ]);
+
+  const [hasRightPanels, setHasRightPanels] = useState(hasPanels('right'));
+  const [hasLeftPanels, setHasLeftPanels] = useState(hasPanels('left'));
+  const [leftPanelClosedState, setLeftPanelClosed] = useState(leftPanelClosed);
+  const [rightPanelClosedState, setRightPanelClosed] = useState(rightPanelClosed);
+
+  const LoadingIndicatorProgress = customizationService.getCustomization(
+    'ui.loadingIndicatorProgress'
+  );
+
+  const getComponent = id => {
+    const entry = extensionManager.getModuleEntry(id);
+
+    if (!entry || !entry.component) {
+      throw new Error(
+        `${id} is not valid for an extension module or no component found from extension ${id}.`
+      );
+    }
+
+    return { entry };
+  };
+
+  const getViewportComponentData = viewportComponent => {
+    const { entry } = getComponent(viewportComponent.namespace);
+
+    return {
+      component: entry.component,
+      isReferenceViewable: entry.isReferenceViewable,
+      displaySetsToDisplay: viewportComponent.displaySetsToDisplay,
+    };
+  };
+
+  useEffect(() => {
+    document.body.classList.add('bg-background');
+    document.body.classList.add('overflow-hidden');
+
+    return () => {
+      document.body.classList.remove('bg-background');
+      document.body.classList.remove('overflow-hidden');
+    };
+  }, []);
+
+  useEffect(() => {
+    const { unsubscribe } = hangingProtocolService.subscribe(
+      HangingProtocolService.EVENTS.PROTOCOL_CHANGED,
+      () => {
+        setShowLoadingIndicator(false);
+      }
+    );
+
+    return () => {
+      unsubscribe();
+    };
+  }, [hangingProtocolService]);
+
+  useEffect(() => {
+    const { unsubscribe } = panelService.subscribe(
+      panelService.EVENTS.PANELS_CHANGED,
+      ({ options }) => {
+        setHasLeftPanels(hasPanels('left'));
+        setHasRightPanels(hasPanels('right'));
+        if (options?.leftPanelClosed !== undefined) {
+          setLeftPanelClosed(options.leftPanelClosed);
+        }
+        if (options?.rightPanelClosed !== undefined) {
+          setRightPanelClosed(options.rightPanelClosed);
+        }
+      }
+    );
+
+    return () => {
+      unsubscribe();
+    };
+  }, [panelService, hasPanels]);
+
+  const viewportComponents = viewports.map(getViewportComponentData);
+
+  return (
+    <div data-cy="dental-viewer-layout">
+      <PracticeHeader
+        hotkeysManager={hotkeysManager}
+        extensionManager={extensionManager}
+        servicesManager={servicesManager}
+        appConfig={appConfig}
+      />
+      <div
+        className="relative flex w-full flex-row flex-nowrap items-stretch overflow-hidden bg-background"
+        style={{ height: 'calc(100vh - 56px)' }}
+      >
+        {showLoadingIndicator ? (
+          <LoadingIndicatorProgress className="h-full w-full bg-background" />
+        ) : null}
+        <div className="flex h-full w-full flex-row overflow-hidden">
+          {hasLeftPanels ? (
+            <SidePanelWithServices
+              side="left"
+              isExpanded={!leftPanelClosedState}
+              servicesManager={servicesManager}
+              expandedWidth={leftPanelInitialExpandedWidth}
+              onOpen={() => setLeftPanelClosed(false)}
+              onClose={() => setLeftPanelClosed(true)}
+            />
+          ) : null}
+          <div className="flex h-full min-w-0 flex-1 flex-col">
+            <div className="relative flex h-full flex-1 items-center justify-center overflow-hidden bg-background">
+              <ViewportGridComp
+                servicesManager={servicesManager}
+                viewportComponents={viewportComponents}
+                commandsManager={commandsManager}
+              />
+            </div>
+          </div>
+          {hasRightPanels ? (
+            <SidePanelWithServices
+              side="right"
+              isExpanded={!rightPanelClosedState}
+              servicesManager={servicesManager}
+              expandedWidth={rightPanelInitialExpandedWidth}
+              onOpen={() => setRightPanelClosed(false)}
+              onClose={() => setRightPanelClosed(true)}
+            />
+          ) : null}
+        </div>
+      </div>
+      <Onboarding tours={customizationService.getCustomization('ohif.tours')} />
+      <InvestigationalUseDialog dialogConfiguration={appConfig?.investigationalUseDialog} />
+    </div>
+  );
+}
+
+DentalViewerLayout.propTypes = {
+  extensionManager: PropTypes.shape({
+    getModuleEntry: PropTypes.func.isRequired,
+  }).isRequired,
+  commandsManager: PropTypes.instanceOf(CommandsManager),
+  servicesManager: PropTypes.object.isRequired,
+  viewports: PropTypes.array,
+};
+
+export default DentalViewerLayout;

--- a/extensions/dental/src/layout/DentalViewerLayout.tsx
+++ b/extensions/dental/src/layout/DentalViewerLayout.tsx
@@ -6,6 +6,7 @@ import { InvestigationalUseDialog, Onboarding } from '@ohif/ui-next';
 import { useAppConfig } from '@state';
 
 import { useDentalPreferences } from '../preferences/useDentalPreferences';
+import { useDentalMeasurements } from '../measurements/useDentalMeasurements';
 import { useDentalViewerState } from '../viewerState/useDentalViewerState';
 import DentalViewportPlaceholders from './DentalViewportPlaceholders';
 import PracticeHeader from './PracticeHeader';
@@ -51,6 +52,11 @@ function DentalViewerLayout({
     servicesManager,
     preferences,
     applyPreferences,
+  });
+  const { armPreset } = useDentalMeasurements({
+    commandsManager,
+    servicesManager,
+    preferences,
   });
 
   const hasPanels = useCallback((side): boolean => !!panelService.getPanels(side).length, [
@@ -150,6 +156,7 @@ function DentalViewerLayout({
         onSelectedToothChange={setSelectedToothId}
         onNumberingSystemChange={setNumberingSystem}
         onThemeToggle={toggleTheme}
+        onSelectMeasurementPreset={armPreset}
       />
       <div
         className={VIEWER_BODY_CLASS_BY_THEME[preferences.theme]}

--- a/extensions/dental/src/layout/DentalViewerLayout.tsx
+++ b/extensions/dental/src/layout/DentalViewerLayout.tsx
@@ -54,6 +54,7 @@ function DentalViewerLayout({
     applyPreferences,
   });
   const { armPreset } = useDentalMeasurements({
+    appConfig,
     commandsManager,
     servicesManager,
     preferences,

--- a/extensions/dental/src/layout/DentalViewerLayout.tsx
+++ b/extensions/dental/src/layout/DentalViewerLayout.tsx
@@ -6,6 +6,7 @@ import { InvestigationalUseDialog, Onboarding } from '@ohif/ui-next';
 import { useAppConfig } from '@state';
 
 import { useDentalPreferences } from '../preferences/useDentalPreferences';
+import DentalViewportPlaceholders from './DentalViewportPlaceholders';
 import PracticeHeader from './PracticeHeader';
 import SidePanelWithServices from './SidePanelWithServices';
 
@@ -162,6 +163,7 @@ function DentalViewerLayout({
                 viewportComponents={viewportComponents}
                 commandsManager={commandsManager}
               />
+              <DentalViewportPlaceholders />
             </div>
           </div>
           {hasRightPanels ? (

--- a/extensions/dental/src/layout/DentalViewerLayout.tsx
+++ b/extensions/dental/src/layout/DentalViewerLayout.tsx
@@ -6,6 +6,7 @@ import { InvestigationalUseDialog, Onboarding } from '@ohif/ui-next';
 import { useAppConfig } from '@state';
 
 import { useDentalPreferences } from '../preferences/useDentalPreferences';
+import { useDentalViewerState } from '../viewerState/useDentalViewerState';
 import DentalViewportPlaceholders from './DentalViewportPlaceholders';
 import PracticeHeader from './PracticeHeader';
 import SidePanelWithServices from './SidePanelWithServices';
@@ -39,8 +40,18 @@ function DentalViewerLayout({
     preferences,
     setSelectedToothId,
     setNumberingSystem,
+    applyPreferences,
     toggleTheme,
   } = useDentalPreferences();
+  const {
+    status: dentalViewerStateStatus,
+    lastError: dentalViewerStateError,
+  } = useDentalViewerState({
+    appConfig,
+    servicesManager,
+    preferences,
+    applyPreferences,
+  });
 
   const hasPanels = useCallback((side): boolean => !!panelService.getPanels(side).length, [
     panelService,
@@ -134,6 +145,8 @@ function DentalViewerLayout({
         servicesManager={servicesManager}
         appConfig={appConfig}
         preferences={preferences}
+        stateStatus={dentalViewerStateStatus}
+        stateMessage={dentalViewerStateError}
         onSelectedToothChange={setSelectedToothId}
         onNumberingSystemChange={setNumberingSystem}
         onThemeToggle={toggleTheme}

--- a/extensions/dental/src/layout/DentalViewportPlaceholders.tsx
+++ b/extensions/dental/src/layout/DentalViewportPlaceholders.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+
+import { useViewportGrid } from '@ohif/ui-next';
+
+type PlaceholderDefinition = {
+  viewportId: string;
+  label: string;
+  description: string;
+  dataCy: string;
+  showWhenEmptyOnly?: boolean;
+};
+
+const PLACEHOLDERS: PlaceholderDefinition[] = [
+  {
+    viewportId: 'dental-prior',
+    label: 'No Prior Exam',
+    description: 'No same-modality prior is available in the loaded studies.',
+    dataCy: 'dental-no-prior-placeholder',
+    showWhenEmptyOnly: true,
+  },
+  {
+    viewportId: 'dental-bitewing-left',
+    label: 'Bitewing Placeholder',
+    description: 'Static MVP placeholder. Bitewing image matching is not enabled.',
+    dataCy: 'dental-bitewing-placeholder-left',
+  },
+  {
+    viewportId: 'dental-bitewing-right',
+    label: 'Bitewing Placeholder',
+    description: 'Static MVP placeholder. Bitewing image matching is not enabled.',
+    dataCy: 'dental-bitewing-placeholder-right',
+  },
+];
+
+function DentalViewportPlaceholder({
+  placeholder,
+}: {
+  placeholder: PlaceholderDefinition;
+}) {
+  const [viewportGrid] = useViewportGrid();
+  const viewport = viewportGrid.viewports.get(placeholder.viewportId);
+
+  if (!viewport) {
+    return null;
+  }
+
+  const hasDisplaySet = Boolean(viewport.displaySetInstanceUIDs?.length);
+
+  if (placeholder.showWhenEmptyOnly && hasDisplaySet) {
+    return null;
+  }
+
+  return (
+    <div
+      className="pointer-events-none absolute flex items-center justify-center p-3"
+      style={{
+        top: `${viewport.y * 100}%`,
+        left: `${viewport.x * 100}%`,
+        width: `${viewport.width * 100}%`,
+        height: `${viewport.height * 100}%`,
+      }}
+      data-cy={placeholder.dataCy}
+    >
+      <div className="border-primary/40 bg-background/90 flex h-full w-full flex-col items-center justify-center rounded border border-dashed px-5 text-center">
+        <div className="text-primary text-sm font-semibold">{placeholder.label}</div>
+        <div className="text-muted-foreground mt-1 max-w-[260px] text-xs">
+          {placeholder.description}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function DentalViewportPlaceholders() {
+  return (
+    <>
+      {PLACEHOLDERS.map(placeholder => (
+        <DentalViewportPlaceholder
+          key={placeholder.viewportId}
+          placeholder={placeholder}
+        />
+      ))}
+    </>
+  );
+}
+
+export default DentalViewportPlaceholders;

--- a/extensions/dental/src/layout/PracticeHeader.tsx
+++ b/extensions/dental/src/layout/PracticeHeader.tsx
@@ -8,6 +8,7 @@ import { preserveQueryParameters } from '@ohif/app';
 
 import { DentalPreferences } from '../preferences/dentalPreferences';
 import { ToothNumberingSystem } from '../tooth/toothIdentity';
+import { DentalViewerStateStatus } from '../viewerState/useDentalViewerState';
 import { formatHeaderValue, getPracticeName } from './practiceHeaderUtils';
 import ToothSelector from './ToothSelector';
 
@@ -26,9 +27,30 @@ const MODE_LABEL_CLASS_BY_THEME = {
   standard: 'text-muted-foreground text-[11px]',
 };
 
+function getStateStatusText(
+  stateStatus: DentalViewerStateStatus,
+  stateMessage: string | null
+): string | null {
+  if (stateStatus === 'loading') {
+    return 'Loading';
+  }
+
+  if (stateStatus === 'locked') {
+    return 'Locked';
+  }
+
+  if (stateStatus === 'unsaved') {
+    return stateMessage || 'Not saved';
+  }
+
+  return null;
+}
+
 type PracticeHeaderProps = withAppTypes<{
   appConfig: AppTypes.Config;
   preferences: DentalPreferences;
+  stateStatus: DentalViewerStateStatus;
+  stateMessage: string | null;
   onSelectedToothChange: (toothId: string) => void;
   onNumberingSystemChange: (numberingSystem: ToothNumberingSystem) => void;
   onThemeToggle: () => void;
@@ -37,6 +59,8 @@ type PracticeHeaderProps = withAppTypes<{
 function PracticeHeader({
   appConfig,
   preferences,
+  stateStatus,
+  stateMessage,
   onSelectedToothChange,
   onNumberingSystemChange,
   onThemeToggle,
@@ -48,6 +72,10 @@ function PracticeHeader({
 
   const practiceName = getPracticeName(appConfig);
   const isDentalTheme = preferences.theme === 'dental';
+  const stateStatusText = useMemo(
+    () => getStateStatusText(stateStatus, stateMessage),
+    [stateMessage, stateStatus]
+  );
 
   const studySummary = useMemo(() => {
     const displaySets = servicesManager.services.displaySetService.getActiveDisplaySets();
@@ -130,11 +158,23 @@ function PracticeHeader({
             </span>
           </div>
 
-          <ToothSelector
-            preferences={preferences}
-            onSelectedToothChange={onSelectedToothChange}
-            onNumberingSystemChange={onNumberingSystemChange}
-          />
+          <div className="flex min-w-0 items-center gap-2">
+            {stateStatusText ? (
+              <span
+                className="border-muted text-muted-foreground hidden h-7 max-w-[96px] items-center truncate rounded border px-2 text-[11px] xl:flex"
+                data-cy="dental-viewer-state-status"
+                title={stateStatusText}
+              >
+                {stateStatusText}
+              </span>
+            ) : null}
+
+            <ToothSelector
+              preferences={preferences}
+              onSelectedToothChange={onSelectedToothChange}
+              onNumberingSystemChange={onNumberingSystemChange}
+            />
+          </div>
 
           <Button
             variant={isDentalTheme ? 'default' : 'ghost'}

--- a/extensions/dental/src/layout/PracticeHeader.tsx
+++ b/extensions/dental/src/layout/PracticeHeader.tsx
@@ -1,0 +1,130 @@
+import React, { useMemo } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+
+import { Button, Icons } from '@ohif/ui-next';
+import { useSystem } from '@ohif/core';
+import { Toolbar, usePatientInfo } from '@ohif/extension-default';
+import { preserveQueryParameters } from '@ohif/app';
+
+import { formatHeaderValue, getPracticeName } from './practiceHeaderUtils';
+
+function PracticeHeader({ appConfig }: withAppTypes<{ appConfig: AppTypes.Config }>) {
+  const { servicesManager, extensionManager, commandsManager } = useSystem();
+  const { patientInfo } = usePatientInfo();
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const practiceName = getPracticeName(appConfig);
+
+  const studySummary = useMemo(() => {
+    const displaySets = servicesManager.services.displaySetService.getActiveDisplaySets();
+    const displaySet = displaySets?.[0];
+    const instance = displaySet?.instances?.[0] || displaySet?.instance;
+
+    return {
+      studyDate: instance?.StudyDate || displaySet?.StudyDate,
+      modality: instance?.Modality || displaySet?.Modality,
+    };
+  }, [servicesManager]);
+
+  const onClickReturnButton = () => {
+    const { pathname } = location;
+    const dataSourceIdx = pathname.indexOf('/', 1);
+    const dataSourceName = pathname.substring(dataSourceIdx + 1);
+    const existingDataSource = extensionManager.getDataSources(dataSourceName);
+
+    const searchQuery = new URLSearchParams();
+    if (dataSourceIdx !== -1 && existingDataSource) {
+      searchQuery.append('datasources', pathname.substring(dataSourceIdx + 1));
+    }
+    preserveQueryParameters(searchQuery);
+
+    navigate({
+      pathname: '/',
+      search: decodeURIComponent(searchQuery.toString()),
+    });
+  };
+
+  return (
+    <header
+      className="bg-background border-muted flex h-[56px] w-full items-center border-b px-3"
+      data-cy="dental-practice-header"
+    >
+      <div className="flex min-w-[260px] items-center gap-2">
+        {appConfig.showStudyList ? (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="text-primary hover:bg-muted"
+            data-cy="return-to-work-list"
+            onClick={onClickReturnButton}
+          >
+            <Icons.ArrowLeft className="h-6 w-6" />
+          </Button>
+        ) : null}
+        <div className="flex min-w-0 flex-col">
+          <span className="text-primary truncate text-sm font-semibold">{practiceName}</span>
+          <span className="text-muted-foreground text-[11px]">Dental Mode</span>
+        </div>
+      </div>
+
+      <div className="flex min-w-0 flex-1 justify-center">
+        <Toolbar buttonSection="primary" />
+      </div>
+
+      <div className="flex min-w-[360px] items-center justify-end gap-3">
+        <div
+          className="hidden min-w-0 flex-col text-right lg:flex"
+          data-cy="dental-patient-summary"
+        >
+          <span className="text-foreground truncate text-[13px] font-semibold">
+            {formatHeaderValue(patientInfo.PatientName, 'Patient')}
+          </span>
+          <span className="text-muted-foreground truncate text-[11px]">
+            {formatHeaderValue(patientInfo.PatientID, 'No ID')} ·{' '}
+            {formatHeaderValue(studySummary.modality, 'No modality')} ·{' '}
+            {formatHeaderValue(studySummary.studyDate, 'No study date')}
+          </span>
+        </div>
+
+        <Button
+          variant="ghost"
+          className="text-primary hover:bg-muted"
+          data-cy="dental-tooth-selector-placeholder"
+        >
+          Tooth
+        </Button>
+
+        <div className="text-primary flex items-center">
+          <Button
+            variant="ghost"
+            className="hover:bg-muted"
+            data-cy="undo-btn"
+            onClick={() => commandsManager.run('undo')}
+          >
+            <Icons.Undo />
+          </Button>
+          <Button
+            variant="ghost"
+            className="hover:bg-muted"
+            data-cy="redo-btn"
+            onClick={() => commandsManager.run('redo')}
+          >
+            <Icons.Redo />
+          </Button>
+        </div>
+
+        <Button
+          variant="ghost"
+          size="icon"
+          className="text-primary hover:bg-muted"
+          data-cy="dental-header-settings"
+        >
+          <Icons.GearSettings />
+        </Button>
+      </div>
+    </header>
+  );
+}
+
+export default PracticeHeader;

--- a/extensions/dental/src/layout/PracticeHeader.tsx
+++ b/extensions/dental/src/layout/PracticeHeader.tsx
@@ -7,6 +7,8 @@ import { Toolbar, usePatientInfo } from '@ohif/extension-default';
 import { preserveQueryParameters } from '@ohif/app';
 
 import { DentalPreferences } from '../preferences/dentalPreferences';
+import DentalMeasurementsPalette from '../measurements/DentalMeasurementsPalette';
+import { DentalMeasurementPresetId } from '../measurements/dentalMeasurementPresets';
 import { ToothNumberingSystem } from '../tooth/toothIdentity';
 import { DentalViewerStateStatus } from '../viewerState/useDentalViewerState';
 import { formatHeaderValue, getPracticeName } from './practiceHeaderUtils';
@@ -54,6 +56,7 @@ type PracticeHeaderProps = withAppTypes<{
   onSelectedToothChange: (toothId: string) => void;
   onNumberingSystemChange: (numberingSystem: ToothNumberingSystem) => void;
   onThemeToggle: () => void;
+  onSelectMeasurementPreset: (presetId: DentalMeasurementPresetId, note: string) => void;
 }>;
 
 function PracticeHeader({
@@ -64,6 +67,7 @@ function PracticeHeader({
   onSelectedToothChange,
   onNumberingSystemChange,
   onThemeToggle,
+  onSelectMeasurementPreset,
 }: PracticeHeaderProps) {
   const { servicesManager, extensionManager, commandsManager } = useSystem();
   const { patientInfo } = usePatientInfo();
@@ -138,8 +142,9 @@ function PracticeHeader({
         </div>
 
         <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 transform">
-          <div className="relative flex justify-center gap-[4px]">
+          <div className="relative flex items-center justify-center gap-[4px]">
             <Toolbar buttonSection="primary" />
+            <DentalMeasurementsPalette onSelectPreset={onSelectMeasurementPreset} />
           </div>
         </div>
 

--- a/extensions/dental/src/layout/PracticeHeader.tsx
+++ b/extensions/dental/src/layout/PracticeHeader.tsx
@@ -1,20 +1,53 @@
 import React, { useMemo } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
-import { Button, Icons } from '@ohif/ui-next';
+import { Button, IconPresentationProvider, Icons, ToolButton } from '@ohif/ui-next';
 import { useSystem } from '@ohif/core';
 import { Toolbar, usePatientInfo } from '@ohif/extension-default';
 import { preserveQueryParameters } from '@ohif/app';
 
+import { DentalPreferences } from '../preferences/dentalPreferences';
+import { ToothNumberingSystem } from '../tooth/toothIdentity';
 import { formatHeaderValue, getPracticeName } from './practiceHeaderUtils';
+import ToothSelector from './ToothSelector';
 
-function PracticeHeader({ appConfig }: withAppTypes<{ appConfig: AppTypes.Config }>) {
+const HEADER_CLASS_BY_THEME = {
+  dental: 'relative h-[56px] w-full border-b border-[#24a78d] bg-[#10201c] px-3',
+  standard: 'bg-background border-muted relative h-[56px] w-full border-b px-3',
+};
+
+const PRACTICE_NAME_CLASS_BY_THEME = {
+  dental: 'truncate text-sm font-semibold text-[#bff4e7]',
+  standard: 'text-primary truncate text-sm font-semibold',
+};
+
+const MODE_LABEL_CLASS_BY_THEME = {
+  dental: 'text-[11px] text-[#76d6c1]',
+  standard: 'text-muted-foreground text-[11px]',
+};
+
+type PracticeHeaderProps = withAppTypes<{
+  appConfig: AppTypes.Config;
+  preferences: DentalPreferences;
+  onSelectedToothChange: (toothId: string) => void;
+  onNumberingSystemChange: (numberingSystem: ToothNumberingSystem) => void;
+  onThemeToggle: () => void;
+}>;
+
+function PracticeHeader({
+  appConfig,
+  preferences,
+  onSelectedToothChange,
+  onNumberingSystemChange,
+  onThemeToggle,
+}: PracticeHeaderProps) {
   const { servicesManager, extensionManager, commandsManager } = useSystem();
   const { patientInfo } = usePatientInfo();
   const navigate = useNavigate();
   const location = useLocation();
 
   const practiceName = getPracticeName(appConfig);
+  const isDentalTheme = preferences.theme === 'dental';
 
   const studySummary = useMemo(() => {
     const displaySets = servicesManager.services.displaySetService.getActiveDisplaySets();
@@ -46,84 +79,104 @@ function PracticeHeader({ appConfig }: withAppTypes<{ appConfig: AppTypes.Config
   };
 
   return (
-    <header
-      className="bg-background border-muted flex h-[56px] w-full items-center border-b px-3"
-      data-cy="dental-practice-header"
+    <IconPresentationProvider
+      size="large"
+      IconContainer={ToolButton}
     >
-      <div className="flex min-w-[260px] items-center gap-2">
-        {appConfig.showStudyList ? (
+      <header
+        className={HEADER_CLASS_BY_THEME[preferences.theme]}
+        data-cy="dental-practice-header"
+      >
+        <div className="absolute left-3 top-1/2 flex min-w-[260px] -translate-y-1/2 items-center gap-2">
+          {appConfig.showStudyList ? (
+            <Button
+              variant="ghost"
+              size="icon"
+              className="text-primary hover:bg-muted"
+              data-cy="return-to-work-list"
+              onClick={onClickReturnButton}
+            >
+              <Icons.ArrowLeft className="h-6 w-6" />
+            </Button>
+          ) : null}
+          <div className="flex min-w-0 flex-col">
+            <span className={PRACTICE_NAME_CLASS_BY_THEME[preferences.theme]}>
+              {practiceName}
+            </span>
+            <span className={MODE_LABEL_CLASS_BY_THEME[preferences.theme]}>
+              Dental Mode
+            </span>
+          </div>
+        </div>
+
+        <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 transform">
+          <div className="relative flex justify-center gap-[4px]">
+            <Toolbar buttonSection="primary" />
+          </div>
+        </div>
+
+        <div className="absolute right-3 top-1/2 flex max-w-[calc(50vw-260px)] -translate-y-1/2 select-none items-center justify-end gap-2 overflow-hidden">
+          <div
+            className="hidden w-[220px] min-w-0 flex-shrink flex-col text-right lg:flex"
+            data-cy="dental-patient-summary"
+          >
+            <span className="text-foreground truncate text-[13px] font-semibold">
+              {formatHeaderValue(patientInfo.PatientName, 'Patient')}
+            </span>
+            <span className="text-muted-foreground truncate text-[11px]">
+              {formatHeaderValue(patientInfo.PatientID, 'No ID')} |{' '}
+              {formatHeaderValue(studySummary.modality, 'No modality')} |{' '}
+              {formatHeaderValue(studySummary.studyDate, 'No study date')}
+            </span>
+          </div>
+
+          <ToothSelector
+            preferences={preferences}
+            onSelectedToothChange={onSelectedToothChange}
+            onNumberingSystemChange={onNumberingSystemChange}
+          />
+
+          <Button
+            variant={isDentalTheme ? 'default' : 'ghost'}
+            className="h-9 px-2 text-xs"
+            data-cy="dental-theme-toggle"
+            onClick={onThemeToggle}
+          >
+            {isDentalTheme ? 'Dental' : 'Theme'}
+          </Button>
+
+          <div className="text-primary flex cursor-pointer items-center">
+            <Button
+              variant="ghost"
+              className="hover:bg-muted"
+              data-cy="undo-btn"
+              onClick={() => commandsManager.run('undo')}
+            >
+              <Icons.Undo />
+            </Button>
+            <Button
+              variant="ghost"
+              className="hover:bg-muted"
+              data-cy="redo-btn"
+              onClick={() => commandsManager.run('redo')}
+            >
+              <Icons.Redo />
+            </Button>
+          </div>
+
+          <div className="border-muted mx-1.5 h-[25px] border-r" />
+
           <Button
             variant="ghost"
             size="icon"
             className="text-primary hover:bg-muted"
-            data-cy="return-to-work-list"
-            onClick={onClickReturnButton}
+            data-cy="dental-header-settings"
           >
-            <Icons.ArrowLeft className="h-6 w-6" />
-          </Button>
-        ) : null}
-        <div className="flex min-w-0 flex-col">
-          <span className="text-primary truncate text-sm font-semibold">{practiceName}</span>
-          <span className="text-muted-foreground text-[11px]">Dental Mode</span>
-        </div>
-      </div>
-
-      <div className="flex min-w-0 flex-1 justify-center">
-        <Toolbar buttonSection="primary" />
-      </div>
-
-      <div className="flex min-w-[360px] items-center justify-end gap-3">
-        <div
-          className="hidden min-w-0 flex-col text-right lg:flex"
-          data-cy="dental-patient-summary"
-        >
-          <span className="text-foreground truncate text-[13px] font-semibold">
-            {formatHeaderValue(patientInfo.PatientName, 'Patient')}
-          </span>
-          <span className="text-muted-foreground truncate text-[11px]">
-            {formatHeaderValue(patientInfo.PatientID, 'No ID')} ·{' '}
-            {formatHeaderValue(studySummary.modality, 'No modality')} ·{' '}
-            {formatHeaderValue(studySummary.studyDate, 'No study date')}
-          </span>
-        </div>
-
-        <Button
-          variant="ghost"
-          className="text-primary hover:bg-muted"
-          data-cy="dental-tooth-selector-placeholder"
-        >
-          Tooth
-        </Button>
-
-        <div className="text-primary flex items-center">
-          <Button
-            variant="ghost"
-            className="hover:bg-muted"
-            data-cy="undo-btn"
-            onClick={() => commandsManager.run('undo')}
-          >
-            <Icons.Undo />
-          </Button>
-          <Button
-            variant="ghost"
-            className="hover:bg-muted"
-            data-cy="redo-btn"
-            onClick={() => commandsManager.run('redo')}
-          >
-            <Icons.Redo />
+            <Icons.GearSettings />
           </Button>
         </div>
-
-        <Button
-          variant="ghost"
-          size="icon"
-          className="text-primary hover:bg-muted"
-          data-cy="dental-header-settings"
-        >
-          <Icons.GearSettings />
-        </Button>
-      </div>
-    </header>
+      </header>
+    </IconPresentationProvider>
   );
 }
 

--- a/extensions/dental/src/layout/PracticeHeader.tsx
+++ b/extensions/dental/src/layout/PracticeHeader.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import { Button, IconPresentationProvider, Icons, ToolButton } from '@ohif/ui-next';
@@ -11,7 +11,7 @@ import DentalMeasurementsPalette from '../measurements/DentalMeasurementsPalette
 import { DentalMeasurementPresetId } from '../measurements/dentalMeasurementPresets';
 import { ToothNumberingSystem } from '../tooth/toothIdentity';
 import { DentalViewerStateStatus } from '../viewerState/useDentalViewerState';
-import { formatHeaderValue, getPracticeName } from './practiceHeaderUtils';
+import { formatHeaderValue, getPracticeName, getStudySummary } from './practiceHeaderUtils';
 import ToothSelector from './ToothSelector';
 
 const HEADER_CLASS_BY_THEME = {
@@ -70,6 +70,7 @@ function PracticeHeader({
   onSelectMeasurementPreset,
 }: PracticeHeaderProps) {
   const { servicesManager, extensionManager, commandsManager } = useSystem();
+  const { displaySetService } = servicesManager.services;
   const { patientInfo } = usePatientInfo();
   const navigate = useNavigate();
   const location = useLocation();
@@ -81,16 +82,26 @@ function PracticeHeader({
     [stateMessage, stateStatus]
   );
 
-  const studySummary = useMemo(() => {
-    const displaySets = servicesManager.services.displaySetService.getActiveDisplaySets();
-    const displaySet = displaySets?.[0];
-    const instance = displaySet?.instances?.[0] || displaySet?.instance;
+  const [studySummary, setStudySummary] = useState(() => getStudySummary(displaySetService));
+  const refreshStudySummary = useCallback(() => {
+    setStudySummary(getStudySummary(displaySetService));
+  }, [displaySetService]);
 
-    return {
-      studyDate: instance?.StudyDate || displaySet?.StudyDate,
-      modality: instance?.Modality || displaySet?.Modality,
-    };
-  }, [servicesManager]);
+  useEffect(() => {
+    refreshStudySummary();
+    const subscriptions = [
+      displaySetService.subscribe?.(
+        displaySetService.EVENTS.DISPLAY_SETS_ADDED,
+        refreshStudySummary
+      ),
+      displaySetService.subscribe?.(
+        displaySetService.EVENTS.DISPLAY_SETS_CHANGED,
+        refreshStudySummary
+      ),
+    ].filter(Boolean);
+
+    return () => subscriptions.forEach(subscription => subscription.unsubscribe());
+  }, [displaySetService, refreshStudySummary]);
 
   const onClickReturnButton = () => {
     const { pathname } = location;

--- a/extensions/dental/src/layout/SidePanelWithServices.tsx
+++ b/extensions/dental/src/layout/SidePanelWithServices.tsx
@@ -1,0 +1,118 @@
+import React, { useCallback, useEffect, useState } from 'react';
+
+import { SidePanel } from '@ohif/ui-next';
+import { Types } from '@ohif/core';
+
+type SidePanelWithServicesProps = {
+  servicesManager: AppTypes.ServicesManager;
+  side: 'left' | 'right';
+  className?: string;
+  activeTabIndex?: number;
+  tabs?: any;
+  expandedWidth?: number;
+  onClose?: () => void;
+  onOpen?: () => void;
+  isExpanded: boolean;
+  collapsedWidth?: number;
+  expandedInsideBorderSize?: number;
+  collapsedInsideBorderSize?: number;
+  collapsedOutsideBorderSize?: number;
+};
+
+const SidePanelWithServices = ({
+  servicesManager,
+  side,
+  activeTabIndex: activeTabIndexProp,
+  isExpanded,
+  tabs: tabsProp,
+  onOpen,
+  onClose,
+  ...props
+}: SidePanelWithServicesProps) => {
+  const { panelService, toolbarService, viewportGridService } = servicesManager.services;
+  const [sidePanelExpanded, setSidePanelExpanded] = useState(isExpanded);
+  const [activeTabIndex, setActiveTabIndex] = useState(activeTabIndexProp ?? 0);
+  const [closedManually, setClosedManually] = useState(false);
+  const [tabs, setTabs] = useState(tabsProp ?? panelService.getPanels(side));
+
+  const handleActiveTabIndexChange = useCallback(
+    ({ activeTabIndex }) => {
+      const { activeViewportId: viewportId } = viewportGridService.getState();
+      toolbarService.refreshToolbarState({ viewportId });
+      setActiveTabIndex(activeTabIndex);
+    },
+    [toolbarService, viewportGridService]
+  );
+
+  const handleOpen = useCallback(() => {
+    setSidePanelExpanded(true);
+    onOpen?.();
+  }, [onOpen]);
+
+  const handleClose = useCallback(() => {
+    setSidePanelExpanded(false);
+    setClosedManually(true);
+    onClose?.();
+  }, [onClose]);
+
+  useEffect(() => {
+    setSidePanelExpanded(isExpanded);
+  }, [isExpanded]);
+
+  useEffect(() => {
+    setActiveTabIndex(activeTabIndexProp ?? 0);
+  }, [activeTabIndexProp]);
+
+  useEffect(() => {
+    const { unsubscribe } = panelService.subscribe(
+      panelService.EVENTS.PANELS_CHANGED,
+      panelChangedEvent => {
+        if (panelChangedEvent.position !== side) {
+          return;
+        }
+
+        setTabs(panelService.getPanels(side));
+      }
+    );
+
+    return () => {
+      unsubscribe();
+    };
+  }, [panelService, side]);
+
+  useEffect(() => {
+    const activatePanelSubscription = panelService.subscribe(
+      panelService.EVENTS.ACTIVATE_PANEL,
+      (activatePanelEvent: Types.ActivatePanelEvent) => {
+        if (sidePanelExpanded || activatePanelEvent.forceActive) {
+          const tabIndex = tabs.findIndex(tab => tab.id === activatePanelEvent.panelId);
+          if (tabIndex !== -1) {
+            if (!closedManually) {
+              setSidePanelExpanded(true);
+            }
+            setActiveTabIndex(tabIndex);
+          }
+        }
+      }
+    );
+
+    return () => {
+      activatePanelSubscription.unsubscribe();
+    };
+  }, [tabs, sidePanelExpanded, panelService, closedManually]);
+
+  return (
+    <SidePanel
+      {...props}
+      side={side}
+      tabs={tabs}
+      activeTabIndex={activeTabIndex}
+      isExpanded={sidePanelExpanded}
+      onOpen={handleOpen}
+      onClose={handleClose}
+      onActiveTabIndexChange={handleActiveTabIndexChange}
+    />
+  );
+};
+
+export default SidePanelWithServices;

--- a/extensions/dental/src/layout/ToothSelector.tsx
+++ b/extensions/dental/src/layout/ToothSelector.tsx
@@ -1,0 +1,112 @@
+import React, { memo, useMemo } from 'react';
+
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  Icons,
+} from '@ohif/ui-next';
+
+import { DentalPreferences } from '../preferences/dentalPreferences';
+import {
+  TOOTH_IDENTITIES,
+  ToothNumberingSystem,
+  getToothDisplayLabel,
+  getToothIdentityById,
+} from '../tooth/toothIdentity';
+
+const TOOTH_SELECTOR_TRIGGER_CLASS =
+  'bg-transparent text-foreground/80 hover:bg-background hover:text-highlight flex h-10 w-[280px] items-center justify-between gap-2 rounded-lg px-2 text-xs';
+
+const NUMBERING_BUTTON_CLASS = 'h-8 px-2 text-xs';
+
+type ToothSelectorProps = {
+  preferences: DentalPreferences;
+  onSelectedToothChange: (toothId: string) => void;
+  onNumberingSystemChange: (numberingSystem: ToothNumberingSystem) => void;
+};
+
+function ToothSelector({
+  preferences,
+  onSelectedToothChange,
+  onNumberingSystemChange,
+}: ToothSelectorProps) {
+  const selectedTooth = getToothIdentityById(preferences.selectedToothId) || TOOTH_IDENTITIES[0];
+  const selectedToothLabel = `${getToothDisplayLabel(
+    selectedTooth,
+    preferences.numberingSystem
+  )} - ${selectedTooth.label}`;
+
+  const toothOptions = useMemo(
+    () =>
+      TOOTH_IDENTITIES.map(tooth => ({
+        id: tooth.id,
+        label: `${getToothDisplayLabel(tooth, preferences.numberingSystem)} - ${tooth.label}`,
+      })),
+    [preferences.numberingSystem]
+  );
+
+  return (
+    <div
+      className="flex h-10 items-center gap-1"
+      data-cy="dental-tooth-selector"
+    >
+      <Button
+        variant={preferences.numberingSystem === 'FDI' ? 'default' : 'ghost'}
+        className={NUMBERING_BUTTON_CLASS}
+        data-cy="dental-numbering-system-fdi"
+        onClick={() => onNumberingSystemChange('FDI')}
+      >
+        FDI
+      </Button>
+      <Button
+        variant={preferences.numberingSystem === 'Universal' ? 'default' : 'ghost'}
+        className={NUMBERING_BUTTON_CLASS}
+        data-cy="dental-numbering-system-universal"
+        onClick={() => onNumberingSystemChange('Universal')}
+      >
+        UNI
+      </Button>
+
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="ghost"
+            className={TOOTH_SELECTOR_TRIGGER_CLASS}
+            data-cy="dental-selected-tooth"
+          >
+            <span className="truncate">{selectedToothLabel}</span>
+            <span className="flex flex-shrink-0 items-center gap-1">
+              <span className="bg-primary h-5 w-px" />
+              <Icons.ByName
+                name="chevron-down"
+                className="text-primary h-5 w-5"
+              />
+            </span>
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent
+          side="bottom"
+          align="start"
+          alignOffset={-40}
+          className="max-h-[420px] w-[280px] overflow-y-auto"
+        >
+          {toothOptions.map(option => (
+            <DropdownMenuItem
+              key={option.id}
+              className="flex items-center space-x-2"
+              data-cy="dental-tooth-option"
+              onSelect={() => onSelectedToothChange(option.id)}
+            >
+              <span className="truncate">{option.label}</span>
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}
+
+export default memo(ToothSelector);

--- a/extensions/dental/src/layout/practiceHeaderUtils.test.ts
+++ b/extensions/dental/src/layout/practiceHeaderUtils.test.ts
@@ -1,0 +1,18 @@
+import { formatHeaderValue, getPracticeName } from './practiceHeaderUtils';
+
+describe('Practice Header utilities', () => {
+  it('prefers Dental Mode practice name from app config', () => {
+    expect(getPracticeName({ dental: { practiceName: 'Northside Dental' } })).toBe(
+      'Northside Dental'
+    );
+  });
+
+  it('falls back to Dental Practice when no practice name is configured', () => {
+    expect(getPracticeName({})).toBe('Dental Practice');
+  });
+
+  it('formats missing header values consistently', () => {
+    expect(formatHeaderValue(null)).toBe('Not available');
+    expect(formatHeaderValue('CT')).toBe('CT');
+  });
+});

--- a/extensions/dental/src/layout/practiceHeaderUtils.test.ts
+++ b/extensions/dental/src/layout/practiceHeaderUtils.test.ts
@@ -1,4 +1,4 @@
-import { formatHeaderValue, getPracticeName } from './practiceHeaderUtils';
+import { formatHeaderValue, getPracticeName, getStudySummary } from './practiceHeaderUtils';
 
 describe('Practice Header utilities', () => {
   it('prefers Dental Mode practice name from app config', () => {
@@ -14,5 +14,25 @@ describe('Practice Header utilities', () => {
   it('formats missing header values consistently', () => {
     expect(formatHeaderValue(null)).toBe('Not available');
     expect(formatHeaderValue('CT')).toBe('CT');
+  });
+
+  it('reads study summary from active display set metadata', () => {
+    expect(
+      getStudySummary({
+        getActiveDisplaySets: () => [
+          {
+            instances: [
+              {
+                Modality: 'CT',
+                StudyDate: '20140522',
+              },
+            ],
+          },
+        ],
+      })
+    ).toEqual({
+      modality: 'CT',
+      studyDate: '20140522',
+    });
   });
 });

--- a/extensions/dental/src/layout/practiceHeaderUtils.ts
+++ b/extensions/dental/src/layout/practiceHeaderUtils.ts
@@ -12,3 +12,13 @@ export function getPracticeName(appConfig): string {
 export function formatHeaderValue(value, fallback = 'Not available'): string {
   return value || fallback;
 }
+
+export function getStudySummary(displaySetService) {
+  const displaySet = displaySetService.getActiveDisplaySets?.()?.[0];
+  const instance = displaySet?.instances?.[0] || displaySet?.instance;
+
+  return {
+    studyDate: instance?.StudyDate || displaySet?.StudyDate,
+    modality: instance?.Modality || displaySet?.Modality,
+  };
+}

--- a/extensions/dental/src/layout/practiceHeaderUtils.ts
+++ b/extensions/dental/src/layout/practiceHeaderUtils.ts
@@ -1,0 +1,14 @@
+const DEFAULT_PRACTICE_NAME = 'Dental Practice';
+
+export function getPracticeName(appConfig): string {
+  return (
+    appConfig?.dental?.practiceName ||
+    appConfig?.practiceName ||
+    appConfig?.whiteLabeling?.practiceName ||
+    DEFAULT_PRACTICE_NAME
+  );
+}
+
+export function formatHeaderValue(value, fallback = 'Not available'): string {
+  return value || fallback;
+}

--- a/extensions/dental/src/measurements/DentalMeasurementsPalette.tsx
+++ b/extensions/dental/src/measurements/DentalMeasurementsPalette.tsx
@@ -1,0 +1,106 @@
+import React, { memo, useCallback, useState } from 'react';
+
+import {
+  Button,
+  Icons,
+  Input,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@ohif/ui-next';
+
+import {
+  DENTAL_MEASUREMENT_PRESETS,
+  DentalMeasurementPresetId,
+} from './dentalMeasurementPresets';
+
+type DentalMeasurementsPaletteProps = {
+  onSelectPreset: (presetId: DentalMeasurementPresetId, note: string) => void;
+};
+
+function DentalMeasurementsPalette({ onSelectPreset }: DentalMeasurementsPaletteProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [note, setNote] = useState('');
+
+  const handlePresetSelect = useCallback(
+    (presetId: DentalMeasurementPresetId) => {
+      onSelectPreset(presetId, note);
+      setNote('');
+      setIsOpen(false);
+    },
+    [note, onSelectPreset]
+  );
+
+  return (
+    <Popover
+      open={isOpen}
+      onOpenChange={setIsOpen}
+    >
+      <PopoverTrigger asChild>
+        <Button
+          variant="ghost"
+          className="text-primary hover:bg-muted h-10 gap-2 px-2 text-xs"
+          data-cy="dental-measurements-button"
+        >
+          <Icons.ByName
+            name="tool-length"
+            className="h-5 w-5"
+          />
+          <span>Measurements</span>
+          <span className="bg-primary h-5 w-px" />
+          <Icons.ByName
+            name="chevron-down"
+            className="h-4 w-4"
+          />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        side="bottom"
+        sideOffset={6}
+        className="w-[260px] p-2"
+        data-cy="dental-measurements-palette"
+      >
+        <div className="px-2 pb-2 pt-1 text-xs font-semibold">Dental measurements</div>
+        <div className="space-y-1">
+          {DENTAL_MEASUREMENT_PRESETS.map(preset => (
+            <Button
+              key={preset.id}
+              variant="ghost"
+              className="hover:bg-muted flex h-10 w-full justify-start gap-3 px-2"
+              data-cy={`dental-measurement-preset-${preset.id}`}
+              onClick={() => handlePresetSelect(preset.id)}
+            >
+              <Icons.ByName
+                name={preset.toolName === 'Angle' ? 'tool-angle' : 'tool-length'}
+                className="text-primary h-5 w-5 flex-shrink-0"
+              />
+              <span className="flex min-w-0 flex-1 items-center justify-between gap-2">
+                <span className="truncate text-sm">{preset.label}</span>
+                <span className="text-muted-foreground text-xs">{preset.unit}</span>
+              </span>
+            </Button>
+          ))}
+        </div>
+        <div className="border-muted mt-2 border-t px-2 pt-2">
+          <label
+            htmlFor="dental-measurement-note"
+            className="text-muted-foreground mb-1 block text-[11px]"
+          >
+            Optional note
+          </label>
+          <Input
+            id="dental-measurement-note"
+            value={note}
+            maxLength={120}
+            className="h-8 text-xs"
+            data-cy="dental-measurement-note"
+            onChange={event => setNote(event.target.value)}
+          />
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+export default memo(DentalMeasurementsPalette);

--- a/extensions/dental/src/measurements/DentalMeasurementsPanel.tsx
+++ b/extensions/dental/src/measurements/DentalMeasurementsPanel.tsx
@@ -1,5 +1,6 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
+import { utils } from '@ohif/core';
 import {
   Button,
   Badge,
@@ -21,6 +22,10 @@ import {
 } from './dentalMeasurementList';
 import { DentalMeasurementsService } from './DentalMeasurementsService';
 import { getToothDisplayLabel, getToothIdentityById } from '../tooth/toothIdentity';
+import {
+  createDentalMeasurementExport,
+  createDentalMeasurementExportFilename,
+} from './dentalMeasurementExport';
 
 const EMPTY_FILTERS: DentalMeasurementFilters = {
   label: '',
@@ -77,6 +82,39 @@ function DentalMeasurementsPanel({ servicesManager }: DentalMeasurementsPanelPro
     setFilters(current => ({ ...current, [key]: value === 'all' ? '' : value }));
   };
 
+  const displaySet = servicesManager.services.displaySetService.getActiveDisplaySets?.()?.[0];
+  const instance = displaySet?.instances?.[0] || displaySet?.instance;
+  const exportContext = {
+    studyInstanceUID: displaySet?.StudyInstanceUID || instance?.StudyInstanceUID,
+    patientId: instance?.PatientID || displaySet?.PatientID,
+  };
+
+  const handleExport = useCallback(() => {
+    if (!exportContext.studyInstanceUID) {
+      return;
+    }
+
+    const exportedAt = new Date();
+    const payload = createDentalMeasurementExport(
+      {
+        studyInstanceUID: exportContext.studyInstanceUID,
+        patientId: exportContext.patientId,
+        exportedAt: exportedAt.toISOString(),
+      },
+      measurements
+    );
+    const blob = new Blob([JSON.stringify(payload, null, 2)], {
+      type: 'application/json;charset=utf-8',
+    });
+
+    utils.downloadBlob(blob, {
+      filename: createDentalMeasurementExportFilename(
+        exportContext.studyInstanceUID,
+        exportedAt
+      ),
+    });
+  }, [exportContext.patientId, exportContext.studyInstanceUID, measurements]);
+
   const getToothLabel = (toothId: string) => {
     const tooth = getToothIdentityById(toothId);
     return tooth ? `FDI ${getToothDisplayLabel(tooth, 'FDI')} - ${tooth.label}` : toothId;
@@ -90,9 +128,22 @@ function DentalMeasurementsPanel({ servicesManager }: DentalMeasurementsPanelPro
       <div className="border-muted space-y-2 border-b p-3">
         <div className="flex items-center justify-between gap-2">
           <div className="text-sm font-semibold">Study Measurements</div>
-          {status !== 'idle' && status !== 'saved' ? (
-            <Badge variant="outline">{status}</Badge>
-          ) : null}
+          <div className="flex items-center gap-1">
+            {status !== 'idle' && status !== 'saved' ? (
+              <Badge variant="outline">{status}</Badge>
+            ) : null}
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8"
+              title="Export JSON"
+              data-cy="dental-export-json"
+              disabled={!exportContext.studyInstanceUID || measurements.length === 0}
+              onClick={handleExport}
+            >
+              <Icons.Download className="h-5 w-5" />
+            </Button>
+          </div>
         </div>
         <div className="grid grid-cols-2 gap-2">
           <Select
@@ -193,7 +244,7 @@ function DentalMeasurementsPanel({ servicesManager }: DentalMeasurementsPanelPro
                 <div className="min-w-0 flex-1">
                   <div className="truncate text-sm font-medium">{measurement.label}</div>
                   <div className="text-primary text-lg font-semibold">
-                    {measurement.value ?? '—'} {measurement.unit}
+                    {measurement.value ?? '-'} {measurement.unit}
                   </div>
                   <div className="text-muted-foreground truncate text-[11px]">
                     {getToothLabel(measurement.toothId)}

--- a/extensions/dental/src/measurements/DentalMeasurementsPanel.tsx
+++ b/extensions/dental/src/measurements/DentalMeasurementsPanel.tsx
@@ -1,0 +1,231 @@
+import React, { useEffect, useMemo, useState } from 'react';
+
+import {
+  Button,
+  Badge,
+  Icons,
+  ScrollArea,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@ohif/ui-next';
+
+import { DentalMeasurement } from './dentalMeasurement';
+import {
+  DentalMeasurementFilters,
+  DentalMeasurementSort,
+  filterDentalMeasurements,
+  sortDentalMeasurements,
+} from './dentalMeasurementList';
+import { DentalMeasurementsService } from './DentalMeasurementsService';
+import { getToothDisplayLabel, getToothIdentityById } from '../tooth/toothIdentity';
+
+const EMPTY_FILTERS: DentalMeasurementFilters = {
+  label: '',
+  toothId: '',
+  unit: '',
+};
+
+type DentalMeasurementsPanelProps = {
+  servicesManager: AppTypes.ServicesManager;
+};
+
+function DentalMeasurementsPanel({ servicesManager }: DentalMeasurementsPanelProps) {
+  const dentalMeasurementsService = servicesManager.services
+    .dentalMeasurementsService as DentalMeasurementsService;
+  const [measurements, setMeasurements] = useState<DentalMeasurement[]>(() =>
+    dentalMeasurementsService.getMeasurements()
+  );
+  const [status, setStatus] = useState(() => dentalMeasurementsService.getStatus());
+  const [filters, setFilters] = useState(EMPTY_FILTERS);
+  const [sortBy, setSortBy] = useState<DentalMeasurementSort>('createdAt');
+
+  useEffect(() => {
+    const subscription = dentalMeasurementsService.subscribe(
+      dentalMeasurementsService.EVENTS.MEASUREMENTS_CHANGED,
+      ({ measurements: nextMeasurements }: { measurements: DentalMeasurement[] }) => {
+        setMeasurements(nextMeasurements);
+      }
+    );
+    const statusSubscription = dentalMeasurementsService.subscribe(
+      dentalMeasurementsService.EVENTS.STATUS_CHANGED,
+      ({ status: nextStatus }) => setStatus(nextStatus)
+    );
+
+    return () => {
+      subscription.unsubscribe();
+      statusSubscription.unsubscribe();
+    };
+  }, [dentalMeasurementsService]);
+
+  const options = useMemo(
+    () => ({
+      labels: Array.from(new Set(measurements.map(item => item.label))).sort(),
+      teeth: Array.from(new Set(measurements.map(item => item.toothId))).sort(),
+      units: Array.from(new Set(measurements.map(item => item.unit))).sort(),
+    }),
+    [measurements]
+  );
+  const visibleMeasurements = useMemo(
+    () => sortDentalMeasurements(filterDentalMeasurements(measurements, filters), sortBy),
+    [filters, measurements, sortBy]
+  );
+
+  const setFilter = (key: keyof DentalMeasurementFilters, value: string) => {
+    setFilters(current => ({ ...current, [key]: value === 'all' ? '' : value }));
+  };
+
+  const getToothLabel = (toothId: string) => {
+    const tooth = getToothIdentityById(toothId);
+    return tooth ? `FDI ${getToothDisplayLabel(tooth, 'FDI')} - ${tooth.label}` : toothId;
+  };
+
+  return (
+    <div
+      className="flex h-full flex-col bg-background"
+      data-cy="dental-measurements-panel"
+    >
+      <div className="border-muted space-y-2 border-b p-3">
+        <div className="flex items-center justify-between gap-2">
+          <div className="text-sm font-semibold">Study Measurements</div>
+          {status !== 'idle' && status !== 'saved' ? (
+            <Badge variant="outline">{status}</Badge>
+          ) : null}
+        </div>
+        <div className="grid grid-cols-2 gap-2">
+          <Select
+            value={filters.label || 'all'}
+            onValueChange={value => setFilter('label', value)}
+          >
+            <SelectTrigger
+              className="h-8 text-xs"
+              data-cy="dental-filter-label"
+            >
+              <SelectValue placeholder="Label" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All labels</SelectItem>
+              {options.labels.map(label => (
+                <SelectItem
+                  key={label}
+                  value={label}
+                >
+                  {label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Select
+            value={filters.toothId || 'all'}
+            onValueChange={value => setFilter('toothId', value)}
+          >
+            <SelectTrigger
+              className="h-8 text-xs"
+              data-cy="dental-filter-tooth"
+            >
+              <SelectValue placeholder="Tooth" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All teeth</SelectItem>
+              {options.teeth.map(toothId => (
+                <SelectItem
+                  key={toothId}
+                  value={toothId}
+                >
+                  {getToothLabel(toothId)}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Select
+            value={filters.unit || 'all'}
+            onValueChange={value => setFilter('unit', value)}
+          >
+            <SelectTrigger
+              className="h-8 text-xs"
+              data-cy="dental-filter-unit"
+            >
+              <SelectValue placeholder="Unit" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All units</SelectItem>
+              {options.units.map(unit => (
+                <SelectItem
+                  key={unit}
+                  value={unit}
+                >
+                  {unit}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Select
+            value={sortBy}
+            onValueChange={value => setSortBy(value as DentalMeasurementSort)}
+          >
+            <SelectTrigger
+              className="h-8 text-xs"
+              data-cy="dental-sort-measurements"
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="createdAt">Newest</SelectItem>
+              <SelectItem value="label">Label</SelectItem>
+              <SelectItem value="toothId">Tooth</SelectItem>
+              <SelectItem value="value">Value</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      <ScrollArea className="min-h-0 flex-1">
+        <div className="space-y-px p-2">
+          {visibleMeasurements.length ? (
+            visibleMeasurements.map(measurement => (
+              <div
+                key={measurement.annotationUID}
+                className="border-muted bg-card flex min-h-[72px] items-start gap-2 rounded border p-2"
+                data-cy="dental-measurement-row"
+              >
+                <div className="min-w-0 flex-1">
+                  <div className="truncate text-sm font-medium">{measurement.label}</div>
+                  <div className="text-primary text-lg font-semibold">
+                    {measurement.value ?? '—'} {measurement.unit}
+                  </div>
+                  <div className="text-muted-foreground truncate text-[11px]">
+                    {getToothLabel(measurement.toothId)}
+                    {measurement.note ? ` | ${measurement.note}` : ''}
+                  </div>
+                </div>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8 flex-shrink-0"
+                  title="Delete measurement"
+                  data-cy="dental-delete-measurement"
+                  onClick={() =>
+                    dentalMeasurementsService.requestDelete(measurement.annotationUID)
+                  }
+                >
+                  <Icons.Delete />
+                </Button>
+              </div>
+            ))
+          ) : (
+            <div
+              className="text-muted-foreground p-6 text-center text-sm"
+              data-cy="dental-measurements-empty"
+            >
+              No dental measurements
+            </div>
+          )}
+        </div>
+      </ScrollArea>
+    </div>
+  );
+}
+
+export default DentalMeasurementsPanel;

--- a/extensions/dental/src/measurements/DentalMeasurementsService.ts
+++ b/extensions/dental/src/measurements/DentalMeasurementsService.ts
@@ -1,0 +1,75 @@
+import { PubSubService } from '@ohif/core';
+
+import { DentalMeasurement } from './dentalMeasurement';
+
+const EVENTS = {
+  MEASUREMENTS_CHANGED: 'event::dental-measurements:changed',
+  STATUS_CHANGED: 'event::dental-measurements:status-changed',
+};
+
+export type DentalMeasurementsStatus = 'idle' | 'loading' | 'saved' | 'unsaved' | 'locked';
+
+export class DentalMeasurementsService extends PubSubService {
+  public static readonly REGISTRATION = {
+    name: 'dentalMeasurementsService',
+    altName: 'DentalMeasurementsService',
+    create: () => new DentalMeasurementsService(),
+  };
+
+  private measurements = new Map<string, DentalMeasurement>();
+  private status: DentalMeasurementsStatus = 'idle';
+  private deleteHandler: ((annotationUID: string) => void) | null = null;
+
+  constructor() {
+    super(EVENTS);
+  }
+
+  getMeasurements(): DentalMeasurement[] {
+    return Array.from(this.measurements.values());
+  }
+
+  setMeasurements(measurements: DentalMeasurement[]): void {
+    this.measurements = new Map(
+      measurements.map(measurement => [measurement.annotationUID, measurement])
+    );
+    this.broadcastMeasurements();
+  }
+
+  upsertMeasurement(measurement: DentalMeasurement): void {
+    this.measurements.set(measurement.annotationUID, measurement);
+    this.broadcastMeasurements();
+  }
+
+  removeMeasurement(annotationUID: string): void {
+    if (this.measurements.delete(annotationUID)) {
+      this.broadcastMeasurements();
+    }
+  }
+
+  getStatus(): DentalMeasurementsStatus {
+    return this.status;
+  }
+
+  setStatus(status: DentalMeasurementsStatus): void {
+    if (status === this.status) {
+      return;
+    }
+
+    this.status = status;
+    this._broadcastEvent(EVENTS.STATUS_CHANGED, { status });
+  }
+
+  setDeleteHandler(handler: ((annotationUID: string) => void) | null): void {
+    this.deleteHandler = handler;
+  }
+
+  requestDelete(annotationUID: string): void {
+    this.deleteHandler?.(annotationUID);
+  }
+
+  private broadcastMeasurements(): void {
+    this._broadcastEvent(EVENTS.MEASUREMENTS_CHANGED, {
+      measurements: this.getMeasurements(),
+    });
+  }
+}

--- a/extensions/dental/src/measurements/dentalMeasurement.test.ts
+++ b/extensions/dental/src/measurements/dentalMeasurement.test.ts
@@ -1,0 +1,56 @@
+import { createDentalMeasurement, updateDentalMeasurement } from './dentalMeasurement';
+import { getDentalMeasurementPreset } from './dentalMeasurementPresets';
+
+describe('dental measurement records', () => {
+  it('keeps the fixed preset label separate from the optional note', () => {
+    const record = createDentalMeasurement({
+      measurement: {
+        uid: 'annotation-1',
+        toolName: 'Length',
+        data: { image: { length: 12.4, unit: 'mm' } },
+      },
+      preset: getDentalMeasurementPreset('pa-length'),
+      toothId: 'permanent-1',
+      note: 'Distal root',
+      createdAt: '2026-06-18T00:00:00.000Z',
+    });
+
+    expect(record).toEqual(
+      expect.objectContaining({
+        annotationUID: 'annotation-1',
+        label: 'PA length',
+        unit: 'mm',
+        value: 12.4,
+        note: 'Distal root',
+      })
+    );
+  });
+
+  it('updates the value for the same annotation record', () => {
+    const record = createDentalMeasurement({
+      measurement: {
+        uid: 'annotation-1',
+        toolName: 'Angle',
+        data: { image: { angle: 31 } },
+      },
+      preset: getDentalMeasurementPreset('canal-angle'),
+      toothId: 'permanent-1',
+      note: '',
+      createdAt: '2026-06-18T00:00:00.000Z',
+    });
+
+    const updated = updateDentalMeasurement(
+      record,
+      {
+        uid: 'annotation-1',
+        toolName: 'Angle',
+        data: { image: { angle: 34.5 } },
+      },
+      '2026-06-18T00:01:00.000Z'
+    );
+
+    expect(updated.value).toBe(34.5);
+    expect(updated.annotationUID).toBe(record.annotationUID);
+    expect(updated.createdAt).toBe(record.createdAt);
+  });
+});

--- a/extensions/dental/src/measurements/dentalMeasurement.ts
+++ b/extensions/dental/src/measurements/dentalMeasurement.ts
@@ -1,0 +1,79 @@
+import {
+  DentalMeasurementPreset,
+  DentalMeasurementPresetId,
+  DentalMeasurementToolName,
+} from './dentalMeasurementPresets';
+
+export type DentalMeasurement = {
+  annotationUID: string;
+  presetId: DentalMeasurementPresetId;
+  label: string;
+  unit: DentalMeasurementPreset['unit'];
+  value: number | null;
+  toothId: string;
+  note: string | null;
+  toolName: DentalMeasurementToolName;
+  referenceStudyUID?: string;
+  referenceSeriesUID?: string;
+  displaySetInstanceUID?: string;
+  viewportId?: string;
+  points?: number[][];
+  createdAt: string;
+  updatedAt: string;
+};
+
+export function getMeasurementValue(measurement: Record<string, any>): number | null {
+  const statistic = Object.values(measurement.data || {}).find(
+    value => value && typeof value === 'object'
+  ) as Record<string, unknown> | undefined;
+  const value = measurement.toolName === 'Angle' ? statistic?.angle : statistic?.length;
+
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+export function createDentalMeasurement({
+  measurement,
+  preset,
+  toothId,
+  note,
+  viewportId,
+  createdAt = new Date().toISOString(),
+}: {
+  measurement: Record<string, any>;
+  preset: DentalMeasurementPreset;
+  toothId: string;
+  note: string;
+  viewportId?: string;
+  createdAt?: string;
+}): DentalMeasurement {
+  return {
+    annotationUID: measurement.uid,
+    presetId: preset.id,
+    label: preset.label,
+    unit: preset.unit,
+    value: getMeasurementValue(measurement),
+    toothId,
+    note: note.trim() || null,
+    toolName: preset.toolName,
+    referenceStudyUID: measurement.referenceStudyUID,
+    referenceSeriesUID: measurement.referenceSeriesUID,
+    displaySetInstanceUID: measurement.displaySetInstanceUID,
+    viewportId,
+    points: measurement.points,
+    createdAt,
+    updatedAt: createdAt,
+  };
+}
+
+export function updateDentalMeasurement(
+  dentalMeasurement: DentalMeasurement,
+  measurement: Record<string, any>,
+  updatedAt = new Date().toISOString()
+): DentalMeasurement {
+  return {
+    ...dentalMeasurement,
+    value: getMeasurementValue(measurement),
+    points: measurement.points || dentalMeasurement.points,
+    updatedAt,
+  };
+}

--- a/extensions/dental/src/measurements/dentalMeasurementExport.test.ts
+++ b/extensions/dental/src/measurements/dentalMeasurementExport.test.ts
@@ -1,0 +1,92 @@
+import {
+  createDentalMeasurementExport,
+  createDentalMeasurementExportFilename,
+} from './dentalMeasurementExport';
+
+describe('Dental Measurement Export', () => {
+  const measurement = {
+    id: 'backend-id-not-exported',
+    annotationUID: 'annotation-1',
+    presetId: 'pa-length',
+    label: 'PA length',
+    unit: 'mm',
+    value: 12.4,
+    toothId: 'permanent-1',
+    note: 'Distal root',
+    toolName: 'Length',
+    viewportId: 'dental-current',
+    displaySetInstanceUID: 'display-set-1',
+    referenceSeriesUID: 'series-1',
+    points: [[1, 2, 3], [4, 5, 6]],
+    createdAt: '2026-06-18T01:00:00.000Z',
+    updatedAt: '2026-06-18T02:00:00.000Z',
+    metadata: {
+      PatientName: 'Not Exported',
+      PatientBirthDate: '19700101',
+    },
+  } as never;
+
+  it('exports minimal identifiers, details, geometry, and timestamps', () => {
+    const exported = createDentalMeasurementExport(
+      {
+        studyInstanceUID: '1.2.3',
+        patientId: 'P-123',
+        exportedAt: '2026-06-18T03:04:05.000Z',
+      },
+      [measurement]
+    );
+
+    expect(exported).toEqual({
+      schemaVersion: 1,
+      studyInstanceUID: '1.2.3',
+      patientId: 'P-123',
+      exportedAt: '2026-06-18T03:04:05.000Z',
+      measurements: [
+        {
+          annotationUID: 'annotation-1',
+          presetId: 'pa-length',
+          label: 'PA length',
+          unit: 'mm',
+          value: 12.4,
+          toothId: 'permanent-1',
+          note: 'Distal root',
+          toolName: 'Length',
+          viewportId: 'dental-current',
+          displaySetInstanceUID: 'display-set-1',
+          referenceSeriesUID: 'series-1',
+          geometry: {
+            points: [[1, 2, 3], [4, 5, 6]],
+          },
+          createdAt: '2026-06-18T01:00:00.000Z',
+          updatedAt: '2026-06-18T02:00:00.000Z',
+        },
+      ],
+    });
+  });
+
+  it('excludes patient name, date of birth, backend ids, and metadata', () => {
+    const json = JSON.stringify(
+      createDentalMeasurementExport(
+        {
+          studyInstanceUID: '1.2.3',
+          patientId: null,
+          exportedAt: '2026-06-18T03:04:05.000Z',
+        },
+        [measurement]
+      )
+    );
+
+    expect(json).not.toContain('PatientName');
+    expect(json).not.toContain('PatientBirthDate');
+    expect(json).not.toContain('Not Exported');
+    expect(json).not.toContain('backend-id-not-exported');
+    expect(json).not.toContain('"metadata"');
+    expect(json).not.toContain('"patientId"');
+  });
+
+  it('creates the required UTC timestamped filename', () => {
+    expect(
+      createDentalMeasurementExportFilename('1.2.840.10008', new Date('2026-06-18T03:04:05Z'))
+    ).toBe('dental-measurements-1.2.840.10008-20260618-030405.json');
+  });
+});

--- a/extensions/dental/src/measurements/dentalMeasurementExport.ts
+++ b/extensions/dental/src/measurements/dentalMeasurementExport.ts
@@ -1,0 +1,81 @@
+import { DentalMeasurement } from './dentalMeasurement';
+
+export type DentalMeasurementExport = {
+  schemaVersion: 1;
+  studyInstanceUID: string;
+  patientId?: string;
+  exportedAt: string;
+  measurements: Array<{
+    annotationUID: string;
+    presetId: DentalMeasurement['presetId'];
+    label: string;
+    unit: DentalMeasurement['unit'];
+    value: number | null;
+    toothId: string;
+    note: string | null;
+    toolName: DentalMeasurement['toolName'];
+    viewportId?: string;
+    displaySetInstanceUID?: string;
+    referenceSeriesUID?: string;
+    geometry?: {
+      points: number[][];
+    };
+    createdAt: string;
+    updatedAt: string;
+  }>;
+};
+
+type DentalMeasurementExportContext = {
+  studyInstanceUID: string;
+  patientId?: string | null;
+  exportedAt?: string;
+};
+
+export function createDentalMeasurementExport(
+  context: DentalMeasurementExportContext,
+  measurements: DentalMeasurement[]
+): DentalMeasurementExport {
+  return {
+    schemaVersion: 1,
+    studyInstanceUID: context.studyInstanceUID,
+    ...(context.patientId ? { patientId: context.patientId } : {}),
+    exportedAt: context.exportedAt || new Date().toISOString(),
+    measurements: measurements.map(measurement => ({
+      annotationUID: measurement.annotationUID,
+      presetId: measurement.presetId,
+      label: measurement.label,
+      unit: measurement.unit,
+      value: measurement.value,
+      toothId: measurement.toothId,
+      note: measurement.note,
+      toolName: measurement.toolName,
+      ...(measurement.viewportId ? { viewportId: measurement.viewportId } : {}),
+      ...(measurement.displaySetInstanceUID
+        ? { displaySetInstanceUID: measurement.displaySetInstanceUID }
+        : {}),
+      ...(measurement.referenceSeriesUID
+        ? { referenceSeriesUID: measurement.referenceSeriesUID }
+        : {}),
+      ...(measurement.points ? { geometry: { points: measurement.points } } : {}),
+      createdAt: measurement.createdAt,
+      updatedAt: measurement.updatedAt,
+    })),
+  };
+}
+
+export function createDentalMeasurementExportFilename(
+  studyInstanceUID: string,
+  exportedAt = new Date()
+): string {
+  const timestamp = [
+    exportedAt.getUTCFullYear(),
+    String(exportedAt.getUTCMonth() + 1).padStart(2, '0'),
+    String(exportedAt.getUTCDate()).padStart(2, '0'),
+    '-',
+    String(exportedAt.getUTCHours()).padStart(2, '0'),
+    String(exportedAt.getUTCMinutes()).padStart(2, '0'),
+    String(exportedAt.getUTCSeconds()).padStart(2, '0'),
+  ].join('');
+
+  return `dental-measurements-${studyInstanceUID}-${timestamp}.json`;
+}

--- a/extensions/dental/src/measurements/dentalMeasurementList.test.ts
+++ b/extensions/dental/src/measurements/dentalMeasurementList.test.ts
@@ -1,0 +1,50 @@
+import { DentalMeasurement } from './dentalMeasurement';
+import { filterDentalMeasurements, sortDentalMeasurements } from './dentalMeasurementList';
+
+const measurements = [
+  {
+    annotationUID: '2',
+    label: 'Canal angle',
+    unit: '°',
+    value: 30,
+    toothId: 'permanent-2',
+    createdAt: '2026-06-18T02:00:00.000Z',
+  },
+  {
+    annotationUID: '1',
+    label: 'PA length',
+    unit: 'mm',
+    value: 12,
+    toothId: 'permanent-1',
+    createdAt: '2026-06-18T01:00:00.000Z',
+  },
+] as DentalMeasurement[];
+
+describe('dental measurement list', () => {
+  it('combines label, tooth, and unit filters', () => {
+    expect(
+      filterDentalMeasurements(measurements, {
+        label: 'PA length',
+        toothId: 'permanent-1',
+        unit: 'mm',
+      })
+    ).toEqual([measurements[1]]);
+  });
+
+  it('sorts newest measurements first by default field', () => {
+    expect(sortDentalMeasurements(measurements, 'createdAt').map(item => item.annotationUID)).toEqual([
+      '2',
+      '1',
+    ]);
+  });
+
+  it.each([
+    ['label', ['2', '1']],
+    ['toothId', ['1', '2']],
+    ['value', ['1', '2']],
+  ])('sorts by %s', (sortBy, expected) => {
+    expect(sortDentalMeasurements(measurements, sortBy as never).map(item => item.annotationUID)).toEqual(
+      expected
+    );
+  });
+});

--- a/extensions/dental/src/measurements/dentalMeasurementList.ts
+++ b/extensions/dental/src/measurements/dentalMeasurementList.ts
@@ -1,0 +1,39 @@
+import { DentalMeasurement } from './dentalMeasurement';
+
+export type DentalMeasurementSort = 'createdAt' | 'label' | 'toothId' | 'value';
+
+export type DentalMeasurementFilters = {
+  label: string;
+  toothId: string;
+  unit: string;
+};
+
+export function filterDentalMeasurements(
+  measurements: DentalMeasurement[],
+  filters: DentalMeasurementFilters
+): DentalMeasurement[] {
+  return measurements.filter(measurement => {
+    return (
+      (!filters.label || measurement.label === filters.label) &&
+      (!filters.toothId || measurement.toothId === filters.toothId) &&
+      (!filters.unit || measurement.unit === filters.unit)
+    );
+  });
+}
+
+export function sortDentalMeasurements(
+  measurements: DentalMeasurement[],
+  sortBy: DentalMeasurementSort
+): DentalMeasurement[] {
+  return [...measurements].sort((left, right) => {
+    if (sortBy === 'createdAt') {
+      return right.createdAt.localeCompare(left.createdAt);
+    }
+
+    if (sortBy === 'value') {
+      return (left.value ?? Number.NEGATIVE_INFINITY) - (right.value ?? Number.NEGATIVE_INFINITY);
+    }
+
+    return String(left[sortBy]).localeCompare(String(right[sortBy]));
+  });
+}

--- a/extensions/dental/src/measurements/dentalMeasurementPresets.test.ts
+++ b/extensions/dental/src/measurements/dentalMeasurementPresets.test.ts
@@ -1,0 +1,36 @@
+import {
+  DENTAL_MEASUREMENT_PRESETS,
+  getDentalMeasurementPreset,
+} from './dentalMeasurementPresets';
+
+describe('dental measurement presets', () => {
+  it.each([
+    ['pa-length', 'PA length'],
+    ['crown-width', 'Crown width'],
+    ['root-length', 'Root length'],
+  ])('maps %s to the Length tool', (presetId, label) => {
+    expect(getDentalMeasurementPreset(presetId as never)).toEqual(
+      expect.objectContaining({
+        label,
+        toolName: 'Length',
+        unit: 'mm',
+      })
+    );
+  });
+
+  it('maps Canal angle to the Angle tool', () => {
+    expect(getDentalMeasurementPreset('canal-angle')).toEqual(
+      expect.objectContaining({
+        label: 'Canal angle',
+        toolName: 'Angle',
+        unit: '°',
+      })
+    );
+  });
+
+  it('defines unique preset ids', () => {
+    const ids = DENTAL_MEASUREMENT_PRESETS.map(preset => preset.id);
+
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});

--- a/extensions/dental/src/measurements/dentalMeasurementPresets.ts
+++ b/extensions/dental/src/measurements/dentalMeasurementPresets.ts
@@ -1,0 +1,53 @@
+export type DentalMeasurementPresetId =
+  | 'pa-length'
+  | 'canal-angle'
+  | 'crown-width'
+  | 'root-length';
+
+export type DentalMeasurementToolName = 'Length' | 'Angle';
+
+export type DentalMeasurementPreset = {
+  id: DentalMeasurementPresetId;
+  label: string;
+  unit: 'mm' | '°';
+  toolName: DentalMeasurementToolName;
+};
+
+export const DENTAL_MEASUREMENT_PRESETS: readonly DentalMeasurementPreset[] = [
+  {
+    id: 'pa-length',
+    label: 'PA length',
+    unit: 'mm',
+    toolName: 'Length',
+  },
+  {
+    id: 'canal-angle',
+    label: 'Canal angle',
+    unit: '°',
+    toolName: 'Angle',
+  },
+  {
+    id: 'crown-width',
+    label: 'Crown width',
+    unit: 'mm',
+    toolName: 'Length',
+  },
+  {
+    id: 'root-length',
+    label: 'Root length',
+    unit: 'mm',
+    toolName: 'Length',
+  },
+];
+
+export function getDentalMeasurementPreset(
+  presetId: DentalMeasurementPresetId
+): DentalMeasurementPreset {
+  const preset = DENTAL_MEASUREMENT_PRESETS.find(candidate => candidate.id === presetId);
+
+  if (!preset) {
+    throw new Error(`Unknown dental measurement preset: ${presetId}`);
+  }
+
+  return preset;
+}

--- a/extensions/dental/src/measurements/dentalMeasurementsApi.test.ts
+++ b/extensions/dental/src/measurements/dentalMeasurementsApi.test.ts
@@ -1,0 +1,77 @@
+import {
+  DentalMeasurementsAuthError,
+  createDentalMeasurementsApi,
+} from './dentalMeasurementsApi';
+
+function response(status: number, body: unknown = {}) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: jest.fn().mockResolvedValue(body),
+  } as unknown as Response;
+}
+
+describe('createDentalMeasurementsApi', () => {
+  const measurement = {
+    annotationUID: 'annotation-1',
+    presetId: 'pa-length',
+    label: 'PA length',
+    unit: 'mm',
+    value: 12,
+    toothId: 'permanent-1',
+    note: null,
+    toolName: 'Length',
+    createdAt: '2026-06-18T00:00:00.000Z',
+    updatedAt: '2026-06-18T00:00:00.000Z',
+  } as const;
+
+  it('loads measurements with bearer auth', async () => {
+    const fetcher = jest.fn().mockResolvedValue(response(200, { measurements: [measurement] }));
+    const api = createDentalMeasurementsApi({
+      baseUrl: 'http://localhost:4007/api/dental',
+      authToken: 'token',
+      fetcher,
+    });
+
+    await expect(api.load('study/1')).resolves.toEqual([measurement]);
+    expect(fetcher).toHaveBeenCalledWith(
+      'http://localhost:4007/api/dental/measurements/study%2F1',
+      expect.objectContaining({
+        headers: expect.objectContaining({ authorization: 'Bearer token' }),
+      })
+    );
+  });
+
+  it('upserts and deletes by annotation UID', async () => {
+    const fetcher = jest.fn().mockResolvedValue(response(200));
+    const api = createDentalMeasurementsApi({
+      baseUrl: 'http://localhost:4007/api/dental',
+      authToken: 'token',
+      fetcher,
+    });
+
+    await api.upsert('study-1', measurement as never);
+    await api.remove('study-1', 'annotation/1');
+
+    expect(fetcher).toHaveBeenNthCalledWith(
+      1,
+      'http://localhost:4007/api/dental/measurements/study-1',
+      expect.objectContaining({ method: 'POST' })
+    );
+    expect(fetcher).toHaveBeenNthCalledWith(
+      2,
+      'http://localhost:4007/api/dental/measurements/study-1/annotation%2F1',
+      expect.objectContaining({ method: 'DELETE' })
+    );
+  });
+
+  it('maps auth failures to locked errors', async () => {
+    const api = createDentalMeasurementsApi({
+      baseUrl: 'http://localhost:4007/api/dental',
+      authToken: 'token',
+      fetcher: jest.fn().mockResolvedValue(response(403)),
+    });
+
+    await expect(api.load('study-1')).rejects.toBeInstanceOf(DentalMeasurementsAuthError);
+  });
+});

--- a/extensions/dental/src/measurements/dentalMeasurementsApi.ts
+++ b/extensions/dental/src/measurements/dentalMeasurementsApi.ts
@@ -1,0 +1,89 @@
+import { DentalMeasurement } from './dentalMeasurement';
+
+export class DentalMeasurementsAuthError extends Error {
+  status: number;
+
+  constructor(status: number) {
+    super('Dental measurements auth failed');
+    this.name = 'DentalMeasurementsAuthError';
+    this.status = status;
+  }
+}
+
+export class DentalMeasurementsUnavailableError extends Error {
+  constructor() {
+    super('Dental measurements API unavailable');
+    this.name = 'DentalMeasurementsUnavailableError';
+  }
+}
+
+type DentalMeasurementsApiConfig = {
+  baseUrl: string;
+  authToken: string;
+  fetcher?: typeof fetch;
+};
+
+function measurementsUrl(baseUrl: string, studyInstanceUID: string): string {
+  return `${baseUrl.replace(/\/+$/, '')}/measurements/${encodeURIComponent(studyInstanceUID)}`;
+}
+
+function requestJson(url: string, options: RequestInit, fetcher: typeof fetch): Promise<unknown> {
+  return fetcher(url, options)
+    .catch(() => {
+      throw new DentalMeasurementsUnavailableError();
+    })
+    .then(response => {
+      if (response.status === 401 || response.status === 403) {
+        throw new DentalMeasurementsAuthError(response.status);
+      }
+
+      if (!response.ok) {
+        throw new DentalMeasurementsUnavailableError();
+      }
+
+      return response.json();
+    });
+}
+
+export function createDentalMeasurementsApi({
+  baseUrl,
+  authToken,
+  fetcher = fetch,
+}: DentalMeasurementsApiConfig) {
+  const headers = {
+    authorization: `Bearer ${authToken}`,
+    'content-type': 'application/json',
+  };
+
+  return {
+    load(studyInstanceUID: string): Promise<DentalMeasurement[]> {
+      return requestJson(
+        measurementsUrl(baseUrl, studyInstanceUID),
+        { method: 'GET', headers },
+        fetcher
+      ).then(
+        payload => (payload as { measurements?: DentalMeasurement[] }).measurements || []
+      );
+    },
+
+    upsert(studyInstanceUID: string, measurement: DentalMeasurement): Promise<void> {
+      return requestJson(
+        measurementsUrl(baseUrl, studyInstanceUID),
+        {
+          method: 'POST',
+          headers,
+          body: JSON.stringify(measurement),
+        },
+        fetcher
+      ).then(() => undefined);
+    },
+
+    remove(studyInstanceUID: string, annotationUID: string): Promise<void> {
+      return requestJson(
+        `${measurementsUrl(baseUrl, studyInstanceUID)}/${encodeURIComponent(annotationUID)}`,
+        { method: 'DELETE', headers },
+        fetcher
+      ).then(() => undefined);
+    },
+  };
+}

--- a/extensions/dental/src/measurements/useDentalMeasurements.test.ts
+++ b/extensions/dental/src/measurements/useDentalMeasurements.test.ts
@@ -1,26 +1,49 @@
 import { act, renderHook } from '@testing-library/react';
 
 import { DEFAULT_DENTAL_PREFERENCES } from '../preferences/dentalPreferences';
+import { DentalMeasurementsService } from './DentalMeasurementsService';
 import { useDentalMeasurements } from './useDentalMeasurements';
 
 function createHarness() {
+  const originalFetch = global.fetch;
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: jest.fn().mockResolvedValue({ measurements: [] }),
+  });
   const subscribers = new Map<string, (event: any) => void>();
   const measurementService = {
     EVENTS: {
       MEASUREMENT_ADDED: 'measurementAdded',
       MEASUREMENT_UPDATED: 'measurementUpdated',
+      MEASUREMENT_REMOVED: 'measurementRemoved',
     },
     subscribe: jest.fn((event, callback) => {
       subscribers.set(event, callback);
       return { unsubscribe: jest.fn() };
     }),
+    getMeasurement: jest.fn(),
     update: jest.fn(),
   };
   const commandsManager = {
     runCommand: jest.fn(),
   };
+  const dentalMeasurementsService = new DentalMeasurementsService();
   const servicesManager = {
     services: {
+      dentalMeasurementsService,
+      displaySetService: {
+        EVENTS: {
+          DISPLAY_SETS_ADDED: 'displaySetsAdded',
+          DISPLAY_SETS_CHANGED: 'displaySetsChanged',
+        },
+        getActiveDisplaySets: jest.fn(() => [
+          {
+            StudyInstanceUID: 'study-1',
+          },
+        ]),
+        subscribe: jest.fn(() => ({ unsubscribe: jest.fn() })),
+      },
       measurementService,
       viewportGridService: {
         getState: jest.fn(() => ({ activeViewportId: 'dental-current' })),
@@ -29,6 +52,12 @@ function createHarness() {
   };
   const hook = renderHook(() =>
     useDentalMeasurements({
+      appConfig: {
+        dental: {
+          measurementsApiUrl: 'http://localhost:4007/api/dental',
+          measurementsAuthToken: 'token',
+        },
+      } as AppTypes.Config,
       commandsManager: commandsManager as never,
       servicesManager: servicesManager as never,
       preferences: DEFAULT_DENTAL_PREFERENCES,
@@ -38,8 +67,12 @@ function createHarness() {
   return {
     ...hook,
     commandsManager,
+    dentalMeasurementsService,
     measurementService,
     emit: (event: string, payload: any) => act(() => subscribers.get(event)?.(payload)),
+    restoreFetch: () => {
+      global.fetch = originalFetch;
+    },
   };
 }
 
@@ -70,8 +103,6 @@ describe('useDentalMeasurements', () => {
     expect(harness.commandsManager.runCommand).toHaveBeenCalledWith('setToolActive', {
       toolName: 'Length',
     });
-    expect(harness.result.current.measurements).toEqual([]);
-
     harness.emit('measurementAdded', {
       measurement: {
         uid: 'annotation-1',
@@ -88,7 +119,7 @@ describe('useDentalMeasurements', () => {
       }),
       true
     );
-    expect(harness.result.current.measurements[0]).toEqual(
+    expect(harness.dentalMeasurementsService.getMeasurements()[0]).toEqual(
       expect.objectContaining({
         annotationUID: 'annotation-1',
         label: 'PA length',
@@ -105,7 +136,9 @@ describe('useDentalMeasurements', () => {
       },
     });
 
-    expect(harness.result.current.measurements).toHaveLength(1);
+    expect(harness.dentalMeasurementsService.getMeasurements()).toHaveLength(1);
+    harness.unmount();
+    harness.restoreFetch();
   });
 
   it('updates an existing record when the annotation value changes', () => {
@@ -127,6 +160,37 @@ describe('useDentalMeasurements', () => {
       },
     });
 
-    expect(harness.result.current.measurements[0].value).toBe(27.5);
+    expect(harness.dentalMeasurementsService.getMeasurements()[0].value).toBe(27.5);
+    harness.unmount();
+    harness.restoreFetch();
+  });
+
+  it('keeps panel state synchronized when a measurement is deleted', () => {
+    const harness = createHarness();
+
+    act(() => harness.result.current.armPreset('root-length'));
+    harness.emit('measurementAdded', {
+      measurement: {
+        uid: 'annotation-1',
+        toolName: 'Length',
+        data: { image: { length: 19 } },
+      },
+    });
+    harness.measurementService.getMeasurement.mockReturnValue({ uid: 'annotation-1' });
+
+    act(() => harness.dentalMeasurementsService.requestDelete('annotation-1'));
+
+    expect(harness.commandsManager.runCommand).toHaveBeenCalledWith('removeMeasurement', {
+      uid: 'annotation-1',
+    });
+    expect(harness.dentalMeasurementsService.getMeasurements()).toHaveLength(1);
+
+    harness.emit('measurementRemoved', {
+      measurement: { uid: 'annotation-1' },
+    });
+
+    expect(harness.dentalMeasurementsService.getMeasurements()).toEqual([]);
+    harness.unmount();
+    harness.restoreFetch();
   });
 });

--- a/extensions/dental/src/measurements/useDentalMeasurements.test.ts
+++ b/extensions/dental/src/measurements/useDentalMeasurements.test.ts
@@ -1,0 +1,132 @@
+import { act, renderHook } from '@testing-library/react';
+
+import { DEFAULT_DENTAL_PREFERENCES } from '../preferences/dentalPreferences';
+import { useDentalMeasurements } from './useDentalMeasurements';
+
+function createHarness() {
+  const subscribers = new Map<string, (event: any) => void>();
+  const measurementService = {
+    EVENTS: {
+      MEASUREMENT_ADDED: 'measurementAdded',
+      MEASUREMENT_UPDATED: 'measurementUpdated',
+    },
+    subscribe: jest.fn((event, callback) => {
+      subscribers.set(event, callback);
+      return { unsubscribe: jest.fn() };
+    }),
+    update: jest.fn(),
+  };
+  const commandsManager = {
+    runCommand: jest.fn(),
+  };
+  const servicesManager = {
+    services: {
+      measurementService,
+      viewportGridService: {
+        getState: jest.fn(() => ({ activeViewportId: 'dental-current' })),
+      },
+    },
+  };
+  const hook = renderHook(() =>
+    useDentalMeasurements({
+      commandsManager: commandsManager as never,
+      servicesManager: servicesManager as never,
+      preferences: DEFAULT_DENTAL_PREFERENCES,
+    })
+  );
+
+  return {
+    ...hook,
+    commandsManager,
+    measurementService,
+    emit: (event: string, payload: any) => act(() => subscribers.get(event)?.(payload)),
+  };
+}
+
+describe('useDentalMeasurements', () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation((message, ...args) => {
+      const text = [message, ...args].join(' ');
+
+      if (text.includes('ReactDOMTestUtils.act') && text.includes('deprecated')) {
+        return;
+      }
+
+      throw new Error(text);
+    });
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('arms the mapped OHIF tool and labels only the next completed annotation', () => {
+    const harness = createHarness();
+
+    act(() => harness.result.current.armPreset('pa-length', 'Distal root'));
+
+    expect(harness.commandsManager.runCommand).toHaveBeenCalledWith('setToolActive', {
+      toolName: 'Length',
+    });
+    expect(harness.result.current.measurements).toEqual([]);
+
+    harness.emit('measurementAdded', {
+      measurement: {
+        uid: 'annotation-1',
+        toolName: 'Length',
+        data: { image: { length: 18.25 } },
+      },
+    });
+
+    expect(harness.measurementService.update).toHaveBeenCalledWith(
+      'annotation-1',
+      expect.objectContaining({
+        label: 'PA length',
+        unit: 'mm',
+      }),
+      true
+    );
+    expect(harness.result.current.measurements[0]).toEqual(
+      expect.objectContaining({
+        annotationUID: 'annotation-1',
+        label: 'PA length',
+        value: 18.25,
+        note: 'Distal root',
+      })
+    );
+
+    harness.emit('measurementAdded', {
+      measurement: {
+        uid: 'annotation-2',
+        toolName: 'Length',
+        data: { image: { length: 20 } },
+      },
+    });
+
+    expect(harness.result.current.measurements).toHaveLength(1);
+  });
+
+  it('updates an existing record when the annotation value changes', () => {
+    const harness = createHarness();
+
+    act(() => harness.result.current.armPreset('canal-angle'));
+    harness.emit('measurementAdded', {
+      measurement: {
+        uid: 'annotation-1',
+        toolName: 'Angle',
+        data: { image: { angle: 22 } },
+      },
+    });
+    harness.emit('measurementUpdated', {
+      measurement: {
+        uid: 'annotation-1',
+        toolName: 'Angle',
+        data: { image: { angle: 27.5 } },
+      },
+    });
+
+    expect(harness.result.current.measurements[0].value).toBe(27.5);
+  });
+});

--- a/extensions/dental/src/measurements/useDentalMeasurements.ts
+++ b/extensions/dental/src/measurements/useDentalMeasurements.ts
@@ -1,0 +1,122 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { DentalPreferences } from '../preferences/dentalPreferences';
+import {
+  createDentalMeasurement,
+  DentalMeasurement,
+  updateDentalMeasurement,
+} from './dentalMeasurement';
+import {
+  DentalMeasurementPresetId,
+  getDentalMeasurementPreset,
+} from './dentalMeasurementPresets';
+
+type PendingMeasurement = {
+  presetId: DentalMeasurementPresetId;
+  toothId: string;
+  note: string;
+};
+
+type UseDentalMeasurementsOptions = {
+  commandsManager: AppTypes.CommandsManager;
+  servicesManager: AppTypes.ServicesManager;
+  preferences: DentalPreferences;
+};
+
+export function useDentalMeasurements({
+  commandsManager,
+  servicesManager,
+  preferences,
+}: UseDentalMeasurementsOptions) {
+  const { measurementService, viewportGridService } = servicesManager.services;
+  const pendingMeasurementRef = useRef<PendingMeasurement | null>(null);
+  const measurementsRef = useRef(new Map<string, DentalMeasurement>());
+  const [measurements, setMeasurements] = useState<DentalMeasurement[]>([]);
+
+  const publishMeasurements = useCallback(() => {
+    setMeasurements(Array.from(measurementsRef.current.values()));
+  }, []);
+
+  const armPreset = useCallback(
+    (presetId: DentalMeasurementPresetId, note = '') => {
+      const preset = getDentalMeasurementPreset(presetId);
+
+      pendingMeasurementRef.current = {
+        presetId,
+        toothId: preferences.selectedToothId,
+        note,
+      };
+      commandsManager.runCommand('setToolActive', {
+        toolName: preset.toolName,
+      });
+    },
+    [commandsManager, preferences.selectedToothId]
+  );
+
+  useEffect(() => {
+    const addedSubscription = measurementService.subscribe(
+      measurementService.EVENTS.MEASUREMENT_ADDED,
+      ({ measurement }) => {
+        const pendingMeasurement = pendingMeasurementRef.current;
+
+        if (!pendingMeasurement) {
+          return;
+        }
+
+        const preset = getDentalMeasurementPreset(pendingMeasurement.presetId);
+        if (measurement.toolName !== preset.toolName) {
+          return;
+        }
+
+        pendingMeasurementRef.current = null;
+        const { activeViewportId } = viewportGridService.getState();
+        const dentalMeasurement = createDentalMeasurement({
+          measurement,
+          preset,
+          toothId: pendingMeasurement.toothId,
+          note: pendingMeasurement.note,
+          viewportId: activeViewportId,
+        });
+
+        measurementsRef.current.set(measurement.uid, dentalMeasurement);
+        publishMeasurements();
+        measurementService.update(
+          measurement.uid,
+          {
+            ...measurement,
+            label: preset.label,
+            unit: preset.unit,
+          },
+          true
+        );
+      }
+    );
+
+    const updatedSubscription = measurementService.subscribe(
+      measurementService.EVENTS.MEASUREMENT_UPDATED,
+      ({ measurement }) => {
+        const dentalMeasurement = measurementsRef.current.get(measurement.uid);
+
+        if (!dentalMeasurement) {
+          return;
+        }
+
+        measurementsRef.current.set(
+          measurement.uid,
+          updateDentalMeasurement(dentalMeasurement, measurement)
+        );
+        publishMeasurements();
+      }
+    );
+
+    return () => {
+      addedSubscription.unsubscribe();
+      updatedSubscription.unsubscribe();
+    };
+  }, [measurementService, publishMeasurements, viewportGridService]);
+
+  return {
+    armPreset,
+    measurements,
+  };
+}

--- a/extensions/dental/src/measurements/useDentalMeasurements.ts
+++ b/extensions/dental/src/measurements/useDentalMeasurements.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 
 import { DentalPreferences } from '../preferences/dentalPreferences';
 import {
@@ -10,6 +10,11 @@ import {
   DentalMeasurementPresetId,
   getDentalMeasurementPreset,
 } from './dentalMeasurementPresets';
+import { DentalMeasurementsService } from './DentalMeasurementsService';
+import {
+  DentalMeasurementsAuthError,
+  createDentalMeasurementsApi,
+} from './dentalMeasurementsApi';
 
 type PendingMeasurement = {
   presetId: DentalMeasurementPresetId;
@@ -18,24 +23,98 @@ type PendingMeasurement = {
 };
 
 type UseDentalMeasurementsOptions = {
+  appConfig: AppTypes.Config;
   commandsManager: AppTypes.CommandsManager;
   servicesManager: AppTypes.ServicesManager;
   preferences: DentalPreferences;
 };
 
+function getStudyInstanceUID(displaySetService): string | undefined {
+  const displaySet = displaySetService.getActiveDisplaySets?.()?.[0];
+  const instance = displaySet?.instances?.[0] || displaySet?.instance;
+
+  return displaySet?.StudyInstanceUID || instance?.StudyInstanceUID;
+}
+
 export function useDentalMeasurements({
+  appConfig,
   commandsManager,
   servicesManager,
   preferences,
 }: UseDentalMeasurementsOptions) {
-  const { measurementService, viewportGridService } = servicesManager.services;
+  const {
+    dentalMeasurementsService,
+    displaySetService,
+    measurementService,
+    viewportGridService,
+  } = servicesManager.services as AppTypes.ServicesManager['services'] & {
+    dentalMeasurementsService: DentalMeasurementsService;
+  };
   const pendingMeasurementRef = useRef<PendingMeasurement | null>(null);
-  const measurementsRef = useRef(new Map<string, DentalMeasurement>());
-  const [measurements, setMeasurements] = useState<DentalMeasurement[]>([]);
+  const studyInstanceUIDRef = useRef<string | undefined>();
+  const lockedRef = useRef(false);
+  const saveTimersRef = useRef(new Map<string, ReturnType<typeof window.setTimeout>>());
+  const dentalConfig = (
+    appConfig as AppTypes.Config & { dental?: Record<string, string> }
+  )?.dental;
+  const api = useMemo(
+    () =>
+      createDentalMeasurementsApi({
+        baseUrl:
+          dentalConfig?.measurementsApiUrl ||
+          dentalConfig?.backendUrl ||
+          'http://localhost:4007/api/dental',
+        authToken:
+          dentalConfig?.measurementsAuthToken ||
+          dentalConfig?.backendAuthToken ||
+          'dev-dental-token',
+      }),
+    [
+      dentalConfig?.backendAuthToken,
+      dentalConfig?.backendUrl,
+      dentalConfig?.measurementsApiUrl,
+      dentalConfig?.measurementsAuthToken,
+    ]
+  );
 
-  const publishMeasurements = useCallback(() => {
-    setMeasurements(Array.from(measurementsRef.current.values()));
-  }, []);
+  const markApiError = useCallback(
+    (error: unknown) => {
+      if (error instanceof DentalMeasurementsAuthError) {
+        lockedRef.current = true;
+        dentalMeasurementsService.setStatus('locked');
+        return;
+      }
+
+      dentalMeasurementsService.setStatus('unsaved');
+    },
+    [dentalMeasurementsService]
+  );
+
+  const persistMeasurement = useCallback(
+    (measurement: DentalMeasurement) => {
+      const studyInstanceUID = studyInstanceUIDRef.current;
+
+      if (!studyInstanceUID || lockedRef.current) {
+        return;
+      }
+
+      const existingTimer = saveTimersRef.current.get(measurement.annotationUID);
+      if (existingTimer) {
+        window.clearTimeout(existingTimer);
+      }
+
+      dentalMeasurementsService.setStatus('unsaved');
+      const timer = window.setTimeout(() => {
+        api
+          .upsert(studyInstanceUID, measurement)
+          .then(() => dentalMeasurementsService.setStatus('saved'))
+          .catch(markApiError);
+        saveTimersRef.current.delete(measurement.annotationUID);
+      }, 300);
+      saveTimersRef.current.set(measurement.annotationUID, timer);
+    },
+    [api, dentalMeasurementsService, markApiError]
+  );
 
   const armPreset = useCallback(
     (presetId: DentalMeasurementPresetId, note = '') => {
@@ -52,6 +131,44 @@ export function useDentalMeasurements({
     },
     [commandsManager, preferences.selectedToothId]
   );
+
+  useEffect(() => {
+    const loadMeasurements = () => {
+      const studyInstanceUID = getStudyInstanceUID(displaySetService);
+
+      if (!studyInstanceUID || studyInstanceUID === studyInstanceUIDRef.current || lockedRef.current) {
+        return;
+      }
+
+      studyInstanceUIDRef.current = studyInstanceUID;
+      dentalMeasurementsService.setMeasurements([]);
+      dentalMeasurementsService.setStatus('loading');
+      api
+        .load(studyInstanceUID)
+        .then(measurements => {
+          dentalMeasurementsService.setMeasurements([
+            ...measurements,
+            ...dentalMeasurementsService.getMeasurements(),
+          ]);
+          dentalMeasurementsService.setStatus('saved');
+        })
+        .catch(markApiError);
+    };
+
+    loadMeasurements();
+    const subscriptions = [
+      displaySetService.subscribe?.(
+        displaySetService.EVENTS.DISPLAY_SETS_ADDED,
+        loadMeasurements
+      ),
+      displaySetService.subscribe?.(
+        displaySetService.EVENTS.DISPLAY_SETS_CHANGED,
+        loadMeasurements
+      ),
+    ].filter(Boolean);
+
+    return () => subscriptions.forEach(subscription => subscription.unsubscribe());
+  }, [api, dentalMeasurementsService, displaySetService, markApiError]);
 
   useEffect(() => {
     const addedSubscription = measurementService.subscribe(
@@ -78,8 +195,8 @@ export function useDentalMeasurements({
           viewportId: activeViewportId,
         });
 
-        measurementsRef.current.set(measurement.uid, dentalMeasurement);
-        publishMeasurements();
+        dentalMeasurementsService.upsertMeasurement(dentalMeasurement);
+        persistMeasurement(dentalMeasurement);
         measurementService.update(
           measurement.uid,
           {
@@ -95,28 +212,70 @@ export function useDentalMeasurements({
     const updatedSubscription = measurementService.subscribe(
       measurementService.EVENTS.MEASUREMENT_UPDATED,
       ({ measurement }) => {
-        const dentalMeasurement = measurementsRef.current.get(measurement.uid);
+        const dentalMeasurement = dentalMeasurementsService
+          .getMeasurements()
+          .find(candidate => candidate.annotationUID === measurement.uid);
 
         if (!dentalMeasurement) {
           return;
         }
 
-        measurementsRef.current.set(
-          measurement.uid,
-          updateDentalMeasurement(dentalMeasurement, measurement)
-        );
-        publishMeasurements();
+        const updatedMeasurement = updateDentalMeasurement(dentalMeasurement, measurement);
+        dentalMeasurementsService.upsertMeasurement(updatedMeasurement);
+        persistMeasurement(updatedMeasurement);
+      }
+    );
+    const removedSubscription = measurementService.subscribe(
+      measurementService.EVENTS.MEASUREMENT_REMOVED,
+      ({ measurement }) => {
+        const annotationUID = measurement?.uid;
+
+        if (!annotationUID) {
+          return;
+        }
+
+        dentalMeasurementsService.removeMeasurement(annotationUID);
+        const studyInstanceUID = studyInstanceUIDRef.current;
+        if (studyInstanceUID && !lockedRef.current) {
+          api.remove(studyInstanceUID, annotationUID).catch(markApiError);
+        }
       }
     );
 
     return () => {
       addedSubscription.unsubscribe();
       updatedSubscription.unsubscribe();
+      removedSubscription.unsubscribe();
     };
-  }, [measurementService, publishMeasurements, viewportGridService]);
+  }, [
+    api,
+    dentalMeasurementsService,
+    markApiError,
+    measurementService,
+    persistMeasurement,
+    viewportGridService,
+  ]);
 
-  return {
-    armPreset,
-    measurements,
-  };
+  useEffect(() => {
+    dentalMeasurementsService.setDeleteHandler(annotationUID => {
+      if (measurementService.getMeasurement(annotationUID)) {
+        commandsManager.runCommand('removeMeasurement', { uid: annotationUID });
+        return;
+      }
+
+      dentalMeasurementsService.removeMeasurement(annotationUID);
+      const studyInstanceUID = studyInstanceUIDRef.current;
+      if (studyInstanceUID && !lockedRef.current) {
+        api.remove(studyInstanceUID, annotationUID).catch(markApiError);
+      }
+    });
+
+    return () => {
+      dentalMeasurementsService.setDeleteHandler(null);
+      saveTimersRef.current.forEach(timer => window.clearTimeout(timer));
+      saveTimersRef.current.clear();
+    };
+  }, [api, commandsManager, dentalMeasurementsService, markApiError, measurementService]);
+
+  return { armPreset };
 }

--- a/extensions/dental/src/preferences/dentalPreferences.ts
+++ b/extensions/dental/src/preferences/dentalPreferences.ts
@@ -1,0 +1,34 @@
+import { DEFAULT_TOOTH_ID, ToothNumberingSystem } from '../tooth/toothIdentity';
+
+export type DentalThemePreference = 'standard' | 'dental';
+
+export type DentalPreferences = {
+  selectedToothId: string;
+  numberingSystem: ToothNumberingSystem;
+  theme: DentalThemePreference;
+};
+
+export const DENTAL_PREFERENCES_STORAGE_KEY = 'ohif.dental.preferences.v1';
+
+export const DEFAULT_DENTAL_PREFERENCES: DentalPreferences = {
+  selectedToothId: DEFAULT_TOOTH_ID,
+  numberingSystem: 'Universal',
+  theme: 'standard',
+};
+
+export function normalizeDentalPreferences(value: unknown): DentalPreferences {
+  if (!value || typeof value !== 'object') {
+    return DEFAULT_DENTAL_PREFERENCES;
+  }
+
+  const candidate = value as Partial<DentalPreferences>;
+
+  return {
+    selectedToothId:
+      typeof candidate.selectedToothId === 'string'
+        ? candidate.selectedToothId
+        : DEFAULT_DENTAL_PREFERENCES.selectedToothId,
+    numberingSystem: candidate.numberingSystem === 'FDI' ? 'FDI' : 'Universal',
+    theme: candidate.theme === 'dental' ? 'dental' : 'standard',
+  };
+}

--- a/extensions/dental/src/preferences/useDentalPreferences.ts
+++ b/extensions/dental/src/preferences/useDentalPreferences.ts
@@ -1,0 +1,76 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import {
+  DEFAULT_DENTAL_PREFERENCES,
+  DENTAL_PREFERENCES_STORAGE_KEY,
+  DentalPreferences,
+  DentalThemePreference,
+  normalizeDentalPreferences,
+} from './dentalPreferences';
+import { ToothNumberingSystem, getToothIdentityById } from '../tooth/toothIdentity';
+
+function readStoredPreferences(): DentalPreferences {
+  if (typeof window === 'undefined') {
+    return DEFAULT_DENTAL_PREFERENCES;
+  }
+
+  const stored = window.localStorage.getItem(DENTAL_PREFERENCES_STORAGE_KEY);
+
+  if (!stored) {
+    return DEFAULT_DENTAL_PREFERENCES;
+  }
+
+  try {
+    return normalizeDentalPreferences(JSON.parse(stored));
+  } catch {
+    return DEFAULT_DENTAL_PREFERENCES;
+  }
+}
+
+export function useDentalPreferences() {
+  const [preferences, setPreferences] = useState<DentalPreferences>(readStoredPreferences);
+
+  useEffect(() => {
+    window.localStorage.setItem(DENTAL_PREFERENCES_STORAGE_KEY, JSON.stringify(preferences));
+  }, [preferences]);
+
+  const setSelectedToothId = useCallback((selectedToothId: string) => {
+    if (!getToothIdentityById(selectedToothId)) {
+      return;
+    }
+
+    setPreferences(current => ({
+      ...current,
+      selectedToothId,
+    }));
+  }, []);
+
+  const setNumberingSystem = useCallback((numberingSystem: ToothNumberingSystem) => {
+    setPreferences(current => ({
+      ...current,
+      numberingSystem,
+    }));
+  }, []);
+
+  const setTheme = useCallback((theme: DentalThemePreference) => {
+    setPreferences(current => ({
+      ...current,
+      theme,
+    }));
+  }, []);
+
+  const toggleTheme = useCallback(() => {
+    setPreferences(current => ({
+      ...current,
+      theme: current.theme === 'dental' ? 'standard' : 'dental',
+    }));
+  }, []);
+
+  return {
+    preferences,
+    setSelectedToothId,
+    setNumberingSystem,
+    setTheme,
+    toggleTheme,
+  };
+}

--- a/extensions/dental/src/preferences/useDentalPreferences.ts
+++ b/extensions/dental/src/preferences/useDentalPreferences.ts
@@ -59,6 +59,10 @@ export function useDentalPreferences() {
     }));
   }, []);
 
+  const applyPreferences = useCallback((nextPreferences: DentalPreferences) => {
+    setPreferences(normalizeDentalPreferences(nextPreferences));
+  }, []);
+
   const toggleTheme = useCallback(() => {
     setPreferences(current => ({
       ...current,
@@ -71,6 +75,7 @@ export function useDentalPreferences() {
     setSelectedToothId,
     setNumberingSystem,
     setTheme,
+    applyPreferences,
     toggleTheme,
   };
 }

--- a/extensions/dental/src/tooth/toothIdentity.test.ts
+++ b/extensions/dental/src/tooth/toothIdentity.test.ts
@@ -1,0 +1,34 @@
+import {
+  DEFAULT_TOOTH_ID,
+  TOOTH_IDENTITIES,
+  getToothDisplayLabel,
+  getToothIdentityByFDI,
+  getToothIdentityById,
+  getToothIdentityByUniversal,
+} from './toothIdentity';
+
+describe('toothIdentity', () => {
+  it('maps all permanent teeth', () => {
+    expect(TOOTH_IDENTITIES).toHaveLength(32);
+    expect(new Set(TOOTH_IDENTITIES.map(tooth => tooth.id)).size).toBe(32);
+  });
+
+  it('maps FDI and Universal numbers to the same canonical tooth identity', () => {
+    const universalTooth = getToothIdentityByUniversal(30);
+    const fdiTooth = getToothIdentityByFDI(46);
+
+    expect(universalTooth).toBeDefined();
+    expect(fdiTooth).toBeDefined();
+    expect(universalTooth?.id).toBe(fdiTooth?.id);
+    expect(universalTooth?.id).toBe('permanent-30');
+  });
+
+  it('keeps selected tooth identity stable when display numbering changes', () => {
+    const selectedTooth = getToothIdentityById(DEFAULT_TOOTH_ID);
+
+    expect(selectedTooth).toBeDefined();
+    expect(getToothDisplayLabel(selectedTooth!, 'Universal')).toBe('Universal 30');
+    expect(getToothDisplayLabel(selectedTooth!, 'FDI')).toBe('FDI 46');
+    expect(selectedTooth?.id).toBe(DEFAULT_TOOTH_ID);
+  });
+});

--- a/extensions/dental/src/tooth/toothIdentity.ts
+++ b/extensions/dental/src/tooth/toothIdentity.ts
@@ -1,0 +1,84 @@
+export type ToothNumberingSystem = 'FDI' | 'Universal';
+
+export type ToothIdentity = {
+  id: string;
+  fdi: string;
+  universal: string;
+  label: string;
+};
+
+const permanentToothMap: Array<[string, string, string]> = [
+  ['18', '1', 'Maxillary right third molar'],
+  ['17', '2', 'Maxillary right second molar'],
+  ['16', '3', 'Maxillary right first molar'],
+  ['15', '4', 'Maxillary right second premolar'],
+  ['14', '5', 'Maxillary right first premolar'],
+  ['13', '6', 'Maxillary right canine'],
+  ['12', '7', 'Maxillary right lateral incisor'],
+  ['11', '8', 'Maxillary right central incisor'],
+  ['21', '9', 'Maxillary left central incisor'],
+  ['22', '10', 'Maxillary left lateral incisor'],
+  ['23', '11', 'Maxillary left canine'],
+  ['24', '12', 'Maxillary left first premolar'],
+  ['25', '13', 'Maxillary left second premolar'],
+  ['26', '14', 'Maxillary left first molar'],
+  ['27', '15', 'Maxillary left second molar'],
+  ['28', '16', 'Maxillary left third molar'],
+  ['38', '17', 'Mandibular left third molar'],
+  ['37', '18', 'Mandibular left second molar'],
+  ['36', '19', 'Mandibular left first molar'],
+  ['35', '20', 'Mandibular left second premolar'],
+  ['34', '21', 'Mandibular left first premolar'],
+  ['33', '22', 'Mandibular left canine'],
+  ['32', '23', 'Mandibular left lateral incisor'],
+  ['31', '24', 'Mandibular left central incisor'],
+  ['41', '25', 'Mandibular right central incisor'],
+  ['42', '26', 'Mandibular right lateral incisor'],
+  ['43', '27', 'Mandibular right canine'],
+  ['44', '28', 'Mandibular right first premolar'],
+  ['45', '29', 'Mandibular right second premolar'],
+  ['46', '30', 'Mandibular right first molar'],
+  ['47', '31', 'Mandibular right second molar'],
+  ['48', '32', 'Mandibular right third molar'],
+];
+
+export const TOOTH_IDENTITIES: ToothIdentity[] = permanentToothMap.map(
+  ([fdi, universal, label]) => ({
+    id: `permanent-${universal}`,
+    fdi,
+    universal,
+    label,
+  })
+);
+
+const toothById = new Map(TOOTH_IDENTITIES.map(tooth => [tooth.id, tooth]));
+const toothByFDI = new Map(TOOTH_IDENTITIES.map(tooth => [tooth.fdi, tooth]));
+const toothByUniversal = new Map(TOOTH_IDENTITIES.map(tooth => [tooth.universal, tooth]));
+
+export const DEFAULT_TOOTH_ID = 'permanent-30';
+
+export function getToothIdentityById(toothId: string): ToothIdentity | undefined {
+  return toothById.get(toothId);
+}
+
+export function getToothIdentityByFDI(fdi: string | number): ToothIdentity | undefined {
+  return toothByFDI.get(String(fdi));
+}
+
+export function getToothIdentityByUniversal(universal: string | number): ToothIdentity | undefined {
+  return toothByUniversal.get(String(universal));
+}
+
+export function getToothDisplayValue(
+  tooth: ToothIdentity,
+  numberingSystem: ToothNumberingSystem
+): string {
+  return numberingSystem === 'FDI' ? tooth.fdi : tooth.universal;
+}
+
+export function getToothDisplayLabel(
+  tooth: ToothIdentity,
+  numberingSystem: ToothNumberingSystem
+): string {
+  return `${numberingSystem} ${getToothDisplayValue(tooth, numberingSystem)}`;
+}

--- a/extensions/dental/src/viewerState/dentalViewerState.test.ts
+++ b/extensions/dental/src/viewerState/dentalViewerState.test.ts
@@ -1,0 +1,43 @@
+import { normalizeDentalViewerState } from './dentalViewerState';
+
+describe('normalizeDentalViewerState', () => {
+  it('normalizes persisted dental viewer state', () => {
+    const state = normalizeDentalViewerState({
+      selectedToothId: 'FDI-46',
+      numberingSystem: 'FDI',
+      theme: 'dental',
+      layoutContext: {
+        activeViewportId: 'dental-current',
+        viewportIds: ['dental-current', 'dental-prior', 42],
+        protocolId: '@ohif/extension-dental.hangingProtocolModule.dental2x2',
+        stageId: 'dental-2x2',
+      },
+    });
+
+    expect(state).toEqual({
+      selectedToothId: 'FDI-46',
+      numberingSystem: 'FDI',
+      theme: 'dental',
+      layoutContext: {
+        activeViewportId: 'dental-current',
+        viewportIds: ['dental-current', 'dental-prior'],
+        protocolId: '@ohif/extension-dental.hangingProtocolModule.dental2x2',
+        stageId: 'dental-2x2',
+      },
+    });
+  });
+
+  it('falls back to safe defaults for invalid state', () => {
+    const state = normalizeDentalViewerState({
+      selectedToothId: 46,
+      numberingSystem: 'Palmer',
+      theme: 'sepia',
+      layoutContext: null,
+    });
+
+    expect(state.selectedToothId).toBe('permanent-30');
+    expect(state.numberingSystem).toBe('Universal');
+    expect(state.theme).toBe('standard');
+    expect(state.layoutContext.viewportIds).toEqual([]);
+  });
+});

--- a/extensions/dental/src/viewerState/dentalViewerState.ts
+++ b/extensions/dental/src/viewerState/dentalViewerState.ts
@@ -1,0 +1,56 @@
+import {
+  DEFAULT_DENTAL_PREFERENCES,
+  DentalPreferences,
+  normalizeDentalPreferences,
+} from '../preferences/dentalPreferences';
+
+export type DentalLayoutContext = {
+  activeViewportId?: string;
+  viewportIds: string[];
+  protocolId?: string;
+  stageId?: string;
+};
+
+export type DentalViewerState = DentalPreferences & {
+  layoutContext: DentalLayoutContext;
+};
+
+const DEFAULT_LAYOUT_CONTEXT: DentalLayoutContext = {
+  viewportIds: [],
+};
+
+export const DEFAULT_DENTAL_VIEWER_STATE: DentalViewerState = {
+  ...DEFAULT_DENTAL_PREFERENCES,
+  layoutContext: DEFAULT_LAYOUT_CONTEXT,
+};
+
+export function normalizeDentalLayoutContext(value: unknown): DentalLayoutContext {
+  if (!value || typeof value !== 'object') {
+    return DEFAULT_LAYOUT_CONTEXT;
+  }
+
+  const candidate = value as Partial<DentalLayoutContext>;
+
+  return {
+    activeViewportId:
+      typeof candidate.activeViewportId === 'string' ? candidate.activeViewportId : undefined,
+    viewportIds: Array.isArray(candidate.viewportIds)
+      ? candidate.viewportIds.filter((viewportId): viewportId is string => typeof viewportId === 'string')
+      : [],
+    protocolId: typeof candidate.protocolId === 'string' ? candidate.protocolId : undefined,
+    stageId: typeof candidate.stageId === 'string' ? candidate.stageId : undefined,
+  };
+}
+
+export function normalizeDentalViewerState(value: unknown): DentalViewerState {
+  if (!value || typeof value !== 'object') {
+    return DEFAULT_DENTAL_VIEWER_STATE;
+  }
+
+  const candidate = value as Partial<DentalViewerState>;
+
+  return {
+    ...normalizeDentalPreferences(candidate),
+    layoutContext: normalizeDentalLayoutContext(candidate.layoutContext),
+  };
+}

--- a/extensions/dental/src/viewerState/dentalViewerStateApi.test.ts
+++ b/extensions/dental/src/viewerState/dentalViewerStateApi.test.ts
@@ -1,0 +1,88 @@
+import {
+  DentalViewerStateAuthError,
+  DentalViewerStateUnavailableError,
+  createDentalViewerStateApi,
+} from './dentalViewerStateApi';
+import { DEFAULT_DENTAL_VIEWER_STATE } from './dentalViewerState';
+
+function response(status: number, body: unknown = {}) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: jest.fn().mockResolvedValue(body),
+  } as unknown as Response;
+}
+
+describe('createDentalViewerStateApi', () => {
+  it('loads persisted Dental Viewer State with bearer auth', () => {
+    const fetcher = jest.fn().mockResolvedValue(
+      response(200, {
+        state: {
+          selectedToothId: 'FDI-46',
+          numberingSystem: 'FDI',
+          theme: 'dental',
+        },
+      })
+    );
+    const api = createDentalViewerStateApi({
+      baseUrl: 'http://localhost:4007/api/dental',
+      authToken: 'token',
+      fetcher,
+    });
+
+    return expect(api.load('1.2.3')).resolves.toMatchObject({
+      selectedToothId: 'FDI-46',
+    }).then(() => {
+      expect(fetcher).toHaveBeenCalledWith(
+        'http://localhost:4007/api/dental/state/1.2.3',
+        expect.objectContaining({
+          method: 'GET',
+          headers: expect.objectContaining({ authorization: 'Bearer token' }),
+        })
+      );
+    });
+  });
+
+  it('saves Dental Viewer State', () => {
+    const fetcher = jest.fn().mockResolvedValue(response(200, { state: DEFAULT_DENTAL_VIEWER_STATE }));
+    const api = createDentalViewerStateApi({
+      baseUrl: 'http://localhost:4007/api/dental/',
+      authToken: 'token',
+      fetcher,
+    });
+
+    return api.save('study uid', DEFAULT_DENTAL_VIEWER_STATE).then(() => {
+      expect(fetcher).toHaveBeenCalledWith(
+        'http://localhost:4007/api/dental/state/study%20uid',
+        expect.objectContaining({
+          method: 'PUT',
+          body: JSON.stringify({ state: DEFAULT_DENTAL_VIEWER_STATE }),
+        })
+      );
+    });
+  });
+
+  it('maps 401 and 403 responses to locked-state auth errors', () => {
+    const fetcher = jest.fn().mockResolvedValue(response(403));
+    const api = createDentalViewerStateApi({
+      baseUrl: 'http://localhost:4007/api/dental',
+      authToken: 'token',
+      fetcher,
+    });
+
+    return expect(api.load('1.2.3')).rejects.toBeInstanceOf(DentalViewerStateAuthError);
+  });
+
+  it('maps network failures to unavailable errors', () => {
+    const fetcher = jest.fn().mockRejectedValue(new Error('network down'));
+    const api = createDentalViewerStateApi({
+      baseUrl: 'http://localhost:4007/api/dental',
+      authToken: 'token',
+      fetcher,
+    });
+
+    return expect(api.load('1.2.3')).rejects.toBeInstanceOf(
+      DentalViewerStateUnavailableError
+    );
+  });
+});

--- a/extensions/dental/src/viewerState/dentalViewerStateApi.ts
+++ b/extensions/dental/src/viewerState/dentalViewerStateApi.ts
@@ -1,0 +1,90 @@
+import { DentalViewerState } from './dentalViewerState';
+
+export class DentalViewerStateAuthError extends Error {
+  status: number;
+
+  constructor(status: number) {
+    super('Dental viewer state auth failed');
+    this.name = 'DentalViewerStateAuthError';
+    this.status = status;
+  }
+}
+
+export class DentalViewerStateUnavailableError extends Error {
+  constructor() {
+    super('Dental viewer state API unavailable');
+    this.name = 'DentalViewerStateUnavailableError';
+  }
+}
+
+type DentalViewerStateApiConfig = {
+  baseUrl: string;
+  authToken: string;
+  fetcher?: typeof fetch;
+};
+
+function trimTrailingSlash(value: string): string {
+  return value.replace(/\/+$/, '');
+}
+
+function stateUrl(baseUrl: string, studyInstanceUID: string): string {
+  return `${trimTrailingSlash(baseUrl)}/state/${encodeURIComponent(studyInstanceUID)}`;
+}
+
+function requestJson(
+  url: string,
+  options: RequestInit,
+  fetcher: typeof fetch
+): Promise<unknown> {
+  return fetcher(url, options)
+    .catch(() => {
+      throw new DentalViewerStateUnavailableError();
+    })
+    .then(response => {
+      if (response.status === 401 || response.status === 403) {
+        throw new DentalViewerStateAuthError(response.status);
+      }
+
+      if (!response.ok) {
+        throw new DentalViewerStateUnavailableError();
+      }
+
+      return response.json();
+    });
+}
+
+export function createDentalViewerStateApi({
+  baseUrl,
+  authToken,
+  fetcher = fetch,
+}: DentalViewerStateApiConfig) {
+  const headers = {
+    authorization: `Bearer ${authToken}`,
+    'content-type': 'application/json',
+  };
+
+  return {
+    load(studyInstanceUID: string): Promise<unknown> {
+      return requestJson(
+        stateUrl(baseUrl, studyInstanceUID),
+        {
+          method: 'GET',
+          headers,
+        },
+        fetcher
+      ).then(payload => (payload as { state?: unknown })?.state || null);
+    },
+
+    save(studyInstanceUID: string, state: DentalViewerState): Promise<void> {
+      return requestJson(
+        stateUrl(baseUrl, studyInstanceUID),
+        {
+          method: 'PUT',
+          headers,
+          body: JSON.stringify({ state }),
+        },
+        fetcher
+      ).then(() => undefined);
+    },
+  };
+}

--- a/extensions/dental/src/viewerState/useDentalViewerState.test.ts
+++ b/extensions/dental/src/viewerState/useDentalViewerState.test.ts
@@ -1,0 +1,191 @@
+import { renderHook, waitFor } from '@testing-library/react';
+
+import { DEFAULT_DENTAL_PREFERENCES, DentalPreferences } from '../preferences/dentalPreferences';
+import { useDentalViewerState } from './useDentalViewerState';
+
+function response(status: number, body: unknown = {}) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: jest.fn().mockResolvedValue(body),
+  } as unknown as Response;
+}
+
+function createServicesManager() {
+  const displaySetService = {
+    EVENTS: {
+      DISPLAY_SETS_ADDED: 'displaySetsAdded',
+      DISPLAY_SETS_CHANGED: 'displaySetsChanged',
+    },
+    getActiveDisplaySets: jest.fn(() => [
+      {
+        StudyInstanceUID: 'study-1',
+        instances: [{ StudyInstanceUID: 'study-1' }],
+      },
+    ]),
+    subscribe: jest.fn(() => ({ unsubscribe: jest.fn() })),
+  };
+  const viewportGridService = {
+    EVENTS: {
+      GRID_STATE_CHANGED: 'gridStateChanged',
+    },
+    getState: jest.fn(() => ({
+      activeViewportId: 'dental-current',
+      viewports: new Map([
+        ['dental-current', {}],
+        ['dental-prior', {}],
+      ]),
+    })),
+    subscribe: jest.fn(() => ({ unsubscribe: jest.fn() })),
+  };
+  const hangingProtocolService = {
+    getState: jest.fn(() => ({
+      protocolId: '@ohif/extension-dental.hangingProtocolModule.dental2x2',
+      stage: { id: 'dental-2x2' },
+    })),
+  };
+
+  return {
+    services: {
+      displaySetService,
+      viewportGridService,
+      hangingProtocolService,
+    },
+  } as unknown as AppTypes.ServicesManager;
+}
+
+function renderDentalViewerStateHook({
+  fetcher,
+  preferences = DEFAULT_DENTAL_PREFERENCES,
+}: {
+  fetcher: jest.Mock;
+  preferences?: DentalPreferences;
+}) {
+  const originalFetch = global.fetch;
+  global.fetch = fetcher;
+
+  const servicesManager = createServicesManager();
+  const applyPreferences = jest.fn();
+  const appConfig = {
+    dental: {
+      viewerStateApiUrl: 'http://localhost:4007/api/dental',
+      viewerStateAuthToken: 'token',
+    },
+  } as AppTypes.Config;
+  const hook = renderHook(
+    props =>
+      useDentalViewerState({
+        appConfig,
+        servicesManager,
+        preferences: props.preferences,
+        applyPreferences,
+      }),
+    {
+      initialProps: {
+        preferences,
+      },
+    }
+  );
+
+  return {
+    ...hook,
+    applyPreferences,
+    servicesManager,
+    restoreFetch: () => {
+      global.fetch = originalFetch;
+    },
+  };
+}
+
+describe('useDentalViewerState', () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation((message, ...args) => {
+      const text = [message, ...args].join(' ');
+      if (
+        text.includes('ReactDOMTestUtils.act') &&
+        text.includes('deprecated')
+      ) {
+        return;
+      }
+
+      throw new Error(text);
+    });
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('loads persisted preferences for the current study', () => {
+    const fetcher = jest.fn().mockResolvedValue(
+      response(200, {
+        state: {
+          selectedToothId: 'FDI-46',
+          numberingSystem: 'FDI',
+          theme: 'dental',
+        },
+      })
+    );
+    const { result, applyPreferences, restoreFetch } = renderDentalViewerStateHook({ fetcher });
+
+    return waitFor(() => expect(result.current.status).toBe('saved')).then(() => {
+      expect(applyPreferences).toHaveBeenCalledWith(
+        expect.objectContaining({
+          selectedToothId: 'FDI-46',
+          numberingSystem: 'FDI',
+          theme: 'dental',
+        })
+      );
+      restoreFetch();
+    });
+  });
+
+  it('keeps controls in memory and marks state unsaved when backend is unavailable', () => {
+    const fetcher = jest.fn().mockRejectedValue(new Error('offline'));
+    const { result, restoreFetch } = renderDentalViewerStateHook({ fetcher });
+
+    return waitFor(() => expect(result.current.status).toBe('unsaved')).then(() => {
+      expect(result.current.lastError).toBe('Dental state not saved');
+      restoreFetch();
+    });
+  });
+
+  it('locks persisted state load/save on auth failure', () => {
+    const fetcher = jest.fn().mockResolvedValue(response(403));
+    const { result, restoreFetch } = renderDentalViewerStateHook({ fetcher });
+
+    return waitFor(() => expect(result.current.status).toBe('locked')).then(() => {
+      expect(result.current.lastError).toBe('Dental state locked');
+      restoreFetch();
+    });
+  });
+
+  it('saves changed preferences after the current study has loaded', () => {
+    const fetcher = jest.fn().mockResolvedValue(response(200, { state: null }));
+    const hook = renderDentalViewerStateHook({ fetcher });
+
+    return waitFor(() => expect(hook.result.current.status).toBe('saved')).then(() => {
+      hook.rerender({
+        preferences: {
+          ...DEFAULT_DENTAL_PREFERENCES,
+          selectedToothId: 'FDI-46',
+          numberingSystem: 'FDI',
+        },
+      });
+
+      return waitFor(() =>
+        expect(fetcher).toHaveBeenCalledWith(
+          'http://localhost:4007/api/dental/state/study-1',
+          expect.objectContaining({
+            method: 'PUT',
+            body: expect.stringContaining('FDI-46'),
+          })
+        )
+      ).then(() => {
+        hook.restoreFetch();
+      });
+    });
+  });
+});

--- a/extensions/dental/src/viewerState/useDentalViewerState.test.ts
+++ b/extensions/dental/src/viewerState/useDentalViewerState.test.ts
@@ -41,7 +41,6 @@ function createServicesManager() {
   const hangingProtocolService = {
     getState: jest.fn(() => ({
       protocolId: '@ohif/extension-dental.hangingProtocolModule.dental2x2',
-      stage: { id: 'dental-2x2' },
     })),
   };
 
@@ -175,17 +174,21 @@ describe('useDentalViewerState', () => {
         },
       });
 
-      return waitFor(() =>
-        expect(fetcher).toHaveBeenCalledWith(
-          'http://localhost:4007/api/dental/state/study-1',
-          expect.objectContaining({
-            method: 'PUT',
-            body: expect.stringContaining('FDI-46'),
-          })
-        )
-      ).then(() => {
-        hook.restoreFetch();
-      });
+    return waitFor(() =>
+      expect(fetcher).toHaveBeenCalledWith(
+        'http://localhost:4007/api/dental/state/study-1',
+        expect.objectContaining({
+          method: 'PUT',
+          body: expect.stringContaining('FDI-46'),
+        })
+      )
+    ).then(() => {
+      const saveCall = fetcher.mock.calls.find(([, options]) => options.method === 'PUT');
+      const payload = JSON.parse(saveCall[1].body);
+
+      expect(payload.state.layoutContext.stageId).toBe('dental-2x2');
+      hook.restoreFetch();
     });
   });
+});
 });

--- a/extensions/dental/src/viewerState/useDentalViewerState.ts
+++ b/extensions/dental/src/viewerState/useDentalViewerState.ts
@@ -25,6 +25,9 @@ type DentalBackendConfig = {
   authToken: string;
 };
 
+const DENTAL_2X2_PROTOCOL_ID = '@ohif/extension-dental.hangingProtocolModule.dental2x2';
+const DENTAL_2X2_STAGE_ID = 'dental-2x2';
+
 function getDentalBackendConfig(appConfig: AppTypes.Config): DentalBackendConfig {
   const dentalConfig = (appConfig as AppTypes.Config & { dental?: Record<string, string> })?.dental;
 
@@ -47,19 +50,45 @@ function getStudyInstanceUID(displaySetService): string | undefined {
   return displaySet?.StudyInstanceUID || instance?.StudyInstanceUID;
 }
 
+function getHangingProtocolStageId(hangingProtocolService): string | undefined {
+  const hangingProtocolState = hangingProtocolService?.getState?.();
+  const protocolId = hangingProtocolState?.protocolId;
+
+  if (typeof hangingProtocolState?.stage?.id === 'string') {
+    return hangingProtocolState.stage.id;
+  }
+
+  if (typeof hangingProtocolState?.activeStage?.id === 'string') {
+    return hangingProtocolState.activeStage.id;
+  }
+
+  const stageIndex = hangingProtocolState?.stageIndex;
+  const protocol = hangingProtocolService?.getProtocol?.(protocolId);
+  const stage = Number.isInteger(stageIndex) ? protocol?.stages?.[stageIndex] : undefined;
+
+  if (typeof stage?.id === 'string') {
+    return stage.id;
+  }
+
+  if (protocolId === DENTAL_2X2_PROTOCOL_ID) {
+    return DENTAL_2X2_STAGE_ID;
+  }
+
+  return undefined;
+}
+
 function getLayoutContext(servicesManager: AppTypes.ServicesManager): DentalLayoutContext {
   const { viewportGridService, hangingProtocolService } = servicesManager.services;
   const viewportGridState = viewportGridService?.getState?.();
   const hangingProtocolState = hangingProtocolService?.getState?.();
   const viewports = viewportGridState?.viewports || new Map();
   const viewportIds = Array.from(viewports.keys ? viewports.keys() : Object.keys(viewports));
-  const stage = hangingProtocolState?.stage;
 
   return {
     activeViewportId: viewportGridState?.activeViewportId,
     viewportIds,
     protocolId: hangingProtocolState?.protocolId,
-    stageId: stage?.id,
+    stageId: getHangingProtocolStageId(hangingProtocolService),
   };
 }
 

--- a/extensions/dental/src/viewerState/useDentalViewerState.ts
+++ b/extensions/dental/src/viewerState/useDentalViewerState.ts
@@ -1,0 +1,228 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { DentalPreferences } from '../preferences/dentalPreferences';
+import {
+  DentalLayoutContext,
+  DentalViewerState,
+  normalizeDentalViewerState,
+} from './dentalViewerState';
+import {
+  DentalViewerStateAuthError,
+  createDentalViewerStateApi,
+} from './dentalViewerStateApi';
+
+export type DentalViewerStateStatus = 'idle' | 'loading' | 'saved' | 'unsaved' | 'locked';
+
+type UseDentalViewerStateProps = {
+  appConfig: AppTypes.Config;
+  servicesManager: AppTypes.ServicesManager;
+  preferences: DentalPreferences;
+  applyPreferences: (preferences: DentalPreferences) => void;
+};
+
+type DentalBackendConfig = {
+  baseUrl: string;
+  authToken: string;
+};
+
+function getDentalBackendConfig(appConfig: AppTypes.Config): DentalBackendConfig {
+  const dentalConfig = (appConfig as AppTypes.Config & { dental?: Record<string, string> })?.dental;
+
+  return {
+    baseUrl:
+      dentalConfig?.viewerStateApiUrl ||
+      dentalConfig?.backendUrl ||
+      'http://localhost:4007/api/dental',
+    authToken:
+      dentalConfig?.viewerStateAuthToken ||
+      dentalConfig?.backendAuthToken ||
+      'dev-dental-token',
+  };
+}
+
+function getStudyInstanceUID(displaySetService): string | undefined {
+  const displaySet = displaySetService.getActiveDisplaySets?.()?.[0];
+  const instance = displaySet?.instances?.[0] || displaySet?.instance;
+
+  return displaySet?.StudyInstanceUID || instance?.StudyInstanceUID;
+}
+
+function getLayoutContext(servicesManager: AppTypes.ServicesManager): DentalLayoutContext {
+  const { viewportGridService, hangingProtocolService } = servicesManager.services;
+  const viewportGridState = viewportGridService?.getState?.();
+  const hangingProtocolState = hangingProtocolService?.getState?.();
+  const viewports = viewportGridState?.viewports || new Map();
+  const viewportIds = Array.from(viewports.keys ? viewports.keys() : Object.keys(viewports));
+  const stage = hangingProtocolState?.stage;
+
+  return {
+    activeViewportId: viewportGridState?.activeViewportId,
+    viewportIds,
+    protocolId: hangingProtocolState?.protocolId,
+    stageId: stage?.id,
+  };
+}
+
+export function useDentalViewerState({
+  appConfig,
+  servicesManager,
+  preferences,
+  applyPreferences,
+}: UseDentalViewerStateProps) {
+  const { displaySetService, viewportGridService } = servicesManager.services;
+  const [studyInstanceUID, setStudyInstanceUID] = useState(() =>
+    getStudyInstanceUID(displaySetService)
+  );
+  const [status, setStatus] = useState<DentalViewerStateStatus>('idle');
+  const [lastError, setLastError] = useState<string | null>(null);
+  const [loadedStudyUID, setLoadedStudyUID] = useState<string | null>(null);
+  const [layoutRevision, setLayoutRevision] = useState(0);
+  const lockedRef = useRef(false);
+  const skipNextSaveRef = useRef(false);
+  const saveTimerRef = useRef<ReturnType<typeof window.setTimeout> | null>(null);
+
+  const backendConfig = useMemo(() => getDentalBackendConfig(appConfig), [appConfig]);
+  const api = useMemo(() => createDentalViewerStateApi(backendConfig), [backendConfig]);
+
+  const refreshStudyInstanceUID = useCallback(() => {
+    setStudyInstanceUID(current => getStudyInstanceUID(displaySetService) || current);
+  }, [displaySetService]);
+
+  useEffect(() => {
+    refreshStudyInstanceUID();
+
+    const subscriptions = [
+      displaySetService.subscribe?.(
+        displaySetService.EVENTS.DISPLAY_SETS_ADDED,
+        refreshStudyInstanceUID
+      ),
+      displaySetService.subscribe?.(
+        displaySetService.EVENTS.DISPLAY_SETS_CHANGED,
+        refreshStudyInstanceUID
+      ),
+    ].filter(Boolean);
+
+    return () => {
+      subscriptions.forEach(({ unsubscribe }) => unsubscribe());
+    };
+  }, [displaySetService, refreshStudyInstanceUID]);
+
+  useEffect(() => {
+    if (!studyInstanceUID || lockedRef.current) {
+      return;
+    }
+
+    let cancelled = false;
+    setStatus('loading');
+    setLastError(null);
+
+    api
+      .load(studyInstanceUID)
+      .then(remoteState => {
+        if (cancelled) {
+          return;
+        }
+
+        if (remoteState) {
+          const normalized = normalizeDentalViewerState(remoteState);
+          applyPreferences(normalized);
+        }
+
+        skipNextSaveRef.current = true;
+        setLoadedStudyUID(studyInstanceUID);
+        setStatus('saved');
+      })
+      .catch(error => {
+        if (cancelled) {
+          return;
+        }
+
+        if (error instanceof DentalViewerStateAuthError) {
+          lockedRef.current = true;
+          setStatus('locked');
+          setLastError('Dental state locked');
+          return;
+        }
+
+        skipNextSaveRef.current = true;
+        setLoadedStudyUID(studyInstanceUID);
+        setStatus('unsaved');
+        setLastError('Dental state not saved');
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [api, applyPreferences, studyInstanceUID]);
+
+  useEffect(() => {
+    if (!studyInstanceUID || loadedStudyUID !== studyInstanceUID || lockedRef.current) {
+      return;
+    }
+
+    if (skipNextSaveRef.current) {
+      skipNextSaveRef.current = false;
+      return;
+    }
+
+    if (saveTimerRef.current) {
+      window.clearTimeout(saveTimerRef.current);
+    }
+
+    setStatus('unsaved');
+    saveTimerRef.current = window.setTimeout(() => {
+      const state: DentalViewerState = {
+        ...preferences,
+        layoutContext: getLayoutContext(servicesManager),
+      };
+
+      api
+        .save(studyInstanceUID, state)
+        .then(() => {
+          setStatus('saved');
+          setLastError(null);
+        })
+        .catch(error => {
+          if (error instanceof DentalViewerStateAuthError) {
+            lockedRef.current = true;
+            setStatus('locked');
+            setLastError('Dental state locked');
+            return;
+          }
+
+          setStatus('unsaved');
+          setLastError('Dental state not saved');
+        });
+    }, 400);
+
+    return () => {
+      if (saveTimerRef.current) {
+        window.clearTimeout(saveTimerRef.current);
+      }
+    };
+  }, [api, layoutRevision, loadedStudyUID, preferences, servicesManager, studyInstanceUID]);
+
+  useEffect(() => {
+    if (!viewportGridService || !studyInstanceUID || lockedRef.current) {
+      return;
+    }
+
+    const subscription = viewportGridService.subscribe?.(
+      viewportGridService.EVENTS.GRID_STATE_CHANGED,
+      () => {
+        setLayoutRevision(current => current + 1);
+        setStatus(current => (current === 'locked' ? current : 'unsaved'));
+      }
+    );
+
+    return () => {
+      subscription?.unsubscribe();
+    };
+  }, [studyInstanceUID, viewportGridService]);
+
+  return {
+    status,
+    lastError,
+    studyInstanceUID,
+  };
+}

--- a/modes/dental/.webpack/webpack.dev.js
+++ b/modes/dental/.webpack/webpack.dev.js
@@ -1,0 +1,13 @@
+const path = require('path');
+const webpackCommon = require('./../../../.webpack/webpack.base.js');
+
+const SRC_DIR = path.join(__dirname, '../src');
+const DIST_DIR = path.join(__dirname, '../dist');
+
+const ENTRY = {
+  app: `${SRC_DIR}/index.ts`,
+};
+
+module.exports = (env, argv) => {
+  return webpackCommon(env, argv, { SRC_DIR, DIST_DIR, ENTRY });
+};

--- a/modes/dental/.webpack/webpack.prod.js
+++ b/modes/dental/.webpack/webpack.prod.js
@@ -1,0 +1,50 @@
+const webpack = require('@rspack/core');
+const { merge } = require('webpack-merge');
+const path = require('path');
+
+const pkg = require('./../package.json');
+const webpackCommon = require('./../../../.webpack/webpack.base.js');
+
+const ROOT_DIR = path.join(__dirname, './../');
+const SRC_DIR = path.join(__dirname, '../src');
+const DIST_DIR = path.join(__dirname, '../dist');
+const ENTRY = {
+  app: `${SRC_DIR}/index.ts`,
+};
+
+module.exports = (env, argv) => {
+  const commonConfig = webpackCommon(env, argv, { SRC_DIR, DIST_DIR, ENTRY });
+
+  return merge(commonConfig, {
+    stats: {
+      colors: true,
+      hash: true,
+      timings: true,
+      assets: true,
+      chunks: false,
+      chunkModules: false,
+      modules: false,
+      children: false,
+      warnings: true,
+    },
+    optimization: {
+      minimize: true,
+      sideEffects: false,
+    },
+    output: {
+      library: {
+        name: 'ohif-mode-dental',
+        type: 'umd',
+        export: 'default',
+      },
+      path: ROOT_DIR,
+      filename: pkg.main,
+    },
+    externals: [/\b(vtk.js)/, /\b(dcmjs)/, /\b(gl-matrix)/, /^@ohif/, /^@cornerstonejs/],
+    plugins: [
+      new webpack.optimize.LimitChunkCountPlugin({
+        maxChunks: 1,
+      }),
+    ],
+  });
+};

--- a/modes/dental/babel.config.js
+++ b/modes/dental/babel.config.js
@@ -1,0 +1,1 @@
+module.exports = require('../../babel.config.js');

--- a/modes/dental/package.json
+++ b/modes/dental/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@ohif/mode-dental",
+  "version": "3.13.0-beta.93",
+  "description": "Dental Mode for OHIF",
+  "author": "OHIF Contributors",
+  "license": "MIT",
+  "repository": "OHIF/Viewers",
+  "main": "dist/ohif-mode-dental.umd.js",
+  "module": "src/index.ts",
+  "engines": {
+    "node": ">=24"
+  },
+  "files": [
+    "dist/**",
+    "public/**",
+    "README.md"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "dev": "cross-env NODE_ENV=development rspack build --config .webpack/webpack.dev.js --watch",
+    "build": "cross-env NODE_ENV=production rspack build --config .webpack/webpack.prod.js",
+    "build:package": "pnpm run build",
+    "start": "pnpm run dev",
+    "test:unit": "jest --watchAll",
+    "test:unit:ci": "jest --ci --runInBand --collectCoverage --passWithNoTests"
+  },
+  "peerDependencies": {
+    "@ohif/core": "workspace:*",
+    "@ohif/extension-dental": "workspace:*",
+    "@ohif/mode-basic": "workspace:*",
+    "i18next": "17.3.1"
+  },
+  "dependencies": {
+    "@babel/runtime": "7.29.7"
+  },
+  "devDependencies": {
+    "webpack-merge": "5.10.0"
+  },
+  "keywords": [
+    "ohif-mode"
+  ]
+}

--- a/modes/dental/src/id.js
+++ b/modes/dental/src/id.js
@@ -1,0 +1,5 @@
+import packageJson from '../package.json';
+
+const id = packageJson.name;
+
+export { id };

--- a/modes/dental/src/index.ts
+++ b/modes/dental/src/index.ts
@@ -1,0 +1,82 @@
+import i18n from 'i18next';
+import {
+  basicLayout,
+  basicRoute,
+  cornerstone,
+  dicomecg,
+  dicompdf,
+  dicomPmap,
+  dicomRT,
+  dicomSeg,
+  dicomsr,
+  dicomvideo,
+  extensionDependencies as basicDependencies,
+  initToolGroups,
+  mode as basicMode,
+  modeInstance as basicModeInstance,
+  ohif,
+  sopClassHandlers,
+  toolbarButtons,
+  toolbarSections,
+} from '@ohif/mode-basic';
+
+import { id } from './id';
+
+const dental = {
+  layout: '@ohif/extension-dental.layoutTemplateModule.dentalViewerLayout',
+};
+
+export const extensionDependencies = {
+  ...basicDependencies,
+  '@ohif/extension-dental': '^3.0.0',
+};
+
+export const dentalLayout = {
+  ...basicLayout,
+  id: dental.layout,
+  props: {
+    ...basicLayout.props,
+    rightPanelClosed: true,
+  },
+};
+
+export const dentalRoute = {
+  ...basicRoute,
+  path: 'dental',
+  layoutInstance: dentalLayout,
+};
+
+export const modeInstance = {
+  ...basicModeInstance,
+  id,
+  routeName: 'dental',
+  hide: true,
+  displayName: i18n.t('Modes:Dental Viewer'),
+  routes: [dentalRoute],
+  extensions: extensionDependencies,
+  toolbarSections,
+  sopClassHandlers,
+  toolbarButtons,
+};
+
+const mode = {
+  ...basicMode,
+  id,
+  modeInstance,
+  extensionDependencies,
+};
+
+export default mode;
+export {
+  cornerstone,
+  dicomecg,
+  dicompdf,
+  dicomPmap,
+  dicomRT,
+  dicomSeg,
+  dicomsr,
+  dicomvideo,
+  initToolGroups,
+  ohif,
+  toolbarButtons,
+};

--- a/modes/dental/src/index.ts
+++ b/modes/dental/src/index.ts
@@ -25,6 +25,7 @@ import { id } from './id';
 const dental = {
   layout: '@ohif/extension-dental.layoutTemplateModule.dentalViewerLayout',
   hangingProtocol: '@ohif/extension-dental.hangingProtocolModule.dental2x2',
+  measurements: '@ohif/extension-dental.panelModule.dentalMeasurements',
 };
 
 export const extensionDependencies = {
@@ -37,6 +38,7 @@ export const dentalLayout = {
   id: dental.layout,
   props: {
     ...basicLayout.props,
+    rightPanels: [dental.measurements],
     rightPanelClosed: true,
   },
 };

--- a/modes/dental/src/index.ts
+++ b/modes/dental/src/index.ts
@@ -24,6 +24,7 @@ import { id } from './id';
 
 const dental = {
   layout: '@ohif/extension-dental.layoutTemplateModule.dentalViewerLayout',
+  hangingProtocol: '@ohif/extension-dental.hangingProtocolModule.dental2x2',
 };
 
 export const extensionDependencies = {
@@ -54,6 +55,7 @@ export const modeInstance = {
   displayName: i18n.t('Modes:Dental Viewer'),
   routes: [dentalRoute],
   extensions: extensionDependencies,
+  hangingProtocol: dental.hangingProtocol,
   toolbarSections,
   sopClassHandlers,
   toolbarButtons,

--- a/platform/app/pluginConfig.json
+++ b/platform/app/pluginConfig.json
@@ -65,6 +65,11 @@
     {
       "packageName": "@ohif/extension-ultrasound-pleura-bline",
       "version": "3.0.0"
+    },
+    {
+      "packageName": "@ohif/extension-dental",
+      "default": false,
+      "version": "3.0.0"
     }
   ],
   "modes": [
@@ -98,6 +103,10 @@
     },
     {
       "packageName": "@ohif/mode-ultrasound-pleura-bline",
+      "version": "3.0.0"
+    },
+    {
+      "packageName": "@ohif/mode-dental",
       "version": "3.0.0"
     }
   ],

--- a/platform/dental-backend/jest.config.js
+++ b/platform/dental-backend/jest.config.js
@@ -1,0 +1,6 @@
+const base = require('../../jest.config.base.js');
+
+module.exports = {
+  ...base,
+  testEnvironment: 'node',
+};

--- a/platform/dental-backend/package.json
+++ b/platform/dental-backend/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@ohif/dental-backend",
+  "version": "3.13.0-beta.93",
+  "description": "Authenticated backend for Dental Mode viewer state and study measurements",
+  "author": "OHIF Contributors",
+  "license": "MIT",
+  "repository": "OHIF/Viewers",
+  "main": "src/index.js",
+  "engines": {
+    "node": ">=24"
+  },
+  "scripts": {
+    "start": "node src/index.js",
+    "dev": "node src/index.js",
+    "test:unit": "jest --watchAll",
+    "test:unit:ci": "jest --ci --runInBand --collectCoverage --passWithNoTests"
+  },
+  "keywords": [
+    "ohif",
+    "dental",
+    "backend"
+  ]
+}

--- a/platform/dental-backend/src/auth.js
+++ b/platform/dental-backend/src/auth.js
@@ -1,0 +1,47 @@
+class AuthError extends Error {
+  constructor(message, statusCode = 401) {
+    super(message);
+    this.name = 'AuthError';
+    this.statusCode = statusCode;
+  }
+}
+
+function getHeader(headers, name) {
+  if (!headers) {
+    return undefined;
+  }
+
+  if (typeof headers.get === 'function') {
+    return headers.get(name);
+  }
+
+  const lowerName = name.toLowerCase();
+  return headers[name] || headers[lowerName];
+}
+
+function authenticateRequest(headers, { authToken, userId }) {
+  const authorization = getHeader(headers, 'authorization');
+
+  if (!authorization) {
+    throw new AuthError('Missing bearer token');
+  }
+
+  const match = /^Bearer\s+(.+)$/i.exec(authorization.trim());
+
+  if (!match) {
+    throw new AuthError('Invalid authorization scheme');
+  }
+
+  if (match[1] !== authToken) {
+    throw new AuthError('Invalid bearer token', 403);
+  }
+
+  return {
+    userId,
+  };
+}
+
+module.exports = {
+  AuthError,
+  authenticateRequest,
+};

--- a/platform/dental-backend/src/config.js
+++ b/platform/dental-backend/src/config.js
@@ -1,0 +1,16 @@
+const path = require('path');
+
+function getConfig(env = process.env) {
+  return {
+    authToken: env.DENTAL_BACKEND_AUTH_TOKEN || 'dev-dental-token',
+    userId: env.DENTAL_BACKEND_USER_ID || 'dev-user',
+    port: Number(env.DENTAL_BACKEND_PORT || 4007),
+    databasePath:
+      env.DENTAL_BACKEND_SQLITE_PATH ||
+      path.join(process.cwd(), '.scratch', 'dental-backend.sqlite'),
+  };
+}
+
+module.exports = {
+  getConfig,
+};

--- a/platform/dental-backend/src/http.js
+++ b/platform/dental-backend/src/http.js
@@ -1,0 +1,161 @@
+const http = require('http');
+const { randomUUID } = require('crypto');
+const { URL } = require('url');
+
+const { AuthError, authenticateRequest } = require('./auth');
+
+function json(statusCode, body) {
+  return {
+    statusCode,
+    headers: {
+      'content-type': 'application/json; charset=utf-8',
+    },
+    body: JSON.stringify(body),
+  };
+}
+
+function notFound() {
+  return json(404, { error: 'Not found' });
+}
+
+function parseJsonBody(body) {
+  if (!body) {
+    return {};
+  }
+
+  try {
+    return JSON.parse(body);
+  } catch (error) {
+    return undefined;
+  }
+}
+
+async function handleDentalRequest({ method, url, headers, body }, { store, config }) {
+  const parsedUrl = new URL(url, 'http://localhost');
+  const parts = parsedUrl.pathname.split('/').filter(Boolean).map(decodeURIComponent);
+
+  if (parts.length === 1 && parts[0] === 'health') {
+    return json(200, { ok: true });
+  }
+
+  if (parts[0] !== 'api' || parts[1] !== 'dental') {
+    return notFound();
+  }
+
+  let session;
+
+  try {
+    session = authenticateRequest(headers, config);
+  } catch (error) {
+    if (error instanceof AuthError) {
+      return json(error.statusCode, { error: error.message });
+    }
+
+    throw error;
+  }
+
+  if (parts[2] === 'state' && parts.length === 4) {
+    const studyInstanceUID = parts[3];
+
+    if (method === 'GET') {
+      const state = await store.getViewerState(session.userId, studyInstanceUID);
+      return json(200, { studyInstanceUID, state: state?.state || null, updatedAt: state?.updatedAt || null });
+    }
+
+    if (method === 'PUT') {
+      const payload = parseJsonBody(body);
+
+      if (!payload || typeof payload.state !== 'object' || payload.state === null) {
+        return json(400, { error: 'Expected JSON body with object field "state"' });
+      }
+
+      const state = await store.putViewerState(session.userId, studyInstanceUID, payload.state);
+      return json(200, { studyInstanceUID, state: state.state, updatedAt: state.updatedAt });
+    }
+  }
+
+  if (parts[2] === 'measurements' && parts.length === 4) {
+    const studyInstanceUID = parts[3];
+
+    if (method === 'GET') {
+      const measurements = await store.listMeasurements(session.userId, studyInstanceUID);
+      return json(200, { studyInstanceUID, measurements });
+    }
+
+    if (method === 'POST') {
+      const payload = parseJsonBody(body);
+
+      if (!payload || typeof payload.label !== 'string' || typeof payload.unit !== 'string') {
+        return json(400, { error: 'Expected measurement label and unit' });
+      }
+
+      const measurement = await store.createMeasurement(session.userId, studyInstanceUID, {
+        id: payload.id || randomUUID(),
+        label: payload.label,
+        value: Number.isFinite(Number(payload.value)) ? Number(payload.value) : null,
+        unit: payload.unit,
+        toolName: payload.toolName || null,
+        annotationUID: payload.annotationUID || null,
+        toothId: payload.toothId || null,
+        notes: payload.notes || null,
+        metadata: payload.metadata || {},
+      });
+
+      return json(201, { studyInstanceUID, measurement });
+    }
+  }
+
+  if (parts[2] === 'measurements' && parts.length === 5 && method === 'DELETE') {
+    const studyInstanceUID = parts[3];
+    const measurementId = parts[4];
+    const deleted = await store.deleteMeasurement(session.userId, studyInstanceUID, measurementId);
+
+    if (!deleted) {
+      return json(404, { error: 'Measurement not found' });
+    }
+
+    return json(200, { studyInstanceUID, deleted: true, id: measurementId });
+  }
+
+  return notFound();
+}
+
+function readBody(req) {
+  return new Promise((resolve, reject) => {
+    let data = '';
+
+    req.setEncoding('utf8');
+    req.on('data', chunk => {
+      data += chunk;
+    });
+    req.on('end', () => resolve(data));
+    req.on('error', reject);
+  });
+}
+
+function createServer({ store, config }) {
+  return http.createServer(async (req, res) => {
+    try {
+      const response = await handleDentalRequest(
+        {
+          method: req.method,
+          url: req.url,
+          headers: req.headers,
+          body: await readBody(req),
+        },
+        { store, config }
+      );
+
+      res.writeHead(response.statusCode, response.headers);
+      res.end(response.body);
+    } catch (error) {
+      res.writeHead(500, { 'content-type': 'application/json; charset=utf-8' });
+      res.end(JSON.stringify({ error: 'Internal server error' }));
+    }
+  });
+}
+
+module.exports = {
+  createServer,
+  handleDentalRequest,
+};

--- a/platform/dental-backend/src/http.js
+++ b/platform/dental-backend/src/http.js
@@ -97,15 +97,21 @@ async function handleDentalRequest({ method, url, headers, body }, { store, conf
       }
 
       const measurement = await store.createMeasurement(session.userId, studyInstanceUID, {
-        id: payload.id || randomUUID(),
+        id: randomUUID(),
+        presetId: payload.presetId || null,
         label: payload.label,
         value: Number.isFinite(Number(payload.value)) ? Number(payload.value) : null,
         unit: payload.unit,
         toolName: payload.toolName || null,
         annotationUID: payload.annotationUID || null,
         toothId: payload.toothId || null,
-        notes: payload.notes || null,
+        note: payload.note || payload.notes || null,
+        viewportId: payload.viewportId || null,
+        displaySetInstanceUID: payload.displaySetInstanceUID || null,
+        referenceSeriesUID: payload.referenceSeriesUID || null,
+        points: Array.isArray(payload.points) ? payload.points : undefined,
         metadata: payload.metadata || {},
+        createdAt: payload.createdAt,
       });
 
       return json(201, { studyInstanceUID, measurement });

--- a/platform/dental-backend/src/http.js
+++ b/platform/dental-backend/src/http.js
@@ -9,6 +9,9 @@ function json(statusCode, body) {
     statusCode,
     headers: {
       'content-type': 'application/json; charset=utf-8',
+      'access-control-allow-origin': '*',
+      'access-control-allow-methods': 'GET, PUT, POST, DELETE, OPTIONS',
+      'access-control-allow-headers': 'authorization, content-type',
     },
     body: JSON.stringify(body),
   };
@@ -33,6 +36,10 @@ function parseJsonBody(body) {
 async function handleDentalRequest({ method, url, headers, body }, { store, config }) {
   const parsedUrl = new URL(url, 'http://localhost');
   const parts = parsedUrl.pathname.split('/').filter(Boolean).map(decodeURIComponent);
+
+  if (method === 'OPTIONS') {
+    return json(204, {});
+  }
 
   if (parts.length === 1 && parts[0] === 'health') {
     return json(200, { ok: true });

--- a/platform/dental-backend/src/http.test.js
+++ b/platform/dental-backend/src/http.test.js
@@ -1,0 +1,170 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { handleDentalRequest } = require('./http');
+const { DentalSQLiteStore } = require('./sqliteStore');
+
+const config = {
+  authToken: 'test-token',
+  userId: 'user-a',
+};
+
+function request(store, options) {
+  return handleDentalRequest(
+    {
+      method: options.method || 'GET',
+      url: options.url,
+      headers: {
+        authorization: options.authorization || 'Bearer test-token',
+      },
+      body: options.body ? JSON.stringify(options.body) : '',
+    },
+    { store, config: { ...config, userId: options.userId || config.userId } }
+  );
+}
+
+function parse(response) {
+  return JSON.parse(response.body);
+}
+
+describe('Dental backend API', () => {
+  let dir;
+  let store;
+
+  beforeEach(async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ohif-dental-backend-'));
+    store = await DentalSQLiteStore.create({ databasePath: path.join(dir, 'dental.sqlite') });
+  });
+
+  afterEach(() => {
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('rejects missing and invalid bearer auth', async () => {
+    const missing = await handleDentalRequest(
+      { method: 'GET', url: '/api/dental/state/1.2.3', headers: {}, body: '' },
+      { store, config }
+    );
+    const invalid = await request(store, {
+      url: '/api/dental/state/1.2.3',
+      authorization: 'Bearer wrong-token',
+    });
+
+    expect(missing.statusCode).toBe(401);
+    expect(invalid.statusCode).toBe(403);
+  });
+
+  it('persists viewer state per user and study', async () => {
+    const saved = await request(store, {
+      method: 'PUT',
+      url: '/api/dental/state/study-a',
+      body: {
+        state: {
+          selectedToothId: 'FDI-46',
+          numberingSystem: 'FDI',
+          dentalTheme: true,
+        },
+      },
+    });
+    const sameUserSameStudy = await request(store, { url: '/api/dental/state/study-a' });
+    const sameUserOtherStudy = await request(store, { url: '/api/dental/state/study-b' });
+    const otherUserSameStudy = await request(store, {
+      url: '/api/dental/state/study-a',
+      userId: 'user-b',
+    });
+
+    expect(saved.statusCode).toBe(200);
+    expect(parse(sameUserSameStudy).state.selectedToothId).toBe('FDI-46');
+    expect(parse(sameUserOtherStudy).state).toBeNull();
+    expect(parse(otherUserSameStudy).state).toBeNull();
+  });
+
+  it('creates, lists, and deletes measurements per user and study', async () => {
+    const created = await request(store, {
+      method: 'POST',
+      url: '/api/dental/measurements/study-a',
+      body: {
+        id: 'measurement-1',
+        label: 'PA length',
+        value: 12.5,
+        unit: 'mm',
+        toolName: 'Length',
+        annotationUID: 'annotation-1',
+        metadata: { source: 'preset' },
+      },
+    });
+    const listed = await request(store, { url: '/api/dental/measurements/study-a' });
+    const otherStudy = await request(store, { url: '/api/dental/measurements/study-b' });
+    const otherUser = await request(store, {
+      url: '/api/dental/measurements/study-a',
+      userId: 'user-b',
+    });
+    const deleted = await request(store, {
+      method: 'DELETE',
+      url: '/api/dental/measurements/study-a/measurement-1',
+    });
+    const afterDelete = await request(store, { url: '/api/dental/measurements/study-a' });
+
+    expect(created.statusCode).toBe(201);
+    expect(parse(created).measurement.label).toBe('PA length');
+    expect(parse(listed).measurements).toHaveLength(1);
+    expect(parse(otherStudy).measurements).toHaveLength(0);
+    expect(parse(otherUser).measurements).toHaveLength(0);
+    expect(deleted.statusCode).toBe(200);
+    expect(parse(afterDelete).measurements).toHaveLength(0);
+  });
+
+  it('persists state and measurements to the SQLite file', async () => {
+    const databasePath = path.join(dir, 'persistent.sqlite');
+    const persistentStore = await DentalSQLiteStore.create({ databasePath });
+
+    await request(persistentStore, {
+      method: 'PUT',
+      url: '/api/dental/state/study-a',
+      body: { state: { selectedToothId: 'FDI-11' } },
+    });
+    await request(persistentStore, {
+      method: 'POST',
+      url: '/api/dental/measurements/study-a',
+      body: {
+        id: 'measurement-1',
+        label: 'Root length',
+        value: 18,
+        unit: 'mm',
+      },
+    });
+    persistentStore.close();
+
+    const reopenedStore = await DentalSQLiteStore.create({ databasePath });
+    const state = await request(reopenedStore, { url: '/api/dental/state/study-a' });
+    const measurements = await request(reopenedStore, { url: '/api/dental/measurements/study-a' });
+
+    expect(parse(state).state.selectedToothId).toBe('FDI-11');
+    expect(parse(measurements).measurements[0].label).toBe('Root length');
+
+    reopenedStore.close();
+  });
+
+  it('returns 404 when deleting another user measurement', async () => {
+    await request(store, {
+      method: 'POST',
+      url: '/api/dental/measurements/study-a',
+      body: {
+        id: 'measurement-1',
+        label: 'Canal angle',
+        value: 37,
+        unit: 'deg',
+      },
+    });
+
+    const deleted = await request(store, {
+      method: 'DELETE',
+      url: '/api/dental/measurements/study-a/measurement-1',
+      userId: 'user-b',
+    });
+
+    expect(deleted.statusCode).toBe(404);
+  });
+});

--- a/platform/dental-backend/src/http.test.js
+++ b/platform/dental-backend/src/http.test.js
@@ -56,6 +56,17 @@ describe('Dental backend API', () => {
     expect(invalid.statusCode).toBe(403);
   });
 
+  it('allows browser CORS preflight without auth', async () => {
+    const preflight = await handleDentalRequest(
+      { method: 'OPTIONS', url: '/api/dental/state/1.2.3', headers: {}, body: '' },
+      { store, config }
+    );
+
+    expect(preflight.statusCode).toBe(204);
+    expect(preflight.headers['access-control-allow-origin']).toBe('*');
+    expect(preflight.headers['access-control-allow-headers']).toContain('authorization');
+  });
+
   it('persists viewer state per user and study', async () => {
     const saved = await request(store, {
       method: 'PUT',

--- a/platform/dental-backend/src/http.test.js
+++ b/platform/dental-backend/src/http.test.js
@@ -97,12 +97,18 @@ describe('Dental backend API', () => {
       method: 'POST',
       url: '/api/dental/measurements/study-a',
       body: {
-        id: 'measurement-1',
         label: 'PA length',
         value: 12.5,
         unit: 'mm',
         toolName: 'Length',
         annotationUID: 'annotation-1',
+        presetId: 'pa-length',
+        toothId: 'permanent-1',
+        note: 'Distal root',
+        viewportId: 'dental-current',
+        displaySetInstanceUID: 'display-set-1',
+        referenceSeriesUID: 'series-1',
+        points: [[1, 2, 3], [4, 5, 6]],
         metadata: { source: 'preset' },
       },
     });
@@ -112,19 +118,54 @@ describe('Dental backend API', () => {
       url: '/api/dental/measurements/study-a',
       userId: 'user-b',
     });
+    const measurementId = parse(created).measurement.id;
     const deleted = await request(store, {
       method: 'DELETE',
-      url: '/api/dental/measurements/study-a/measurement-1',
+      url: `/api/dental/measurements/study-a/${measurementId}`,
     });
     const afterDelete = await request(store, { url: '/api/dental/measurements/study-a' });
 
     expect(created.statusCode).toBe(201);
     expect(parse(created).measurement.label).toBe('PA length');
+    expect(parse(created).measurement).toEqual(
+      expect.objectContaining({
+        presetId: 'pa-length',
+        toothId: 'permanent-1',
+        note: 'Distal root',
+        viewportId: 'dental-current',
+        displaySetInstanceUID: 'display-set-1',
+        referenceSeriesUID: 'series-1',
+        points: [[1, 2, 3], [4, 5, 6]],
+      })
+    );
     expect(parse(listed).measurements).toHaveLength(1);
     expect(parse(otherStudy).measurements).toHaveLength(0);
     expect(parse(otherUser).measurements).toHaveLength(0);
     expect(deleted.statusCode).toBe(200);
     expect(parse(afterDelete).measurements).toHaveLength(0);
+  });
+
+  it('upserts measurements by annotation UID', async () => {
+    const create = body =>
+      request(store, {
+        method: 'POST',
+        url: '/api/dental/measurements/study-a',
+        body: {
+          annotationUID: 'annotation-1',
+          presetId: 'pa-length',
+          label: 'PA length',
+          unit: 'mm',
+          toothId: 'permanent-1',
+          ...body,
+        },
+      });
+
+    await create({ value: 12 });
+    await create({ value: 14.5 });
+    const listed = await request(store, { url: '/api/dental/measurements/study-a' });
+
+    expect(parse(listed).measurements).toHaveLength(1);
+    expect(parse(listed).measurements[0].value).toBe(14.5);
   });
 
   it('persists state and measurements to the SQLite file', async () => {
@@ -140,7 +181,6 @@ describe('Dental backend API', () => {
       method: 'POST',
       url: '/api/dental/measurements/study-a',
       body: {
-        id: 'measurement-1',
         label: 'Root length',
         value: 18,
         unit: 'mm',
@@ -163,16 +203,17 @@ describe('Dental backend API', () => {
       method: 'POST',
       url: '/api/dental/measurements/study-a',
       body: {
-        id: 'measurement-1',
         label: 'Canal angle',
         value: 37,
         unit: 'deg',
       },
     });
 
+    const listed = await request(store, { url: '/api/dental/measurements/study-a' });
+    const measurementId = parse(listed).measurements[0].id;
     const deleted = await request(store, {
       method: 'DELETE',
-      url: '/api/dental/measurements/study-a/measurement-1',
+      url: `/api/dental/measurements/study-a/${measurementId}`,
       userId: 'user-b',
     });
 

--- a/platform/dental-backend/src/index.js
+++ b/platform/dental-backend/src/index.js
@@ -1,0 +1,29 @@
+const { getConfig } = require('./config');
+const { createServer } = require('./http');
+const { DentalSQLiteStore } = require('./sqliteStore');
+
+async function start() {
+  const config = getConfig();
+  const store = await DentalSQLiteStore.create({ databasePath: config.databasePath });
+  const server = createServer({ store, config });
+
+  server.listen(config.port, () => {
+    // eslint-disable-next-line no-console
+    console.log(`Dental backend listening on http://localhost:${config.port}`);
+  });
+}
+
+if (require.main === module) {
+  start().catch(error => {
+    // eslint-disable-next-line no-console
+    console.error(error);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  start,
+  getConfig,
+  createServer,
+  DentalSQLiteStore,
+};

--- a/platform/dental-backend/src/sqliteStore.js
+++ b/platform/dental-backend/src/sqliteStore.js
@@ -10,13 +10,18 @@ function rowToMeasurement(record) {
   return {
     id: record.id,
     studyInstanceUID: record.study_instance_uid,
+    presetId: record.preset_id,
     label: record.label,
     value: record.value,
     unit: record.unit,
     toolName: record.tool_name,
     annotationUID: record.annotation_uid,
     toothId: record.tooth_id,
-    notes: record.notes,
+    note: record.notes,
+    viewportId: record.viewport_id,
+    displaySetInstanceUID: record.display_set_instance_uid,
+    referenceSeriesUID: record.reference_series_uid,
+    points: record.geometry_json ? JSON.parse(record.geometry_json) : undefined,
     metadata: record.metadata_json ? JSON.parse(record.metadata_json) : {},
     createdAt: record.created_at,
     updatedAt: record.updated_at,
@@ -72,6 +77,19 @@ class DentalSQLiteStore {
       CREATE INDEX IF NOT EXISTS idx_dental_measurements_owner_study
       ON dental_measurements (user_id, study_instance_uid);
     `);
+
+    this.ensureMeasurementColumn('preset_id', 'TEXT');
+    this.ensureMeasurementColumn('viewport_id', 'TEXT');
+    this.ensureMeasurementColumn('display_set_instance_uid', 'TEXT');
+    this.ensureMeasurementColumn('reference_series_uid', 'TEXT');
+    this.ensureMeasurementColumn('geometry_json', 'TEXT');
+  }
+
+  ensureMeasurementColumn(name, type) {
+    const columns = this.db.prepare('PRAGMA table_info(dental_measurements)').all();
+    if (!columns.some(column => column.name === name)) {
+      this.db.exec(`ALTER TABLE dental_measurements ADD COLUMN ${name} ${type}`);
+    }
   }
 
   async getViewerState(userId, studyInstanceUID) {
@@ -115,11 +133,12 @@ class DentalSQLiteStore {
     const rows = this.db
       .prepare(
         `
-      SELECT id, study_instance_uid, label, value, unit, tool_name, annotation_uid, tooth_id,
-             notes, metadata_json, created_at, updated_at
+      SELECT id, study_instance_uid, preset_id, label, value, unit, tool_name, annotation_uid,
+             tooth_id, notes, viewport_id, display_set_instance_uid, reference_series_uid,
+             geometry_json, metadata_json, created_at, updated_at
       FROM dental_measurements
       WHERE user_id = ? AND study_instance_uid = ?
-      ORDER BY created_at ASC
+      ORDER BY created_at DESC
       `
       )
       .all(userId, studyInstanceUID);
@@ -128,35 +147,66 @@ class DentalSQLiteStore {
   }
 
   async createMeasurement(userId, studyInstanceUID, measurement) {
-    const createdAt = nowIso();
+    const existing = measurement.annotationUID
+      ? this.db
+          .prepare(
+            `SELECT id FROM dental_measurements
+             WHERE user_id = ? AND study_instance_uid = ? AND annotation_uid = ?`
+          )
+          .get(userId, studyInstanceUID, measurement.annotationUID)
+      : null;
+    const createdAt = measurement.createdAt || nowIso();
+    const updatedAt = nowIso();
     const record = {
       ...measurement,
+      id: existing?.id || measurement.id,
       metadata: measurement.metadata || {},
       createdAt,
-      updatedAt: createdAt,
+      updatedAt,
     };
 
     this.db
       .prepare(
         `
       INSERT INTO dental_measurements (
-        id, user_id, study_instance_uid, label, value, unit, tool_name,
-        annotation_uid, tooth_id, notes, metadata_json, created_at, updated_at
+        id, user_id, study_instance_uid, preset_id, label, value, unit, tool_name,
+        annotation_uid, tooth_id, notes, viewport_id, display_set_instance_uid,
+        reference_series_uid, geometry_json, metadata_json, created_at, updated_at
       )
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(id) DO UPDATE SET
+        preset_id = excluded.preset_id,
+        label = excluded.label,
+        value = excluded.value,
+        unit = excluded.unit,
+        tool_name = excluded.tool_name,
+        annotation_uid = excluded.annotation_uid,
+        tooth_id = excluded.tooth_id,
+        notes = excluded.notes,
+        viewport_id = excluded.viewport_id,
+        display_set_instance_uid = excluded.display_set_instance_uid,
+        reference_series_uid = excluded.reference_series_uid,
+        geometry_json = excluded.geometry_json,
+        metadata_json = excluded.metadata_json,
+        updated_at = excluded.updated_at
       `
       )
       .run(
         record.id,
         userId,
         studyInstanceUID,
+        record.presetId,
         record.label,
         record.value,
         record.unit,
         record.toolName,
         record.annotationUID,
         record.toothId,
-        record.notes,
+        record.note,
+        record.viewportId,
+        record.displaySetInstanceUID,
+        record.referenceSeriesUID,
+        record.points ? JSON.stringify(record.points) : null,
         JSON.stringify(record.metadata),
         record.createdAt,
         record.updatedAt
@@ -170,8 +220,11 @@ class DentalSQLiteStore {
 
   async deleteMeasurement(userId, studyInstanceUID, id) {
     const result = this.db
-      .prepare('DELETE FROM dental_measurements WHERE user_id = ? AND study_instance_uid = ? AND id = ?')
-      .run(userId, studyInstanceUID, id);
+      .prepare(
+        `DELETE FROM dental_measurements
+         WHERE user_id = ? AND study_instance_uid = ? AND (id = ? OR annotation_uid = ?)`
+      )
+      .run(userId, studyInstanceUID, id, id);
 
     return result.changes > 0;
   }

--- a/platform/dental-backend/src/sqliteStore.js
+++ b/platform/dental-backend/src/sqliteStore.js
@@ -1,0 +1,186 @@
+const fs = require('fs');
+const path = require('path');
+const { DatabaseSync } = require('node:sqlite');
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function rowToMeasurement(record) {
+  return {
+    id: record.id,
+    studyInstanceUID: record.study_instance_uid,
+    label: record.label,
+    value: record.value,
+    unit: record.unit,
+    toolName: record.tool_name,
+    annotationUID: record.annotation_uid,
+    toothId: record.tooth_id,
+    notes: record.notes,
+    metadata: record.metadata_json ? JSON.parse(record.metadata_json) : {},
+    createdAt: record.created_at,
+    updatedAt: record.updated_at,
+  };
+}
+
+class DentalSQLiteStore {
+  constructor({ databasePath }) {
+    this.databasePath = databasePath;
+    this.db = this.openDatabase();
+    this.migrate();
+  }
+
+  static async create({ databasePath }) {
+    return new DentalSQLiteStore({ databasePath });
+  }
+
+  openDatabase() {
+    if (!this.databasePath) {
+      return new DatabaseSync(':memory:');
+    }
+
+    fs.mkdirSync(path.dirname(this.databasePath), { recursive: true });
+    return new DatabaseSync(this.databasePath);
+  }
+
+  migrate() {
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS dental_viewer_state (
+        user_id TEXT NOT NULL,
+        study_instance_uid TEXT NOT NULL,
+        state_json TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        PRIMARY KEY (user_id, study_instance_uid)
+      );
+
+      CREATE TABLE IF NOT EXISTS dental_measurements (
+        id TEXT PRIMARY KEY,
+        user_id TEXT NOT NULL,
+        study_instance_uid TEXT NOT NULL,
+        label TEXT NOT NULL,
+        value REAL,
+        unit TEXT NOT NULL,
+        tool_name TEXT,
+        annotation_uid TEXT,
+        tooth_id TEXT,
+        notes TEXT,
+        metadata_json TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_dental_measurements_owner_study
+      ON dental_measurements (user_id, study_instance_uid);
+    `);
+  }
+
+  async getViewerState(userId, studyInstanceUID) {
+    const row = this.db
+      .prepare(
+        'SELECT state_json, updated_at FROM dental_viewer_state WHERE user_id = ? AND study_instance_uid = ?'
+      )
+      .get(userId, studyInstanceUID);
+
+    if (!row) {
+      return null;
+    }
+
+    return {
+      state: JSON.parse(row.state_json),
+      updatedAt: row.updated_at,
+    };
+  }
+
+  async putViewerState(userId, studyInstanceUID, state) {
+    const updatedAt = nowIso();
+
+    this.db
+      .prepare(
+        `
+      INSERT INTO dental_viewer_state (user_id, study_instance_uid, state_json, updated_at)
+      VALUES (?, ?, ?, ?)
+      ON CONFLICT(user_id, study_instance_uid)
+      DO UPDATE SET state_json = excluded.state_json, updated_at = excluded.updated_at
+      `
+      )
+      .run(userId, studyInstanceUID, JSON.stringify(state), updatedAt);
+
+    return {
+      state,
+      updatedAt,
+    };
+  }
+
+  async listMeasurements(userId, studyInstanceUID) {
+    const rows = this.db
+      .prepare(
+        `
+      SELECT id, study_instance_uid, label, value, unit, tool_name, annotation_uid, tooth_id,
+             notes, metadata_json, created_at, updated_at
+      FROM dental_measurements
+      WHERE user_id = ? AND study_instance_uid = ?
+      ORDER BY created_at ASC
+      `
+      )
+      .all(userId, studyInstanceUID);
+
+    return rows.map(rowToMeasurement);
+  }
+
+  async createMeasurement(userId, studyInstanceUID, measurement) {
+    const createdAt = nowIso();
+    const record = {
+      ...measurement,
+      metadata: measurement.metadata || {},
+      createdAt,
+      updatedAt: createdAt,
+    };
+
+    this.db
+      .prepare(
+        `
+      INSERT INTO dental_measurements (
+        id, user_id, study_instance_uid, label, value, unit, tool_name,
+        annotation_uid, tooth_id, notes, metadata_json, created_at, updated_at
+      )
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `
+      )
+      .run(
+        record.id,
+        userId,
+        studyInstanceUID,
+        record.label,
+        record.value,
+        record.unit,
+        record.toolName,
+        record.annotationUID,
+        record.toothId,
+        record.notes,
+        JSON.stringify(record.metadata),
+        record.createdAt,
+        record.updatedAt
+      );
+
+    return {
+      ...record,
+      studyInstanceUID,
+    };
+  }
+
+  async deleteMeasurement(userId, studyInstanceUID, id) {
+    const result = this.db
+      .prepare('DELETE FROM dental_measurements WHERE user_id = ? AND study_instance_uid = ? AND id = ?')
+      .run(userId, studyInstanceUID, id);
+
+    return result.changes > 0;
+  }
+
+  close() {
+    this.db.close();
+  }
+}
+
+module.exports = {
+  DentalSQLiteStore,
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -568,6 +568,40 @@ importers:
         specifier: 5.10.0
         version: 5.10.0
 
+  extensions/dental:
+    dependencies:
+      '@babel/runtime':
+        specifier: 7.29.7
+        version: 7.29.7
+      '@ohif/core':
+        specifier: workspace:*
+        version: link:../../platform/core
+      '@ohif/extension-default':
+        specifier: workspace:*
+        version: link:../default
+      '@ohif/ui-next':
+        specifier: workspace:*
+        version: link:../../platform/ui-next
+      prop-types:
+        specifier: 15.8.1
+        version: 15.8.1
+      react:
+        specifier: 18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: 18.3.1
+        version: 18.3.1(react@18.3.1)
+      react-i18next:
+        specifier: 12.3.1
+        version: 12.3.1(i18next@17.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-router-dom:
+        specifier: 6.30.3
+        version: 6.30.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+    devDependencies:
+      webpack-merge:
+        specifier: 5.10.0
+        version: 5.10.0
+
   extensions/dicom-microscopy:
     dependencies:
       '@babel/runtime':
@@ -1011,6 +1045,28 @@ importers:
       '@ohif/extension-test':
         specifier: workspace:*
         version: link:../../extensions/test-extension
+      i18next:
+        specifier: 17.3.1
+        version: 17.3.1
+    devDependencies:
+      webpack-merge:
+        specifier: 5.10.0
+        version: 5.10.0
+
+  modes/dental:
+    dependencies:
+      '@babel/runtime':
+        specifier: 7.29.7
+        version: 7.29.7
+      '@ohif/core':
+        specifier: workspace:*
+        version: link:../../platform/core
+      '@ohif/extension-dental':
+        specifier: workspace:*
+        version: link:../../extensions/dental
+      '@ohif/mode-basic':
+        specifier: workspace:*
+        version: link:../basic
       i18next:
         specifier: 17.3.1
         version: 17.3.1
@@ -16296,7 +16352,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/traverse@7.29.7':
+  '@babel/traverse@7.29.7(supports-color@8.1.1)':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
@@ -16949,7 +17005,7 @@ snapshots:
       '@babel/preset-env': 7.29.5(@babel/core@7.28.0)
       '@babel/preset-react': 7.27.1(@babel/core@7.28.0)
       '@babel/preset-typescript': 7.27.1(@babel/core@7.28.0)
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       '@babel/runtime-corejs3': 7.29.0
       '@babel/traverse': 7.29.0(supports-color@8.1.1)
       '@docusaurus/logger': 3.7.0
@@ -17959,7 +18015,7 @@ snapshots:
 
   '@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       '@emotion/babel-plugin': 11.13.5
       '@emotion/cache': 11.14.0
       '@emotion/serialize': 1.3.3
@@ -19741,7 +19797,7 @@ snapshots:
   '@testing-library/dom@8.20.1':
     dependencies:
       '@babel/code-frame': 7.29.0
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       '@types/aria-query': 5.0.4
       aria-query: 5.1.3
       chalk: 4.1.2
@@ -19751,7 +19807,7 @@ snapshots:
 
   '@testing-library/react@13.4.0(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       '@testing-library/dom': 8.20.1
       '@types/react-dom': 18.3.7(@types/react@18.3.23)
       react: 18.3.1
@@ -23225,7 +23281,7 @@ snapshots:
 
   history@5.3.0:
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
 
   hmac-drbg@1.0.1:
     dependencies:
@@ -23398,11 +23454,11 @@ snapshots:
 
   i18next-locize-backend@2.2.2:
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
 
   i18next@17.3.1:
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
 
   iconv-lite@0.4.24:
     dependencies:
@@ -24565,7 +24621,7 @@ snapshots:
 
   locize-editor@2.2.2:
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
 
   locize-lastused@1.1.1: {}
 
@@ -24701,7 +24757,7 @@ snapshots:
 
   mathjs@12.4.3:
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       complex.js: 2.4.3
       decimal.js: 10.6.0
       escape-latex: 1.2.0
@@ -27462,7 +27518,7 @@ snapshots:
 
   react-error-boundary@3.1.4(react@18.3.1):
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       react: 18.3.1
 
   react-error-overlay@6.1.0: {}
@@ -27471,7 +27527,7 @@ snapshots:
 
   react-helmet-async@1.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       invariant: 2.2.4
       prop-types: 15.8.1
       react: 18.3.1
@@ -27481,7 +27537,7 @@ snapshots:
 
   react-i18next@12.3.1(i18next@17.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       html-parse-stringify: 3.0.1
       i18next: 17.3.1
       react: 18.3.1
@@ -27510,7 +27566,7 @@ snapshots:
 
   react-loadable-ssr-addon-v5-slorber@1.0.1(@docusaurus/react-loadable@6.0.0(react@18.3.1))(webpack@5.105.0(@swc/core@1.15.13(@swc/helpers@0.5.21))):
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@18.3.1)'
       webpack: 5.105.0(@swc/core@1.15.13(@swc/helpers@0.5.21))
 
@@ -27577,13 +27633,13 @@ snapshots:
 
   react-router-config@5.1.1(react-router@5.3.4(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       react: 18.3.1
       react-router: 5.3.4(react@18.3.1)
 
   react-router-dom@5.3.4(react@18.3.1):
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       history: 4.10.1
       loose-envify: 1.4.0
       prop-types: 15.8.1
@@ -27601,7 +27657,7 @@ snapshots:
 
   react-router@5.3.4(react@18.3.1):
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       history: 4.10.1
       hoist-non-react-statics: 3.3.2
       loose-envify: 1.4.0
@@ -27619,7 +27675,7 @@ snapshots:
 
   react-select@5.7.4(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       '@emotion/cache': 11.14.0
       '@emotion/react': 11.14.0(@types/react@18.3.23)(react@18.3.1)
       '@floating-ui/dom': 1.7.5
@@ -27664,7 +27720,7 @@ snapshots:
 
   react-transition-group@4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       dom-helpers: 5.2.1
       loose-envify: 1.4.0
       prop-types: 15.8.1
@@ -27673,7 +27729,7 @@ snapshots:
 
   react-waypoint@10.3.0(react@18.3.1):
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       consolidated-events: 2.0.2
       prop-types: 15.8.1
       react: 18.3.1
@@ -29656,7 +29712,7 @@ snapshots:
       '@apideck/better-ajv-errors': 0.3.6(ajv@8.18.0)
       '@babel/core': 7.28.0
       '@babel/preset-env': 7.29.5(@babel/core@7.28.0)
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       '@rollup/plugin-babel': 5.3.1(@babel/core@7.28.0)(@types/babel__core@7.20.5)(rollup@2.80.0)
       '@rollup/plugin-node-resolve': 15.3.1(rollup@2.80.0)
       '@rollup/plugin-replace': 2.4.2(rollup@2.80.0)

--- a/tests/DentalMode.spec.ts
+++ b/tests/DentalMode.spec.ts
@@ -1,0 +1,81 @@
+import { addOHIFConfiguration, expect, test, visitStudy } from './utils';
+
+const studyInstanceUID = '1.3.6.1.4.1.25403.345050719074.3824.20170125095438.5';
+
+test.beforeEach(async ({ page }) => {
+  await addOHIFConfiguration(page, {
+    modes: ['@ohif/mode-test', '@ohif/mode-dental'],
+    dental: {
+      practiceName: 'E2E Dental Practice',
+      backendUrl: 'http://localhost:4007/api/dental',
+      backendAuthToken: 'e2e-dental-token',
+    },
+  });
+
+  await page.route('http://localhost:4007/api/dental/state/**', async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        studyInstanceUID,
+        state: null,
+        updatedAt: null,
+      }),
+    });
+  });
+  await page.route('http://localhost:4007/api/dental/measurements/**', async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        studyInstanceUID,
+        measurements: [],
+      }),
+    });
+  });
+
+  await visitStudy(page, studyInstanceUID, 'dental', 2000, 'ohif');
+});
+
+test('opens Dental Mode and exposes its critical workflow surfaces', async ({ page }) => {
+  await expect(page).toHaveURL(/\/dental\/ohif\?/);
+
+  const practiceHeader = page.getByTestId('dental-practice-header');
+  await expect(practiceHeader).toBeVisible();
+  await expect(practiceHeader).toContainText('E2E Dental Practice');
+  await expect(practiceHeader).toContainText('Dental Mode');
+
+  const patientSummary = page.getByTestId('dental-patient-summary');
+  await expect(patientSummary).toBeVisible();
+  await expect(patientSummary).not.toContainText('No ID');
+  await expect(patientSummary).not.toContainText('No modality');
+  await expect(patientSummary).not.toContainText('No study date');
+
+  await expect(page.getByTestId('dental-tooth-selector')).toBeVisible();
+  await expect(page.getByTestId('dental-numbering-system-fdi')).toBeVisible();
+  await expect(page.getByTestId('dental-numbering-system-universal')).toBeVisible();
+  await expect(page.getByTestId('dental-selected-tooth')).toBeVisible();
+
+  await expect(page.getByTestId('viewport-grid')).toBeVisible();
+  await expect(page.locator('[data-viewportid="dental-current"]')).toBeAttached();
+  await expect(page.getByTestId('dental-no-prior-placeholder')).toBeVisible();
+  await expect(page.getByTestId('dental-bitewing-placeholder-left')).toBeVisible();
+  await expect(page.getByTestId('dental-bitewing-placeholder-right')).toBeVisible();
+
+  await page.getByTestId('dental-measurements-button').click();
+  const palette = page.getByTestId('dental-measurements-palette');
+  await expect(palette).toBeVisible();
+  await expect(page.getByTestId('dental-measurement-preset-pa-length')).toBeVisible();
+  await expect(page.getByTestId('dental-measurement-preset-canal-angle')).toBeVisible();
+  await expect(page.getByTestId('dental-measurement-preset-crown-width')).toBeVisible();
+  await expect(page.getByTestId('dental-measurement-preset-root-length')).toBeVisible();
+  await page.keyboard.press('Escape');
+
+  await page.getByTestId('side-panel-header-right').click();
+  const measurementsPanel = page.getByTestId('dental-measurements-panel');
+  await expect(measurementsPanel).toBeVisible();
+  await expect(measurementsPanel).toContainText('Study Measurements');
+  await expect(page.getByTestId('dental-measurements-empty')).toBeVisible();
+  await expect(page.getByTestId('dental-export-json')).toBeVisible();
+  await expect(page.getByTestId('dental-export-json')).toBeDisabled();
+});


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] OS: <!--[e.g. Windows 10, macOS 10.15.4]-->
- [] Node version: <!--[e.g. 18.16.1]-->
- [] Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Dental Viewer mode with specialized 2x2 viewport layout for dental imaging workflows
  * Introduced tooth selector with FDI and Universal numbering systems
  * Added dental measurements tool supporting PA length, canal angle, crown width, and root length
  * Implemented measurements panel with filtering, sorting, and export capabilities
  * Added practice header with patient summary and study metadata display
  * Introduced dental-themed UI with standard/dental theme toggle option
  * Added persistent viewer state and measurement storage

* **Tests**
  * Added comprehensive test coverage for dental viewer and measurement functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a new **Dental mode** for the OHIF viewer, comprising a full-stack addition: a new `@ohif/extension-dental` extension, a `@ohif/mode-dental` mode, and a `platform/dental-backend` Node.js/SQLite server that persists per-user viewer state and measurements. The feature includes custom layouts, a 2×2 hanging protocol, a tooth-numbering system (FDI/Universal), measurement presets, and a side-panel UI for filtering and exporting measurements.

- The dental backend (`platform/dental-backend`) is a new standalone HTTP service with Bearer-token auth, a SQLite store, and REST endpoints for viewer state and measurements; it ships with publicly-known default credentials (`dev-dental-token` / `dev-user`) and no request body size limit.
- The frontend extension (`extensions/dental`) registers a `DentalMeasurementsService`, hooks into OHIF's measurement and display-set events, and persists state to the backend with debounced saves; the load effect in `useDentalMeasurements` lacks the cancellation guard that `useDentalViewerState` already applies correctly.

<h3>Confidence Score: 3/5</h3>

The backend service introduces real security gaps that need to be addressed before any shared or production deployment.

The dental backend ships with a publicly-known default auth token baked into the source, no request body size cap, and a wildcard CORS policy on credentialed endpoints. Any operator who runs the backend without setting env vars exposes measurement and viewer-state data. The frontend measurement loader also lacks a stale-response guard that the sibling viewer-state hook already implements correctly. The rest of the extension and mode code is well-structured and thoroughly tested.

platform/dental-backend/src/config.js, platform/dental-backend/src/http.js, extensions/dental/src/measurements/useDentalMeasurements.ts

<details open><summary><h3>Security Review</h3></summary>

- **Known default auth token** (`platform/dental-backend/src/config.js`): Backend and frontend both fall back to `'dev-dental-token'` when env vars are not set. Any deployment without explicit configuration is accessible to anyone who can read this repository.
- **No request body size limit** (`platform/dental-backend/src/http.js` `readBody`): Incoming bodies are accumulated in memory without a cap, making the process vulnerable to memory exhaustion from a large or malicious payload.
- **Wildcard CORS on authenticated endpoints** (`platform/dental-backend/src/http.js`): `access-control-allow-origin: *` is set on all responses including state/measurement routes; if the backend is ever reachable from a non-localhost origin, any page in the browser can read or write patient measurement data cross-origin.
- **String-interpolated DDL in migration helper** (`platform/dental-backend/src/sqliteStore.js` `ensureMeasurementColumn`): `ALTER TABLE` is built by interpolating `name` and `type` without an allowlist; currently safe with hardcoded callers but structurally unsafe.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| platform/dental-backend/src/config.js | Hardcoded default auth token ('dev-dental-token') and userId ('dev-user') that are publicly visible in the repo; production deployments that skip env-var configuration are fully accessible with the known token. |
| platform/dental-backend/src/http.js | Lightweight HTTP router for the dental backend; has two issues: readBody accumulates the full request body with no size limit (OOM/DoS vector), and CORS is set to wildcard '*' on authenticated endpoints. |
| platform/dental-backend/src/sqliteStore.js | SQLite persistence layer; uses parameterized queries throughout except for the ALTER TABLE in ensureMeasurementColumn, which string-interpolates column name and type — safe today with hardcoded callers but lacks an allowlist guard. |
| extensions/dental/src/measurements/DentalMeasurementsService.ts | PubSub service holding the in-memory measurement Map; setMeasurements keys on annotationUID, which can be null for backend-loaded records, silently collapsing multiple measurements to a single entry. |
| extensions/dental/src/measurements/useDentalMeasurements.ts | React hook wiring OHIF measurement events to the dental API; the load effect lacks a cancellation guard, allowing a stale in-flight response to overwrite newer service state after unmount/remount. |
| extensions/dental/src/viewerState/useDentalViewerState.ts | Viewer state persistence hook; correctly uses a cancelled flag to guard in-flight API responses and handles auth-lock, debounced saves, and layout change tracking cleanly. |
| extensions/dental/src/measurements/DentalMeasurementsPanel.tsx | Read-only panel component for listing, filtering, sorting, and exporting dental measurements; no significant issues found. |
| extensions/dental/src/layout/DentalViewerLayout.tsx | Top-level layout component composing header, side panels, and viewport grid for the dental mode; follows existing OHIF layout patterns. |
| modes/dental/src/index.ts | Dental mode definition extending basic mode with the dental layout, hanging protocol, and measurements panel; straightforward composition. |
| platform/app/pluginConfig.json | Registers @ohif/extension-dental and @ohif/mode-dental in the shared plugin config; no issues found. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 6 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 6
platform/dental-backend/src/config.js:5-6
**Well-known default auth token shipped in source**

Both the backend (`config.js` line 5) and the frontend (`useDentalMeasurements.ts`, `useDentalViewerState.ts`) default to `'dev-dental-token'` when `DENTAL_BACKEND_AUTH_TOKEN` / `backendAuthToken` is not configured. Because this value is now publicly visible in the repository, any operator who deploys without explicitly setting the env var will run a backend that anyone can authenticate against with the known token. This is compounded by the fact that the backend also defaults `userId` to `'dev-user'`, so all unauthenticated queries read/write a single shared user's data.

### Issue 2 of 6
platform/dental-backend/src/http.js:136-147
**Unbounded request body accumulation**

`readBody` appends every incoming chunk to an in-memory string with no size cap. A client sending a very large body (e.g. a multi-megabyte `state` or `metadata` payload, or just garbage bytes) will grow `data` until the process runs out of memory or the OS kills it. A simple `if (data.length > MAX_BYTES) { req.destroy(); reject(…) }` guard inside the `data` handler would prevent this.

### Issue 3 of 6
platform/dental-backend/src/sqliteStore.js:88-93
**String-interpolated `ALTER TABLE` in migration helper**

`ensureMeasurementColumn` builds a DDL statement by directly interpolating `name` and `type` into the SQL string. SQLite does not support parameterized identifiers in DDL, so this cannot use `?` placeholders, but the function has no whitelist guard on either argument. All current callers pass hardcoded literals, so there is no immediate exposure, but if a future call ever passes a caller-controlled value the entire database file can be affected. Adding an allowlist check (e.g. `/^[a-z_]+$/` for name, `TEXT|REAL|INTEGER|BLOB` for type) before the `exec` would keep the interface safe.

### Issue 4 of 6
extensions/dental/src/measurements/DentalMeasurementsService.ts:32-36
**`null` annotationUID collapses multiple measurements into one Map entry**

The Map is keyed on `measurement.annotationUID`. The backend stores `annotation_uid` as `TEXT` (nullable) and `rowToMeasurement` maps it directly, so measurements that were persisted without an annotationUID come back as `{ annotationUID: null, … }`. When `setMeasurements` is called with such a list, every null-annotationUID entry writes to key `null` and only the last survives. The TypeScript type declares `annotationUID: string` (non-optional), but the API cast `as { measurements?: DentalMeasurement[] }` does not validate the runtime shape, so the collision is silent.

### Issue 5 of 6
platform/dental-backend/src/http.js:12-15
**Wildcard CORS origin on a credentials-bearing endpoint**

Every response (including authenticated state/measurements routes) sends `'access-control-allow-origin': '*'`. Any page loaded in the same browser can make credentialed requests to this local backend. For a pure development tool running on localhost this is low-risk, but if the backend is ever deployed to a shared host or reaches a non-localhost port, the open CORS policy allows arbitrary cross-origin reads and writes of patient measurement data. Restricting the allowed origin to the known viewer origin (or making it configurable) would harden the deployment surface.

### Issue 6 of 6
extensions/dental/src/measurements/useDentalMeasurements.ts:136-171
**In-flight load request is not cancelled on unmount**

The `useEffect` that calls `api.load` has no cancellation guard. If the component unmounts (or the effect's dependency array causes a re-run) while an API call is already in flight, the stale `.then` callback still fires and calls `dentalMeasurementsService.setMeasurements([…])` with possibly outdated data, overwriting any state built up since the component remounted. The `useDentalViewerState` hook handles this correctly (see its `cancelled` boolean), and the same pattern should be applied here.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add Dental Mode end-to-end smoke coverag..."](https://github.com/ohif/viewers/commit/4e249b6c30a2a00a64612e7b9d56c0158e0e3aca) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38342533)</sub>

> Greptile also left **6 inline comments** on this PR.

<!-- /greptile_comment -->