### PR TITLE
chore(testing): Playwright tests for contour segmentation create, update, delete  interactions

### DIFF
--- a/tests/ContourSegmentationCreateAndAddSegment.spec.ts
+++ b/tests/ContourSegmentationCreateAndAddSegment.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test, visitStudyAndHydrate } from './utils';
-import { expectRowSelected } from './utils/assertions';
+import { expectRowSelected, expectRowNotSelected } from './utils/assertions';
 
 const studyInstanceUID = '1.2.840.113619.2.290.3.3767434740.226.1600859119.501';
 
@@ -30,4 +30,47 @@ test('should create a new contour segmentation seeded with a default active segm
   const defaultSegment = panel.nthSegment(0);
   await expect(defaultSegment.title).toHaveText('Segment 1');
   await expectRowSelected(defaultSegment);
+});
+
+test('should add multiple segments to a newly created contour segmentation', async ({
+  rightPanelPageObject,
+}) => {
+  const { panel, addSegmentButton } = rightPanelPageObject.contourSegmentationPanel;
+
+  await panel.moreMenu.createNewSegmentation();
+  await expect(panel.rows).toHaveCount(1);
+
+  // Each added segment becomes the active one in place of the previous.
+  await addSegmentButton.click();
+  await expect(panel.rows).toHaveCount(2);
+  await expectRowSelected(panel.nthSegment(1));
+  await expectRowNotSelected(panel.nthSegment(0));
+
+  await addSegmentButton.click();
+  await expect(panel.rows).toHaveCount(3);
+  await expectRowSelected(panel.nthSegment(2));
+  await expectRowNotSelected(panel.nthSegment(1));
+
+  await expect(panel.getSegmentLabels()).toHaveText(['Segment 1', 'Segment 2', 'Segment 3']);
+});
+
+test('should list every created segmentation in the segmentation selector', async ({
+  rightPanelPageObject,
+}) => {
+  const { panel, segmentationSelect } = rightPanelPageObject.contourSegmentationPanel;
+
+  // Only the hydrated RTSTRUCT segmentation exists at first.
+  await expect(await segmentationSelect.getSegmentationLabels()).toHaveText(['Contours on PET']);
+  await segmentationSelect.close();
+
+  await panel.moreMenu.createNewSegmentation();
+  await panel.moreMenu.createNewSegmentation();
+
+  // The two newly created segmentations are added to the selector.
+  await expect(await segmentationSelect.getSegmentationLabels()).toHaveText([
+    'Contours on PET',
+    'Segmentation 2',
+    'Segmentation 3',
+  ]);
+  await segmentationSelect.close();
 });

--- a/tests/ContourSegmentationCreateAndAddSegment.spec.ts
+++ b/tests/ContourSegmentationCreateAndAddSegment.spec.ts
@@ -75,6 +75,29 @@ test('should list every created segmentation in the segmentation selector', asyn
   await segmentationSelect.close();
 });
 
+test('should switch between segmentations and show the matching segments', async ({
+  rightPanelPageObject,
+}) => {
+  const { panel, segmentationSelect } = rightPanelPageObject.contourSegmentationPanel;
+
+  // Create a second segmentation alongside the hydrated RTSTRUCT one.
+  await panel.moreMenu.createNewSegmentation();
+  await expect(segmentationSelect.selectedValue).toHaveText('Segmentation 2');
+  await expect(panel.rows).toHaveCount(1);
+
+  // Switching to the RTSTRUCT segmentation shows its four segments.
+  await segmentationSelect.selectNthSegmentation(0);
+  await expect(segmentationSelect.selectedValue).toHaveText('Contours on PET');
+  await expect(panel.rows).toHaveCount(4);
+  await expect(panel.getSegmentLabels().filter({ hasText: 'Threshold' })).toHaveCount(1);
+
+  // Switching back to the created segmentation shows only its default segment.
+  await segmentationSelect.selectNthSegmentation(1);
+  await expect(segmentationSelect.selectedValue).toHaveText('Segmentation 2');
+  await expect(panel.rows).toHaveCount(1);
+  await expect(panel.nthSegment(0).title).toHaveText('Segment 1');
+});
+
 test('should rename a segmentation and reflect the new name in the selector', async ({
   rightPanelPageObject,
 }) => {

--- a/tests/ContourSegmentationCreateAndAddSegment.spec.ts
+++ b/tests/ContourSegmentationCreateAndAddSegment.spec.ts
@@ -109,3 +109,39 @@ test('should not rename a segmentation when the rename dialog is cancelled', asy
   await panel.moreMenu.cancelRename('Discarded Name');
   await expect(segmentationSelect.selectedValue).toHaveText('Segmentation 2');
 });
+
+test('should delete a segmentation and remove it from the selector', async ({
+  rightPanelPageObject,
+}) => {
+  const { panel, segmentationSelect } = rightPanelPageObject.contourSegmentationPanel;
+
+  await panel.moreMenu.createNewSegmentation();
+  await expect(segmentationSelect.selectedValue).toHaveText('Segmentation 2');
+
+  await panel.moreMenu.delete();
+
+  // The remaining RTSTRUCT segmentation becomes active and is the only one left.
+  await expect(segmentationSelect.selectedValue).toHaveText('Contours on PET');
+  await expect(await segmentationSelect.getSegmentationLabels()).toHaveText(['Contours on PET']);
+  await segmentationSelect.close();
+});
+
+test('should delete every segmentation until none remain', async ({
+  rightPanelPageObject,
+}) => {
+  const { panel, addSegmentationButton } = rightPanelPageObject.contourSegmentationPanel;
+
+  // Start with the hydrated RTSTRUCT plus two created segmentations.
+  await panel.moreMenu.createNewSegmentation();
+  await panel.moreMenu.createNewSegmentation();
+
+  // Delete each of the three segmentations one by one.
+  await panel.moreMenu.delete();
+  await panel.moreMenu.delete();
+  await panel.moreMenu.delete();
+
+  // No segmentation remains, so the panel has no segment rows and the
+  // "Add segmentation" entry point is shown again.
+  await expect(panel.rows).toHaveCount(0);
+  await expect(addSegmentationButton.button).toBeVisible();
+});

--- a/tests/ContourSegmentationCreateAndAddSegment.spec.ts
+++ b/tests/ContourSegmentationCreateAndAddSegment.spec.ts
@@ -74,3 +74,38 @@ test('should list every created segmentation in the segmentation selector', asyn
   ]);
   await segmentationSelect.close();
 });
+
+test('should rename a segmentation and reflect the new name in the selector', async ({
+  rightPanelPageObject,
+}) => {
+  const { panel, segmentationSelect } = rightPanelPageObject.contourSegmentationPanel;
+
+  await panel.moreMenu.createNewSegmentation();
+  await expect(segmentationSelect.selectedValue).toHaveText('Segmentation 2');
+
+  await panel.moreMenu.rename('Renamed Segmentation');
+
+  await expect(segmentationSelect.selectedValue).toHaveText('Renamed Segmentation');
+  await expect(await segmentationSelect.getSegmentationLabels()).toHaveText([
+    'Contours on PET',
+    'Renamed Segmentation',
+  ]);
+  await segmentationSelect.close();
+});
+
+test('should not rename a segmentation when the rename dialog is cancelled', async ({
+  rightPanelPageObject,
+}) => {
+  const { panel, segmentationSelect } = rightPanelPageObject.contourSegmentationPanel;
+
+  await panel.moreMenu.createNewSegmentation();
+  await expect(segmentationSelect.selectedValue).toHaveText('Segmentation 2');
+
+  // Cancelling with an untouched dialog leaves the name unchanged.
+  await panel.moreMenu.cancelRename();
+  await expect(segmentationSelect.selectedValue).toHaveText('Segmentation 2');
+
+  // Cancelling after typing a new name also discards it.
+  await panel.moreMenu.cancelRename('Discarded Name');
+  await expect(segmentationSelect.selectedValue).toHaveText('Segmentation 2');
+});

--- a/tests/ContourSegmentationCreateAndAddSegment.spec.ts
+++ b/tests/ContourSegmentationCreateAndAddSegment.spec.ts
@@ -168,3 +168,42 @@ test('should delete every segmentation until none remain', async ({
   await expect(panel.rows).toHaveCount(0);
   await expect(addSegmentationButton.button).toBeVisible();
 });
+
+test('should remove a segmentation from the viewport and drop it from the selector', async ({
+  rightPanelPageObject,
+}) => {
+  const { panel, segmentationSelect } = rightPanelPageObject.contourSegmentationPanel;
+
+  await panel.moreMenu.createNewSegmentation();
+  await expect(segmentationSelect.selectedValue).toHaveText('Segmentation 2');
+
+  await panel.moreMenu.removeFromViewport();
+
+  // Removing from the viewport drops it from the selector; the RTSTRUCT one stays active.
+  await expect(segmentationSelect.selectedValue).toHaveText('Contours on PET');
+  await expect(await segmentationSelect.getSegmentationLabels()).toHaveText(['Contours on PET']);
+  await segmentationSelect.close();
+});
+
+// KNOWN BUG: the last remaining segmentation cannot be removed from the viewport
+// ("Remove from Viewport" is a silent no-op once it is the only one left), so the
+// panel keeps its segment row instead of clearing. Skipped until the bug is fixed.
+test.skip('should remove every segmentation from the viewport', async ({
+  rightPanelPageObject,
+}) => {
+  const { panel, addSegmentationButton } = rightPanelPageObject.contourSegmentationPanel;
+
+  // Start with the hydrated RTSTRUCT plus two created segmentations.
+  await panel.moreMenu.createNewSegmentation();
+  await panel.moreMenu.createNewSegmentation();
+
+  // Remove each segmentation from the viewport one by one.
+  await panel.moreMenu.removeFromViewport();
+  await panel.moreMenu.removeFromViewport();
+  await panel.moreMenu.removeFromViewport();
+
+  // The viewport should have no segmentations left: the selector is empty and the
+  // "Add segmentation" entry point is shown again.
+  await expect(panel.rows).toHaveCount(0);
+  await expect(addSegmentationButton.button).toBeVisible();
+});

--- a/tests/ContourSegmentationCreateAndAddSegment.spec.ts
+++ b/tests/ContourSegmentationCreateAndAddSegment.spec.ts
@@ -1,92 +1,33 @@
-import { expect, test, visitStudy, waitForViewportsRendered } from './utils';
-import { expectRowSelected, expectRowNotSelected } from './utils/assertions';
+import { expect, test, visitStudyAndHydrate } from './utils';
+import { expectRowSelected } from './utils/assertions';
 
 const studyInstanceUID = '1.2.840.113619.2.290.3.3767434740.226.1600859119.501';
 
-test.beforeEach(async ({ page, rightPanelPageObject }) => {
-  const mode = 'segmentation';
-  await visitStudy(page, studyInstanceUID, mode, 2000);
-
-  // "Add segmentation" silently does nothing while the viewport is still being
-  // registered in the grid, so wait for the first render before interacting.
-  await waitForViewportsRendered(page);
-
-  // The segmentation mode opens on the labelmap tab; switch to the contour tab.
-  await rightPanelPageObject.contourSegmentationPanel.select();
+test.beforeEach(async ({ page, leftPanelPageObject, DOMOverlayPageObject }) => {
+  await visitStudyAndHydrate({
+    page,
+    leftPanelPageObject,
+    DOMOverlayPageObject,
+    studyInstanceUID,
+    modality: 'RTSTRUCT',
+  });
 });
 
 test('should create a new contour segmentation seeded with a default active segment', async ({
   rightPanelPageObject,
 }) => {
-  const { addSegmentationButton, panel, segmentationSelect } =
-    rightPanelPageObject.contourSegmentationPanel;
+  const { panel, segmentationSelect } = rightPanelPageObject.contourSegmentationPanel;
 
-  // Precondition: no contour segmentation exists yet, so the panel has no segment rows.
-  await expect(panel.rows).toHaveCount(0);
+  // The hydrated RTSTRUCT segmentation is active with its four segments.
+  await expect(panel.rows).toHaveCount(4);
 
-  await addSegmentationButton.click();
+  // "Add segmentation" is hidden once a segmentation exists, so use the more-menu.
+  await panel.moreMenu.createNewSegmentation();
 
-  // The new segmentation becomes the active selection in the segmentation selector.
-  await expect(segmentationSelect.selectedValue).toHaveText('Segmentation 1');
-
-  // The new segmentation is seeded with a single default segment, which is active.
+  // The new segmentation becomes active, seeded with a single default active segment.
+  await expect(segmentationSelect.selectedValue).toHaveText('Segmentation 2');
   await expect(panel.rows).toHaveCount(1);
   const defaultSegment = panel.nthSegment(0);
   await expect(defaultSegment.title).toHaveText('Segment 1');
   await expectRowSelected(defaultSegment);
-});
-
-test('should add new segments to the active contour segmentation', async ({
-  rightPanelPageObject,
-}) => {
-  const { addSegmentationButton, addSegmentButton, panel } =
-    rightPanelPageObject.contourSegmentationPanel;
-
-  await addSegmentationButton.click();
-  await expect(panel.rows).toHaveCount(1);
-
-  await addSegmentButton.click();
-
-  const secondSegment = panel.nthSegment(1);
-  await expect(panel.rows).toHaveCount(2);
-  await expect(secondSegment.title).toHaveText('Segment 2');
-
-  // The newly added segment becomes the active segment in place of the default one.
-  await expectRowSelected(secondSegment);
-  await expectRowNotSelected(panel.nthSegment(0));
-
-  await addSegmentButton.click();
-
-  const thirdSegment = panel.nthSegment(2);
-  await expect(panel.rows).toHaveCount(3);
-  await expect(thirdSegment.title).toHaveText('Segment 3');
-  await expectRowSelected(thirdSegment);
-  await expectRowNotSelected(secondSegment);
-});
-
-test('should create and activate a new contour segmentation when an RTSTRUCT segmentation is already hydrated', async ({
-  page,
-  leftPanelPageObject,
-  DOMOverlayPageObject,
-  rightPanelPageObject,
-}) => {
-  const { panel, segmentationSelect } = rightPanelPageObject.contourSegmentationPanel;
-
-  await leftPanelPageObject.loadSeriesByModality('RTSTRUCT');
-  await waitForViewportsRendered(page);
-  await expect(DOMOverlayPageObject.viewport.segmentationHydration.locator).toBeVisible();
-  await DOMOverlayPageObject.viewport.segmentationHydration.yes.click();
-
-  // Precondition: the hydrated RTSTRUCT segmentation is active and lists its four segments.
-  await expect(panel.rows).toHaveCount(4);
-
-  // With a contour segmentation already present, the "Add segmentation" row is not
-  // rendered in collapsed mode; create the new segmentation from the more-menu instead.
-  await panel.moreMenu.createNewSegmentation();
-
-  // The new segmentation becomes active: the selector switches to it and the panel
-  // shows only its default segment instead of the RTSTRUCT segments.
-  await expect(segmentationSelect.selectedValue).toHaveText('Segmentation 2');
-  await expect(panel.rows).toHaveCount(1);
-  await expect(panel.nthSegment(0).title).toHaveText('Segment 1');
 });

--- a/tests/ContourSegmentationCreateAndAddSegment.spec.ts
+++ b/tests/ContourSegmentationCreateAndAddSegment.spec.ts
@@ -1,0 +1,92 @@
+import { expect, test, visitStudy, waitForViewportsRendered } from './utils';
+import { expectRowSelected, expectRowNotSelected } from './utils/assertions';
+
+const studyInstanceUID = '1.2.840.113619.2.290.3.3767434740.226.1600859119.501';
+
+test.beforeEach(async ({ page, rightPanelPageObject }) => {
+  const mode = 'segmentation';
+  await visitStudy(page, studyInstanceUID, mode, 2000);
+
+  // "Add segmentation" silently does nothing while the viewport is still being
+  // registered in the grid, so wait for the first render before interacting.
+  await waitForViewportsRendered(page);
+
+  // The segmentation mode opens on the labelmap tab; switch to the contour tab.
+  await rightPanelPageObject.contourSegmentationPanel.select();
+});
+
+test('should create a new contour segmentation seeded with a default active segment', async ({
+  rightPanelPageObject,
+}) => {
+  const { addSegmentationButton, panel, segmentationSelect } =
+    rightPanelPageObject.contourSegmentationPanel;
+
+  // Precondition: no contour segmentation exists yet, so the panel has no segment rows.
+  await expect(panel.rows).toHaveCount(0);
+
+  await addSegmentationButton.click();
+
+  // The new segmentation becomes the active selection in the segmentation selector.
+  await expect(segmentationSelect.selectedValue).toHaveText('Segmentation 1');
+
+  // The new segmentation is seeded with a single default segment, which is active.
+  await expect(panel.rows).toHaveCount(1);
+  const defaultSegment = panel.nthSegment(0);
+  await expect(defaultSegment.title).toHaveText('Segment 1');
+  await expectRowSelected(defaultSegment);
+});
+
+test('should add new segments to the active contour segmentation', async ({
+  rightPanelPageObject,
+}) => {
+  const { addSegmentationButton, addSegmentButton, panel } =
+    rightPanelPageObject.contourSegmentationPanel;
+
+  await addSegmentationButton.click();
+  await expect(panel.rows).toHaveCount(1);
+
+  await addSegmentButton.click();
+
+  const secondSegment = panel.nthSegment(1);
+  await expect(panel.rows).toHaveCount(2);
+  await expect(secondSegment.title).toHaveText('Segment 2');
+
+  // The newly added segment becomes the active segment in place of the default one.
+  await expectRowSelected(secondSegment);
+  await expectRowNotSelected(panel.nthSegment(0));
+
+  await addSegmentButton.click();
+
+  const thirdSegment = panel.nthSegment(2);
+  await expect(panel.rows).toHaveCount(3);
+  await expect(thirdSegment.title).toHaveText('Segment 3');
+  await expectRowSelected(thirdSegment);
+  await expectRowNotSelected(secondSegment);
+});
+
+test('should create and activate a new contour segmentation when an RTSTRUCT segmentation is already hydrated', async ({
+  page,
+  leftPanelPageObject,
+  DOMOverlayPageObject,
+  rightPanelPageObject,
+}) => {
+  const { panel, segmentationSelect } = rightPanelPageObject.contourSegmentationPanel;
+
+  await leftPanelPageObject.loadSeriesByModality('RTSTRUCT');
+  await waitForViewportsRendered(page);
+  await expect(DOMOverlayPageObject.viewport.segmentationHydration.locator).toBeVisible();
+  await DOMOverlayPageObject.viewport.segmentationHydration.yes.click();
+
+  // Precondition: the hydrated RTSTRUCT segmentation is active and lists its four segments.
+  await expect(panel.rows).toHaveCount(4);
+
+  // With a contour segmentation already present, the "Add segmentation" row is not
+  // rendered in collapsed mode; create the new segmentation from the more-menu instead.
+  await panel.moreMenu.createNewSegmentation();
+
+  // The new segmentation becomes active: the selector switches to it and the panel
+  // shows only its default segment instead of the RTSTRUCT segments.
+  await expect(segmentationSelect.selectedValue).toHaveText('Segmentation 2');
+  await expect(panel.rows).toHaveCount(1);
+  await expect(panel.nthSegment(0).title).toHaveText('Segment 1');
+});

--- a/tests/ContourSegmentationCreateAndAddSegment.spec.ts
+++ b/tests/ContourSegmentationCreateAndAddSegment.spec.ts
@@ -1,209 +1,231 @@
-import { expect, test, visitStudyAndHydrate } from './utils';
+import { expect, test, visitStudy, visitStudyAndHydrate, waitForViewportsRendered } from './utils';
 import { expectRowSelected, expectRowNotSelected } from './utils/assertions';
 
 const studyInstanceUID = '1.2.840.113619.2.290.3.3767434740.226.1600859119.501';
+test.describe('Contour Segmentation interactions without RTSTRUCT', () => {
+  test.beforeEach(async ({ page, rightPanelPageObject }) => {
+    await visitStudy(page, studyInstanceUID, 'segmentation', 2000);
+    await waitForViewportsRendered(page);
+    // Segmentation mode opens on the labelmap tab; switch to the contour tab.
+    await rightPanelPageObject.contourSegmentationPanel.select();
+  });
 
-test.beforeEach(async ({ page, leftPanelPageObject, DOMOverlayPageObject }) => {
-  await visitStudyAndHydrate({
-    page,
-    leftPanelPageObject,
-    DOMOverlayPageObject,
-    studyInstanceUID,
-    modality: 'RTSTRUCT',
+  test('should add a contour segmentation from the empty panel', async ({
+    rightPanelPageObject,
+  }) => {
+    const { addSegmentationButton, panel, segmentationSelect } =
+      rightPanelPageObject.contourSegmentationPanel;
+
+    // No contour segmentation exists yet.
+    await expect(panel.rows).toHaveCount(0);
+    await expect(addSegmentationButton.button).toBeVisible();
+
+    await addSegmentationButton.click();
+
+    // The segmentation is added and becomes the active selection.
+    await expect(segmentationSelect.selectedValue).toHaveText('Segmentation 1');
+    await expect(panel.rows).toHaveCount(1);
   });
 });
 
-test('should create a new contour segmentation seeded with a default active segment', async ({
-  rightPanelPageObject,
-}) => {
-  const { panel, segmentationSelect } = rightPanelPageObject.contourSegmentationPanel;
+test.describe('Contour Segmentation interactions on RTSTRUCT', () => {
+  test.beforeEach(async ({ page, leftPanelPageObject, DOMOverlayPageObject }) => {
+    await visitStudyAndHydrate({
+      page,
+      leftPanelPageObject,
+      DOMOverlayPageObject,
+      studyInstanceUID,
+      modality: 'RTSTRUCT',
+    });
+  });
 
-  // The hydrated RTSTRUCT segmentation is active with its four segments.
-  await expect(panel.rows).toHaveCount(4);
+  test('should create a new contour segmentation seeded with a default active segment', async ({
+    rightPanelPageObject,
+  }) => {
+    const { panel, segmentationSelect } = rightPanelPageObject.contourSegmentationPanel;
 
-  // "Add segmentation" is hidden once a segmentation exists, so use the more-menu.
-  await panel.moreMenu.createNewSegmentation();
+    await expect(panel.rows).toHaveCount(4);
 
-  // The new segmentation becomes active, seeded with a single default active segment.
-  await expect(segmentationSelect.selectedValue).toHaveText('Segmentation 2');
-  await expect(panel.rows).toHaveCount(1);
-  const defaultSegment = panel.nthSegment(0);
-  await expect(defaultSegment.title).toHaveText('Segment 1');
-  await expectRowSelected(defaultSegment);
-});
+    await panel.moreMenu.createNewSegmentation();
 
-test('should add multiple segments to a newly created contour segmentation', async ({
-  rightPanelPageObject,
-}) => {
-  const { panel, addSegmentButton } = rightPanelPageObject.contourSegmentationPanel;
+    await expect(segmentationSelect.selectedValue).toHaveText('Segmentation 2');
+    await expect(panel.rows).toHaveCount(1);
+    const defaultSegment = panel.nthSegment(0);
+    await expect(defaultSegment.title).toHaveText('Segment 1');
+    await expectRowSelected(defaultSegment);
+  });
 
-  await panel.moreMenu.createNewSegmentation();
-  await expect(panel.rows).toHaveCount(1);
+  test('should add multiple segments to a newly created contour segmentation', async ({
+    rightPanelPageObject,
+  }) => {
+    const { panel, addSegmentButton } = rightPanelPageObject.contourSegmentationPanel;
 
-  // Each added segment becomes the active one in place of the previous.
-  await addSegmentButton.click();
-  await expect(panel.rows).toHaveCount(2);
-  await expectRowSelected(panel.nthSegment(1));
-  await expectRowNotSelected(panel.nthSegment(0));
+    await panel.moreMenu.createNewSegmentation();
+    await expect(panel.rows).toHaveCount(1);
 
-  await addSegmentButton.click();
-  await expect(panel.rows).toHaveCount(3);
-  await expectRowSelected(panel.nthSegment(2));
-  await expectRowNotSelected(panel.nthSegment(1));
+    // Each added segment becomes the active one in place of the previous.
+    await addSegmentButton.click();
+    await expect(panel.rows).toHaveCount(2);
+    await expectRowSelected(panel.nthSegment(1));
+    await expectRowNotSelected(panel.nthSegment(0));
 
-  await expect(panel.getSegmentLabels()).toHaveText(['Segment 1', 'Segment 2', 'Segment 3']);
-});
+    await addSegmentButton.click();
+    await expect(panel.rows).toHaveCount(3);
+    await expectRowSelected(panel.nthSegment(2));
+    await expectRowNotSelected(panel.nthSegment(1));
 
-test('should list every created segmentation in the segmentation selector', async ({
-  rightPanelPageObject,
-}) => {
-  const { panel, segmentationSelect } = rightPanelPageObject.contourSegmentationPanel;
+    await expect(panel.getSegmentLabels()).toHaveText(['Segment 1', 'Segment 2', 'Segment 3']);
+  });
 
-  // Only the hydrated RTSTRUCT segmentation exists at first.
-  await expect(await segmentationSelect.getSegmentationLabels()).toHaveText(['Contours on PET']);
-  await segmentationSelect.close();
+  test('should list every created segmentation in the segmentation selector', async ({
+    rightPanelPageObject,
+  }) => {
+    const { panel, segmentationSelect } = rightPanelPageObject.contourSegmentationPanel;
 
-  await panel.moreMenu.createNewSegmentation();
-  await panel.moreMenu.createNewSegmentation();
+    // Only the hydrated RTSTRUCT segmentation exists at first.
+    await expect(await segmentationSelect.getSegmentationLabels()).toHaveText(['Contours on PET']);
+    await segmentationSelect.close();
 
-  // The two newly created segmentations are added to the selector.
-  await expect(await segmentationSelect.getSegmentationLabels()).toHaveText([
-    'Contours on PET',
-    'Segmentation 2',
-    'Segmentation 3',
-  ]);
-  await segmentationSelect.close();
-});
+    await panel.moreMenu.createNewSegmentation();
+    await panel.moreMenu.createNewSegmentation();
 
-test('should switch between segmentations and show the matching segments', async ({
-  rightPanelPageObject,
-}) => {
-  const { panel, segmentationSelect } = rightPanelPageObject.contourSegmentationPanel;
+    // The two newly created segmentations are added to the selector.
+    await expect(await segmentationSelect.getSegmentationLabels()).toHaveText([
+      'Contours on PET',
+      'Segmentation 2',
+      'Segmentation 3',
+    ]);
+    await segmentationSelect.close();
+  });
 
-  // Create a second segmentation alongside the hydrated RTSTRUCT one.
-  await panel.moreMenu.createNewSegmentation();
-  await expect(segmentationSelect.selectedValue).toHaveText('Segmentation 2');
-  await expect(panel.rows).toHaveCount(1);
+  test('should switch between segmentations and show the matching segments', async ({
+    rightPanelPageObject,
+  }) => {
+    const { panel, segmentationSelect } = rightPanelPageObject.contourSegmentationPanel;
 
-  // Switching to the RTSTRUCT segmentation shows its four segments.
-  await segmentationSelect.selectNthSegmentation(0);
-  await expect(segmentationSelect.selectedValue).toHaveText('Contours on PET');
-  await expect(panel.rows).toHaveCount(4);
-  await expect(panel.getSegmentLabels().filter({ hasText: 'Threshold' })).toHaveCount(1);
+    // Create a second segmentation alongside the hydrated RTSTRUCT one.
+    await panel.moreMenu.createNewSegmentation();
+    await expect(segmentationSelect.selectedValue).toHaveText('Segmentation 2');
+    await expect(panel.rows).toHaveCount(1);
 
-  // Switching back to the created segmentation shows only its default segment.
-  await segmentationSelect.selectNthSegmentation(1);
-  await expect(segmentationSelect.selectedValue).toHaveText('Segmentation 2');
-  await expect(panel.rows).toHaveCount(1);
-  await expect(panel.nthSegment(0).title).toHaveText('Segment 1');
-});
+    // Switching to the RTSTRUCT segmentation shows its four segments.
+    await segmentationSelect.selectNthSegmentation(0);
+    await expect(segmentationSelect.selectedValue).toHaveText('Contours on PET');
+    await expect(panel.rows).toHaveCount(4);
+    await expect(panel.getSegmentLabels().filter({ hasText: 'Threshold' })).toHaveCount(1);
 
-test('should rename a segmentation and reflect the new name in the selector', async ({
-  rightPanelPageObject,
-}) => {
-  const { panel, segmentationSelect } = rightPanelPageObject.contourSegmentationPanel;
+    // Switching back to the created segmentation shows only its default segment.
+    await segmentationSelect.selectNthSegmentation(1);
+    await expect(segmentationSelect.selectedValue).toHaveText('Segmentation 2');
+    await expect(panel.rows).toHaveCount(1);
+    await expect(panel.nthSegment(0).title).toHaveText('Segment 1');
+  });
 
-  await panel.moreMenu.createNewSegmentation();
-  await expect(segmentationSelect.selectedValue).toHaveText('Segmentation 2');
+  test('should rename a segmentation and reflect the new name in the selector', async ({
+    rightPanelPageObject,
+  }) => {
+    const { panel, segmentationSelect } = rightPanelPageObject.contourSegmentationPanel;
 
-  await panel.moreMenu.rename('Renamed Segmentation');
+    await panel.moreMenu.createNewSegmentation();
+    await expect(segmentationSelect.selectedValue).toHaveText('Segmentation 2');
 
-  await expect(segmentationSelect.selectedValue).toHaveText('Renamed Segmentation');
-  await expect(await segmentationSelect.getSegmentationLabels()).toHaveText([
-    'Contours on PET',
-    'Renamed Segmentation',
-  ]);
-  await segmentationSelect.close();
-});
+    await panel.moreMenu.rename('Renamed Segmentation');
 
-test('should not rename a segmentation when the rename dialog is cancelled', async ({
-  rightPanelPageObject,
-}) => {
-  const { panel, segmentationSelect } = rightPanelPageObject.contourSegmentationPanel;
+    await expect(segmentationSelect.selectedValue).toHaveText('Renamed Segmentation');
+    await expect(await segmentationSelect.getSegmentationLabels()).toHaveText([
+      'Contours on PET',
+      'Renamed Segmentation',
+    ]);
+    await segmentationSelect.close();
+  });
 
-  await panel.moreMenu.createNewSegmentation();
-  await expect(segmentationSelect.selectedValue).toHaveText('Segmentation 2');
+  test('should not rename a segmentation when the rename dialog is cancelled', async ({
+    rightPanelPageObject,
+  }) => {
+    const { panel, segmentationSelect } = rightPanelPageObject.contourSegmentationPanel;
 
-  // Cancelling with an untouched dialog leaves the name unchanged.
-  await panel.moreMenu.cancelRename();
-  await expect(segmentationSelect.selectedValue).toHaveText('Segmentation 2');
+    await panel.moreMenu.createNewSegmentation();
+    await expect(segmentationSelect.selectedValue).toHaveText('Segmentation 2');
 
-  // Cancelling after typing a new name also discards it.
-  await panel.moreMenu.cancelRename('Discarded Name');
-  await expect(segmentationSelect.selectedValue).toHaveText('Segmentation 2');
-});
+    // Cancelling with an untouched dialog leaves the name unchanged.
+    await panel.moreMenu.cancelRename();
+    await expect(segmentationSelect.selectedValue).toHaveText('Segmentation 2');
 
-test('should delete a segmentation and remove it from the selector', async ({
-  rightPanelPageObject,
-}) => {
-  const { panel, segmentationSelect } = rightPanelPageObject.contourSegmentationPanel;
+    // Cancelling after typing a new name also discards it.
+    await panel.moreMenu.cancelRename('Discarded Name');
+    await expect(segmentationSelect.selectedValue).toHaveText('Segmentation 2');
+  });
 
-  await panel.moreMenu.createNewSegmentation();
-  await expect(segmentationSelect.selectedValue).toHaveText('Segmentation 2');
+  test('should delete a segmentation and remove it from the selector', async ({
+    rightPanelPageObject,
+  }) => {
+    const { panel, segmentationSelect } = rightPanelPageObject.contourSegmentationPanel;
 
-  await panel.moreMenu.delete();
+    await panel.moreMenu.createNewSegmentation();
+    await expect(segmentationSelect.selectedValue).toHaveText('Segmentation 2');
 
-  // The remaining RTSTRUCT segmentation becomes active and is the only one left.
-  await expect(segmentationSelect.selectedValue).toHaveText('Contours on PET');
-  await expect(await segmentationSelect.getSegmentationLabels()).toHaveText(['Contours on PET']);
-  await segmentationSelect.close();
-});
+    await panel.moreMenu.delete();
 
-test('should delete every segmentation until none remain', async ({
-  rightPanelPageObject,
-}) => {
-  const { panel, addSegmentationButton } = rightPanelPageObject.contourSegmentationPanel;
+    // The remaining RTSTRUCT segmentation becomes active and is the only one left.
+    await expect(segmentationSelect.selectedValue).toHaveText('Contours on PET');
+    await expect(await segmentationSelect.getSegmentationLabels()).toHaveText(['Contours on PET']);
+    await segmentationSelect.close();
+  });
 
-  // Start with the hydrated RTSTRUCT plus two created segmentations.
-  await panel.moreMenu.createNewSegmentation();
-  await panel.moreMenu.createNewSegmentation();
+  test('should delete every segmentation until none remain', async ({ rightPanelPageObject }) => {
+    const { panel, addSegmentationButton } = rightPanelPageObject.contourSegmentationPanel;
 
-  // Delete each of the three segmentations one by one.
-  await panel.moreMenu.delete();
-  await panel.moreMenu.delete();
-  await panel.moreMenu.delete();
+    // Start with the hydrated RTSTRUCT plus two created segmentations.
+    await panel.moreMenu.createNewSegmentation();
+    await panel.moreMenu.createNewSegmentation();
 
-  // No segmentation remains, so the panel has no segment rows and the
-  // "Add segmentation" entry point is shown again.
-  await expect(panel.rows).toHaveCount(0);
-  await expect(addSegmentationButton.button).toBeVisible();
-});
+    // Delete each of the three segmentations one by one.
+    await panel.moreMenu.delete();
+    await panel.moreMenu.delete();
+    await panel.moreMenu.delete();
 
-test('should remove a segmentation from the viewport and drop it from the selector', async ({
-  rightPanelPageObject,
-}) => {
-  const { panel, segmentationSelect } = rightPanelPageObject.contourSegmentationPanel;
+    // No segmentation remains, so the panel has no segment rows and the
+    // "Add segmentation" entry point is shown again.
+    await expect(panel.rows).toHaveCount(0);
+    await expect(addSegmentationButton.button).toBeVisible();
+  });
 
-  await panel.moreMenu.createNewSegmentation();
-  await expect(segmentationSelect.selectedValue).toHaveText('Segmentation 2');
+  test('should remove a segmentation from the viewport and drop it from the selector', async ({
+    rightPanelPageObject,
+  }) => {
+    const { panel, segmentationSelect } = rightPanelPageObject.contourSegmentationPanel;
 
-  await panel.moreMenu.removeFromViewport();
+    await panel.moreMenu.createNewSegmentation();
+    await expect(segmentationSelect.selectedValue).toHaveText('Segmentation 2');
 
-  // Removing from the viewport drops it from the selector; the RTSTRUCT one stays active.
-  await expect(segmentationSelect.selectedValue).toHaveText('Contours on PET');
-  await expect(await segmentationSelect.getSegmentationLabels()).toHaveText(['Contours on PET']);
-  await segmentationSelect.close();
-});
+    await panel.moreMenu.removeFromViewport();
 
-// KNOWN BUG: the last remaining segmentation cannot be removed from the viewport
-// ("Remove from Viewport" is a silent no-op once it is the only one left), so the
-// panel keeps its segment row instead of clearing. Skipped until the bug is fixed.
-test.skip('should remove every segmentation from the viewport', async ({
-  rightPanelPageObject,
-}) => {
-  const { panel, addSegmentationButton } = rightPanelPageObject.contourSegmentationPanel;
+    // Removing from the viewport drops it from the selector; the RTSTRUCT one stays active.
+    await expect(segmentationSelect.selectedValue).toHaveText('Contours on PET');
+    await expect(await segmentationSelect.getSegmentationLabels()).toHaveText(['Contours on PET']);
+    await segmentationSelect.close();
+  });
 
-  // Start with the hydrated RTSTRUCT plus two created segmentations.
-  await panel.moreMenu.createNewSegmentation();
-  await panel.moreMenu.createNewSegmentation();
+  // KNOWN BUG: the last remaining segmentation cannot be removed from the viewport
+  // ("Remove from Viewport" is a silent no-op once it is the only one left), so the
+  // panel keeps its segment row instead of clearing. Skipped until the bug is fixed.
+  test.skip('should remove every segmentation from the viewport', async ({
+    rightPanelPageObject,
+  }) => {
+    const { panel, addSegmentationButton } = rightPanelPageObject.contourSegmentationPanel;
 
-  // Remove each segmentation from the viewport one by one.
-  await panel.moreMenu.removeFromViewport();
-  await panel.moreMenu.removeFromViewport();
-  await panel.moreMenu.removeFromViewport();
+    // Start with the hydrated RTSTRUCT plus two created segmentations.
+    await panel.moreMenu.createNewSegmentation();
+    await panel.moreMenu.createNewSegmentation();
 
-  // The viewport should have no segmentations left: the selector is empty and the
-  // "Add segmentation" entry point is shown again.
-  await expect(panel.rows).toHaveCount(0);
-  await expect(addSegmentationButton.button).toBeVisible();
+    // Remove each segmentation from the viewport one by one.
+    await panel.moreMenu.removeFromViewport();
+    await panel.moreMenu.removeFromViewport();
+    await panel.moreMenu.removeFromViewport();
+
+    // The viewport should have no segmentations left: the selector is empty and the
+    // "Add segmentation" entry point is shown again.
+    await expect(panel.rows).toHaveCount(0);
+    await expect(addSegmentationButton.button).toBeVisible();
+  });
 });

--- a/tests/ContourSegmentationCrudInteractions.spec.ts
+++ b/tests/ContourSegmentationCrudInteractions.spec.ts
@@ -1,5 +1,9 @@
 import { expect, test, visitStudy, visitStudyAndHydrate, waitForViewportsRendered } from './utils';
-import { expectRowSelected, expectRowNotSelected } from './utils/assertions';
+import {
+  expectRowSelected,
+  expectRowNotSelected,
+  expectSegmentationLabels,
+} from './utils/assertions';
 
 const studyInstanceUID = '1.2.840.113619.2.290.3.3767434740.226.1600859119.501';
 test.describe('Contour Segmentation from an empty panel', () => {
@@ -85,19 +89,17 @@ test.describe('Contour Segmentation interactions on RTSTRUCT panel', () => {
     const { panel, segmentationSelect } = rightPanelPageObject.contourSegmentationPanel;
 
     // Only the hydrated RTSTRUCT segmentation exists at first.
-    await expect(await segmentationSelect.getSegmentationLabels()).toHaveText(['Contours on PET']);
-    await segmentationSelect.close();
+    await expectSegmentationLabels(segmentationSelect, ['Contours on PET']);
 
     await panel.moreMenu.createNewSegmentation();
     await panel.moreMenu.createNewSegmentation();
 
     // The two newly created segmentations are added to the selector.
-    await expect(await segmentationSelect.getSegmentationLabels()).toHaveText([
+    await expectSegmentationLabels(segmentationSelect, [
       'Contours on PET',
       'Segmentation 2',
       'Segmentation 3',
     ]);
-    await segmentationSelect.close();
   });
 
   test('should switch between segmentations and show the matching segments', async ({
@@ -105,12 +107,16 @@ test.describe('Contour Segmentation interactions on RTSTRUCT panel', () => {
   }) => {
     const { panel, segmentationSelect } = rightPanelPageObject.contourSegmentationPanel;
 
-    // Create a second segmentation alongside the hydrated RTSTRUCT one.
+    // Create two more segmentations alongside the hydrated RTSTRUCT one, so the
+    // selector lists: [0] Contours on PET, [1] Segmentation 2, [2] Segmentation 3.
     await panel.moreMenu.createNewSegmentation();
-    await expect(segmentationSelect.selectedValue).toHaveText('Segmentation 2');
-    await expect(panel.rows).toHaveCount(1);
+    await panel.moreMenu.createNewSegmentation();
+    await expect(segmentationSelect.selectedValue).toHaveText('Segmentation 3');
 
-    // Switching to the RTSTRUCT segmentation shows its four segments.
+    // Select out of listed order (active is 2 → 0 → 2 → 1) to prove the active
+    // segmentation follows the selection, not the order the options are listed in.
+
+    // Index 0: the RTSTRUCT segmentation shows its four segments.
     await segmentationSelect.selectNthSegmentation(0);
     await expect(segmentationSelect.selectedValue).toHaveText('Contours on PET');
     await expect(panel.rows).toHaveCount(4);
@@ -121,7 +127,13 @@ test.describe('Contour Segmentation interactions on RTSTRUCT panel', () => {
       'Large Box',
     ]);
 
-    // Switching back to the created segmentation shows only its default segment.
+    // Jump to the last-created segmentation (index 2), skipping over index 1.
+    await segmentationSelect.selectNthSegmentation(2);
+    await expect(segmentationSelect.selectedValue).toHaveText('Segmentation 3');
+    await expect(panel.rows).toHaveCount(1);
+    await expect(panel.nthSegment(0).title).toHaveText('Segment 1');
+
+    // Back up to the middle segmentation (index 1).
     await segmentationSelect.selectNthSegmentation(1);
     await expect(segmentationSelect.selectedValue).toHaveText('Segmentation 2');
     await expect(panel.rows).toHaveCount(1);
@@ -139,11 +151,7 @@ test.describe('Contour Segmentation interactions on RTSTRUCT panel', () => {
     await panel.moreMenu.rename('Renamed Segmentation');
 
     await expect(segmentationSelect.selectedValue).toHaveText('Renamed Segmentation');
-    await expect(await segmentationSelect.getSegmentationLabels()).toHaveText([
-      'Contours on PET',
-      'Renamed Segmentation',
-    ]);
-    await segmentationSelect.close();
+    await expectSegmentationLabels(segmentationSelect, ['Contours on PET', 'Renamed Segmentation']);
   });
 
   test('should not rename a segmentation when the rename dialog is cancelled', async ({
@@ -175,8 +183,7 @@ test.describe('Contour Segmentation interactions on RTSTRUCT panel', () => {
 
     // The remaining RTSTRUCT segmentation becomes active and is the only one left.
     await expect(segmentationSelect.selectedValue).toHaveText('Contours on PET');
-    await expect(await segmentationSelect.getSegmentationLabels()).toHaveText(['Contours on PET']);
-    await segmentationSelect.close();
+    await expectSegmentationLabels(segmentationSelect, ['Contours on PET']);
   });
 
   test('should delete every segmentation until none remain', async ({ rightPanelPageObject }) => {
@@ -212,13 +219,13 @@ test.describe('Contour Segmentation interactions on RTSTRUCT panel', () => {
 
     // Removing from the viewport drops it from the selector; the RTSTRUCT one stays active.
     await expect(segmentationSelect.selectedValue).toHaveText('Contours on PET');
-    await expect(await segmentationSelect.getSegmentationLabels()).toHaveText(['Contours on PET']);
-    await segmentationSelect.close();
+    await expectSegmentationLabels(segmentationSelect, ['Contours on PET']);
   });
 
   // KNOWN BUG: the last remaining segmentation cannot be removed from the viewport
   // ("Remove from Viewport" is a silent no-op once it is the only one left), so the
   // panel keeps its segment row instead of clearing. Skipped until the bug is fixed.
+  // Tracked in https://github.com/OHIF/Viewers/issues/6090
   test.skip('should remove every segmentation from the viewport', async ({
     rightPanelPageObject,
   }) => {

--- a/tests/ContourSegmentationCrudInteractions.spec.ts
+++ b/tests/ContourSegmentationCrudInteractions.spec.ts
@@ -2,17 +2,16 @@ import { expect, test, visitStudy, visitStudyAndHydrate, waitForViewportsRendere
 import { expectRowSelected, expectRowNotSelected } from './utils/assertions';
 
 const studyInstanceUID = '1.2.840.113619.2.290.3.3767434740.226.1600859119.501';
-test.describe('Contour Segmentation interactions without RTSTRUCT', () => {
-  test.beforeEach(async ({ page, rightPanelPageObject }) => {
+test.describe('Contour Segmentation from an empty panel', () => {
+  test('should add a contour segmentation from the empty panel', async ({
+    rightPanelPageObject,
+    page,
+  }) => {
     await visitStudy(page, studyInstanceUID, 'segmentation', 2000);
     await waitForViewportsRendered(page);
     // Segmentation mode opens on the labelmap tab; switch to the contour tab.
     await rightPanelPageObject.contourSegmentationPanel.select();
-  });
 
-  test('should add a contour segmentation from the empty panel', async ({
-    rightPanelPageObject,
-  }) => {
     const { addSegmentationButton, panel, segmentationSelect } =
       rightPanelPageObject.contourSegmentationPanel;
 
@@ -25,10 +24,13 @@ test.describe('Contour Segmentation interactions without RTSTRUCT', () => {
     // The segmentation is added and becomes the active selection.
     await expect(segmentationSelect.selectedValue).toHaveText('Segmentation 1');
     await expect(panel.rows).toHaveCount(1);
+    const defaultSegment = panel.nthSegment(0);
+    await expect(defaultSegment.title).toHaveText('Segment 1');
+    await expectRowSelected(defaultSegment);
   });
 });
 
-test.describe('Contour Segmentation interactions on RTSTRUCT', () => {
+test.describe('Contour Segmentation interactions on RTSTRUCT panel', () => {
   test.beforeEach(async ({ page, leftPanelPageObject, DOMOverlayPageObject }) => {
     await visitStudyAndHydrate({
       page,
@@ -112,7 +114,12 @@ test.describe('Contour Segmentation interactions on RTSTRUCT', () => {
     await segmentationSelect.selectNthSegmentation(0);
     await expect(segmentationSelect.selectedValue).toHaveText('Contours on PET');
     await expect(panel.rows).toHaveCount(4);
-    await expect(panel.getSegmentLabels().filter({ hasText: 'Threshold' })).toHaveCount(1);
+    await expect(panel.getSegmentLabels()).toHaveText([
+      'Threshold',
+      'Big Sphere',
+      'Small Sphere',
+      'Large Box',
+    ]);
 
     // Switching back to the created segmentation shows only its default segment.
     await segmentationSelect.selectNthSegmentation(1);
@@ -173,7 +180,8 @@ test.describe('Contour Segmentation interactions on RTSTRUCT', () => {
   });
 
   test('should delete every segmentation until none remain', async ({ rightPanelPageObject }) => {
-    const { panel, addSegmentationButton } = rightPanelPageObject.contourSegmentationPanel;
+    const { panel, addSegmentationButton, segmentationSelect } =
+      rightPanelPageObject.contourSegmentationPanel;
 
     // Start with the hydrated RTSTRUCT plus two created segmentations.
     await panel.moreMenu.createNewSegmentation();
@@ -181,7 +189,9 @@ test.describe('Contour Segmentation interactions on RTSTRUCT', () => {
 
     // Delete each of the three segmentations one by one.
     await panel.moreMenu.delete();
+    await expect(segmentationSelect.selectedValue).toHaveText('Contours on PET');
     await panel.moreMenu.delete();
+    await expect(segmentationSelect.selectedValue).toHaveText('Segmentation 2');
     await panel.moreMenu.delete();
 
     // No segmentation remains, so the panel has no segment rows and the

--- a/tests/pages/RightPanelPageObject.ts
+++ b/tests/pages/RightPanelPageObject.ts
@@ -32,6 +32,10 @@ export class RightPanelPageObject {
         await page.getByRole('menuitem', { name: 'Rename' }).click();
         await this.DOMOverlayPageObject.dialog.input.fillAndSave(text);
       },
+      createNewSegmentation: async () => {
+        await button.click();
+        await page.getByRole('menuitem', { name: 'Create New Segmentation' }).click();
+      },
     };
   }
 
@@ -231,6 +235,17 @@ export class RightPanelPageObject {
     };
   }
 
+  /** The "Add Segment" row button of the active segmentation in the visible panel */
+  private get addSegmentButton() {
+    const button = this.page.getByRole('button', { name: 'Add Segment' });
+    return {
+      button,
+      click: async () => {
+        await button.click();
+      },
+    };
+  }
+
   private getSegmentsVisibilityToggle(type?: string) {
     const testId = type
       ? `all-segments-visibility-toggle-${type}`
@@ -276,6 +291,7 @@ export class RightPanelPageObject {
   get contourSegmentationPanel() {
     const page = this.page;
     const addSegmentationButton = this.addSegmentationButton;
+    const addSegmentButton = this.addSegmentButton;
     const panel = this.getSegmentationPanel('Contour');
     const menuButton = page.getByTestId('panelSegmentationWithToolsContour-btn');
     const segmentationSelect = this.getSegmentationSelect('Contour');
@@ -283,6 +299,7 @@ export class RightPanelPageObject {
 
     return {
       addSegmentationButton,
+      addSegmentButton,
       menuButton,
       segmentsVisibilityToggle,
       panel,
@@ -295,12 +312,14 @@ export class RightPanelPageObject {
   get labelMapSegmentationPanel() {
     const page = this.page;
     const addSegmentationButton = this.addSegmentationButton;
+    const addSegmentButton = this.addSegmentButton;
     const panel = this.getSegmentationPanel('Labelmap');
     const menuButton = page.getByTestId('panelSegmentationWithToolsLabelMap-btn');
     const segmentationSelect = this.getSegmentationSelect('Labelmap');
 
     return {
       addSegmentationButton,
+      addSegmentButton,
       menuButton,
       panel,
       segmentationSelect,

--- a/tests/pages/RightPanelPageObject.ts
+++ b/tests/pages/RightPanelPageObject.ts
@@ -2,6 +2,16 @@ import { Locator, Page } from '@playwright/test';
 
 import { DOMOverlayPageObject } from './DOMOverlayPageObject';
 
+/** The segmentation selector (dropdown) returned by the segmentation panels. */
+export type SegmentationSelect = {
+  locator: Locator;
+  selectedValue: Locator;
+  getSegmentationLabels: () => Promise<Locator>;
+  close: () => Promise<void>;
+  nthSegmentation: (n: number) => Promise<Locator>;
+  selectNthSegmentation: (n: number) => Promise<void>;
+};
+
 export class RightPanelPageObject {
   readonly page: Page;
   private readonly DOMOverlayPageObject: DOMOverlayPageObject;
@@ -213,7 +223,7 @@ export class RightPanelPageObject {
     };
   }
 
-  private getSegmentationSelect(type: string) {
+  private getSegmentationSelect(type: string): SegmentationSelect {
     const page = this.page;
     const suffix = type ? `-${type}` : '';
     const locator = page.getByTestId(`segmentation-select${suffix}`);

--- a/tests/pages/RightPanelPageObject.ts
+++ b/tests/pages/RightPanelPageObject.ts
@@ -216,6 +216,15 @@ export class RightPanelPageObject {
       locator,
       /** The span showing the currently selected segmentation label */
       selectedValue,
+      // Opens the dropdown and returns the option locator; leaves it open, so call close() after.
+      getSegmentationLabels: async () => {
+        await locator.click();
+        return page.getByRole('option');
+      },
+      // Click the selected option to dismiss without changing the active segmentation.
+      close: async () => {
+        await page.getByRole('option', { selected: true }).click();
+      },
       /** Opens the dropdown and returns a locator for the nth option (0-based) */
       nthSegmentation,
       /** Opens the dropdown and clicks the nth segmentation (0-based) */

--- a/tests/pages/RightPanelPageObject.ts
+++ b/tests/pages/RightPanelPageObject.ts
@@ -292,6 +292,11 @@ export class RightPanelPageObject {
       // Retrying-friendly locator for `expect(...).toHaveCount(n)` — prefer this
       // over the one-shot getSegmentCount() when asserting row counts.
       rows: page.getByTestId('data-row'),
+      /**
+       * @deprecated One-shot count that races the render. Prefer
+       * `expect(panel.rows).toHaveCount(n)` for assertions. Use this only to
+       * capture a stable baseline value (e.g. for a delta).
+       */
       getSegmentCount: async () => {
         return await page.getByTestId('data-row').count();
       },

--- a/tests/pages/RightPanelPageObject.ts
+++ b/tests/pages/RightPanelPageObject.ts
@@ -27,6 +27,10 @@ export class RightPanelPageObject {
         await button.click();
         await page.getByRole('menuitem', { name: 'Delete' }).click();
       },
+      removeFromViewport: async () => {
+        await button.click();
+        await page.getByRole('menuitem', { name: 'Remove from Viewport' }).click();
+      },
       rename: async (text: string) => {
         await button.click();
         await page.getByRole('menuitem', { name: 'Rename' }).click();

--- a/tests/pages/RightPanelPageObject.ts
+++ b/tests/pages/RightPanelPageObject.ts
@@ -32,6 +32,15 @@ export class RightPanelPageObject {
         await page.getByRole('menuitem', { name: 'Rename' }).click();
         await this.DOMOverlayPageObject.dialog.input.fillAndSave(text);
       },
+      cancelRename: async (newName?: string) => {
+        await button.click();
+        await page.getByRole('menuitem', { name: 'Rename' }).click();
+        if (newName) {
+          await this.DOMOverlayPageObject.dialog.input.fillAndCancel(newName);
+        } else {
+          await this.DOMOverlayPageObject.dialog.input.cancel();
+        }
+      },
       createNewSegmentation: async () => {
         await button.click();
         await page.getByRole('menuitem', { name: 'Create New Segmentation' }).click();

--- a/tests/utils/assertions.ts
+++ b/tests/utils/assertions.ts
@@ -77,3 +77,14 @@ export async function expectRowUnlocked(rowObject: { lockIcon: Locator }) {
 export async function expectRowNotSelected(rowObject) {
   await expect(rowObject.locator).not.toContainClass('bg-popover');
 }
+
+export async function expectSegmentationLabels(
+  segmentationSelect: {
+    getSegmentationLabels: () => Promise<Locator>;
+    close: () => Promise<void>;
+  },
+  labels: string[]
+) {
+  await expect(await segmentationSelect.getSegmentationLabels()).toHaveText(labels);
+  await segmentationSelect.close();
+}

--- a/tests/utils/assertions.ts
+++ b/tests/utils/assertions.ts
@@ -2,6 +2,7 @@ import { Locator, Page } from '@playwright/test';
 import { expect } from 'playwright-test-coverage';
 
 import { DOMOverlayPageObject } from '../pages';
+import type { SegmentationSelect } from '../pages/RightPanelPageObject';
 
 /**
  * Asserts the number of Modality Load Badges present on the page.
@@ -78,13 +79,12 @@ export async function expectRowNotSelected(rowObject) {
   await expect(rowObject.locator).not.toContainClass('bg-popover');
 }
 
+// Opens the segmentation selector, asserts its options match `labels`, then closes it.
 export async function expectSegmentationLabels(
-  segmentationSelect: {
-    getSegmentationLabels: () => Promise<Locator>;
-    close: () => Promise<void>;
-  },
+  segmentationSelect: SegmentationSelect,
   labels: string[]
 ) {
-  await expect(await segmentationSelect.getSegmentationLabels()).toHaveText(labels);
+  const options = await segmentationSelect.getSegmentationLabels();
+  await expect(options).toHaveText(labels);
   await segmentationSelect.close();
 }

--- a/tests/utils/assertions.ts
+++ b/tests/utils/assertions.ts
@@ -73,3 +73,7 @@ export async function expectRowLocked(rowObject: { lockIcon: Locator }) {
 export async function expectRowUnlocked(rowObject: { lockIcon: Locator }) {
   await expect(rowObject.lockIcon, 'Expected the row to not show the lock icon').toHaveCount(0);
 }
+
+export async function expectRowNotSelected(rowObject) {
+  await expect(rowObject.locator).not.toContainClass('bg-popover');
+}


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context
Expands Playwright e2e coverage for contour segmentation interactions. 


<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

- **New `ContourSegmentationCrudInteractions.spec.ts`** — add-from-empty-panel, create new segmentation, add multiple segments, list in selector, switch (order-independent), rename (confirm + cancel), delete, delete-all, remove-from-viewport.
- **Page object (`RightPanelPageObject`)** — add `createNewSegmentation`, `removeFromViewport`, `cancelRename`, `addSegmentButton`, and segmentation-selector `getSegmentationLabels`/`close`.
- **Test utils** — `expectSegmentationLabels`/`expectRowNotSelected` assertions.


### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->
All pass except the `test.skip` tracking #6090.

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] OS: macOS 26.4
- [x] Node version: 25.4.0
- [x] Browser: Chrome 149.0.7827.115


<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive Playwright coverage for Contour Segmentation CRUD interactions, including empty and RTSTRUCT-hydrated states, selection updates, renaming (confirm/cancel), deletion flows, and viewport removal behavior.
  * Expanded test infrastructure with a typed segmentation dropdown helper, improved “remove from viewport” support, and new assertions for verifying row selection state and dropdown label contents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Playwright end-to-end coverage for contour segmentation CRUD interactions, complementing the existing labelmap tests. The new spec, page-object helpers, and assertion utilities are well-structured and internally consistent.

- **`ContourSegmentationCrudInteractions.spec.ts`** — nine tests (one `test.skip` tracking a known upstream bug) exercising add-from-empty, create, multi-segment, selector listing, order-independent switching, rename confirm/cancel, delete, delete-all, and remove-from-viewport flows.
- **`RightPanelPageObject.ts`** — extends the collapsed more-menu with `createNewSegmentation`, `removeFromViewport`, and `cancelRename`; exposes `addSegmentButton` and the new `getSegmentationLabels`/`close` pair on the segmentation select object to both panel accessors.
- **`assertions.ts`** — adds `expectRowNotSelected` (inverse of the existing `expectRowSelected`) and `expectSegmentationLabels` (open → assert → close) to the shared assertion library.

<h3>Confidence Score: 5/5</h3>

Pure test additions with no changes to production code; safe to merge.

All changes are confined to the test layer. The new helpers follow the existing page-object patterns closely, the assertions use Playwright's retrying expect correctly, and the one known-broken scenario is properly skipped with a tracking issue reference.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| tests/ContourSegmentationCrudInteractions.spec.ts | New spec file with 9 tests (1 skipped) covering the full contour-segmentation CRUD lifecycle: add from empty, create, multi-segment, selector listing, switching, rename (confirm + cancel), delete, delete-all, and remove-from-viewport. |
| tests/pages/RightPanelPageObject.ts | Adds createNewSegmentation, removeFromViewport, cancelRename methods to the collapsed more-menu, exposes addSegmentButton on both panel accessors, and introduces getSegmentationLabels/close helpers on the segmentation select object. |
| tests/utils/assertions.ts | Adds expectRowNotSelected (counterpart to expectRowSelected) and expectSegmentationLabels (opens dropdown, asserts labels, then closes it) assertion helpers. |

</details>


</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `tests/ContourSegmentationCrudInteractions.spec.ts`, line 500-519 ([link](https://github.com/ohif/viewers/blob/7ceefaf5f1bad17c921e69874289c2374209357e/tests/ContourSegmentationCrudInteractions.spec.ts#L500-L519)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Delete-all activation order is order-sensitive**

   After creating `Segmentation 3` (active) on top of `Segmentation 2`, the first delete is expected to land on `Contours on PET` (line 510) rather than `Segmentation 2` (the immediately adjacent previous entry). If the application ever changes so that deleting the active segmentation activates the adjacent previous one instead of the first, this test will silently pass the deletion loop but fail on the `selectedValue` assertions — and the failure message won't make the order-dependency obvious. A comment explaining *why* the application skips to `Contours on PET` (e.g., "the implementation always falls back to the first segmentation in the list") would make the intent clear and help future maintainers.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: tests/ContourSegmentationCrudInteractions.spec.ts
   Line: 500-519

   Comment:
   **Delete-all activation order is order-sensitive**

   After creating `Segmentation 3` (active) on top of `Segmentation 2`, the first delete is expected to land on `Contours on PET` (line 510) rather than `Segmentation 2` (the immediately adjacent previous entry). If the application ever changes so that deleting the active segmentation activates the adjacent previous one instead of the first, this test will silently pass the deletion loop but fail on the `selectedValue` assertions — and the failure message won't make the order-dependency obvious. A comment explaining *why* the application skips to `Contours on PET` (e.g., "the implementation always falls back to the first segmentation in the list") would make the intent clear and help future maintainers.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

2. `tests/pages/RightPanelPageObject.ts`, line 595-609 ([link](https://github.com/ohif/viewers/blob/7ceefaf5f1bad17c921e69874289c2374209357e/tests/pages/RightPanelPageObject.ts#L595-L609)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`lockToggle` locator captured outside the row scope**

   `lockToggle` is resolved as `this.page.getByTestId('LockToggle')` — a page-wide locator, not scoped to the specific `row` being acted on. Both `lockToggleMenuItem` and `toggleLock` open the dropdown for that row and then interact with this page-wide locator. As long as only one actions menu is ever open at a time this is harmless, but if a test ever opens two menus (or if the testId appears elsewhere in the DOM) the locator will match unintended elements. Scoping it to the row (e.g., `row.getByTestId('LockToggle')`) would make the intent explicit and guard against that scenario.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: tests/pages/RightPanelPageObject.ts
   Line: 595-609

   Comment:
   **`lockToggle` locator captured outside the row scope**

   `lockToggle` is resolved as `this.page.getByTestId('LockToggle')` — a page-wide locator, not scoped to the specific `row` being acted on. Both `lockToggleMenuItem` and `toggleLock` open the dropdown for that row and then interact with this page-wide locator. As long as only one actions menu is ever open at a time this is harmless, but if a test ever opens two menus (or if the testId appears elsewhere in the DOM) the locator will match unintended elements. Scoping it to the row (e.g., `row.getByTestId('LockToggle')`) would make the intent explicit and guard against that scenario.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (4): Last reviewed commit: ["test(contour): refactor segmentation lab..."](https://github.com/ohif/viewers/commit/f785cc96faf18e1a6ef8552e53c7f8cf78782e9f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38391816)</sub>

<!-- /greptile_comment -->