### PR TITLE
fix(Cornerstone): guard volume validation when metadata is unavailable

### DIFF
--- a/extensions/cornerstone/src/components/ViewportDataOverlaySettingMenu/utils.ts
+++ b/extensions/cornerstone/src/components/ViewportDataOverlaySettingMenu/utils.ts
@@ -18,7 +18,8 @@ const isValidVolumeDisplaySet = imageIds => {
 
   try {
     return csUtils.isValidVolume(imageIds);
-  } catch {
+  } catch (e) {
+    console.warn('[isValidVolumeDisplaySet] isValidVolume threw, treating as invalid:', e);
     return false;
   }
 };

--- a/extensions/cornerstone/src/components/ViewportDataOverlaySettingMenu/utils.ts
+++ b/extensions/cornerstone/src/components/ViewportDataOverlaySettingMenu/utils.ts
@@ -5,6 +5,24 @@ export const DEFAULT_OPACITY = 0.5;
 export const DEFAULT_OPACITY_PERCENT = DEFAULT_OPACITY * 100;
 export const DERIVED_OVERLAY_MODALITIES = ['SEG', 'RTSTRUCT'];
 
+const getImageIdsFromDisplaySet = displaySet =>
+  displaySet?.imageIds ||
+  displaySet?.images?.map(image => image.imageId).filter(Boolean) ||
+  displaySet?.instances?.map(instance => instance.imageId).filter(Boolean) ||
+  [];
+
+const isValidVolumeDisplaySet = imageIds => {
+  if (!imageIds?.length) {
+    return false;
+  }
+
+  try {
+    return csUtils.isValidVolume(imageIds);
+  } catch {
+    return false;
+  }
+};
+
 /**
  * Get modality-specific color and opacity settings from the customization service
  */
@@ -60,11 +78,12 @@ export function getEnhancedDisplaySets({ viewportId, services }) {
     displaySetService.getDisplaySetByUID(displaySetUID)
   );
 
-  const backgroundCanBeVolume = csUtils.isValidVolume(viewportDisplaySets[0].imageIds || []);
   const backgroundDisplaySet = viewportDisplaySets[0];
+  const backgroundImageIds = getImageIdsFromDisplaySet(backgroundDisplaySet);
+  const backgroundCanBeVolume = isValidVolumeDisplaySet(backgroundImageIds);
 
   const enhancedDisplaySets = otherDisplaySets.map(displaySet => {
-    if (!backgroundDisplaySet.isReconstructable) {
+    if (!backgroundDisplaySet?.isReconstructable) {
       return {
         ...displaySet,
         isOverlayable: false,
@@ -98,10 +117,10 @@ export function getEnhancedDisplaySets({ viewportId, services }) {
         };
       }
 
-      const imageIds = displaySet.imageIds || displaySet.images?.map(image => image.imageId);
+      const imageIds = getImageIdsFromDisplaySet(displaySet);
       const isMultiframe = displaySet.isMultiFrame;
 
-      if (!isMultiframe && imageIds?.length > 0 && !csUtils.isValidVolume(imageIds)) {
+      if (!isMultiframe && imageIds?.length > 0 && !isValidVolumeDisplaySet(imageIds)) {
         return {
           ...displaySet,
           isOverlayable: false,

--- a/extensions/cornerstone/src/components/ViewportDataOverlaySettingMenu/utils.ts
+++ b/extensions/cornerstone/src/components/ViewportDataOverlaySettingMenu/utils.ts
@@ -7,8 +7,8 @@ export const DERIVED_OVERLAY_MODALITIES = ['SEG', 'RTSTRUCT'];
 
 const getImageIdsFromDisplaySet = displaySet =>
   displaySet?.imageIds ||
-  displaySet?.images?.map(image => image.imageId).filter(Boolean) ||
-  displaySet?.instances?.map(instance => instance.imageId).filter(Boolean) ||
+  displaySet?.images?.map(image => image?.imageId).filter(Boolean) ||
+  displaySet?.instances?.map(instance => instance?.imageId).filter(Boolean) ||
   [];
 
 const isValidVolumeDisplaySet = imageIds => {

--- a/extensions/cornerstone/src/services/CornerstoneCacheService/CornerstoneCacheService.ts
+++ b/extensions/cornerstone/src/services/CornerstoneCacheService/CornerstoneCacheService.ts
@@ -142,7 +142,7 @@ class CornerstoneCacheService {
     // the 1st display set is the one of interest
     const [displaySet] = displaySets;
     if (!displaySet.imageIds) {
-      displaySet.imagesIds = this._getCornerstoneStackImageIds(displaySet, dataSource);
+      displaySet.imageIds = this._getCornerstoneStackImageIds(displaySet, dataSource);
     }
     const { imageIds: data, viewportType: dsViewportType } = displaySet;
     return {


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

When opening some multi-frame DICOM studies from JSON metadata, the viewport overlay/rendering controls can crash while evaluating overlay display sets.

The crash happens in `getEnhancedDisplaySets` when `csUtils.isValidVolume(imageIds)` is called before Cornerstone metadata is available for one or more imageIds.

Example error:

```text
TypeError: Cannot destructure property 'modality' of 'metaData.get(...)' as it is undefined.
    at Module.isValidVolume
    at getEnhancedDisplaySets
    at useViewportDisplaySets
    at useViewportRendering
    at AdvancedRenderingControls
```

This can happen during viewport initialization, where the display set already has imageIds but the metadata provider is not ready for all of them yet.

Fixes #5680
Fixes #5909

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

- Add a defensive helper around `csUtils.isValidVolume`.
- Return `false` when there are no imageIds or when volume validation throws because metadata is unavailable.
- Reuse the same helper for background and foreground display set volume checks.
- Fix a typo in `CornerstoneCacheService` where stack image IDs were assigned to `imagesIds` instead of `imageIds`.

Before:

- The viewport UI could crash when `isValidVolume` tried to read missing metadata.

After:

- The display set is treated as not volume-compatible until metadata is available, and the viewport UI does not crash.

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

Tested locally with a multi-frame DICOM study loaded from JSON metadata.

- Started the OHIF viewer locally.
- Opened a study containing a multi-frame DICOM instance.
- Verified that viewport overlay/rendering controls no longer crash with metaData.get(...) is undefined.

Also ran:

```
./node_modules/.bin/prettier --write extensions/cornerstone/src/components/ViewportDataOverlaySettingMenu/utils.ts
NX_SKIP_NX_CACHE=true npx lerna run build --scope @ohif/extension-cornerstone --stream
```

The extension build completed successfully.

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals. 

No public API additions or removals were made.

#### Tested Environment

- [x] OS: Windows 11 (WSL)
- [x] Node version: 24.2.0
- [x] Browser: Google Chrome 149.0.7827.116

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected how image identifiers are populated in cached viewport data, ensuring consistent downstream access to the right image IDs.
* **Improvements**
  * Enhanced background/volume overlay eligibility by more reliably extracting image IDs across varied display-set formats.
  * When image IDs are missing or validation fails, the overlay is now treated as invalid for more consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR guards against a crash in `getEnhancedDisplaySets` when Cornerstone metadata is not yet available for all imageIds during viewport initialization, and fixes a typo in `CornerstoneCacheService` that silently wrote stack image IDs to the wrong property name.

- Introduces `isValidVolumeDisplaySet`, a try/catch wrapper around `csUtils.isValidVolume` that returns `false` (with a `console.warn`) instead of crashing when metadata is absent; both background and foreground volume checks now use it.
- Adds `getImageIdsFromDisplaySet` to normalize imageId extraction across the three display set shapes (`imageIds`, `images[].imageId`, `instances[].imageId`), always returning at least `[]`.
- Fixes the `imagesIds` → `imageIds` typo in `CornerstoneCacheService._getOtherViewportData` so that `displaySet.imageIds` is actually populated and readable by downstream consumers.

<h3>Confidence Score: 5/5</h3>

Safe to merge — both changes are narrowly scoped defensive fixes with no behavioural regressions on the happy path.

The crash guard in `isValidVolumeDisplaySet` only activates when `csUtils.isValidVolume` throws or receives an empty array, leaving normal execution unchanged. The typo fix in `CornerstoneCacheService` corrects a silent no-op assignment so that `displaySet.imageIds` is correctly populated; the return value shape of the function is unaffected. No new logic branches, no API surface changes, and the previous review concern about silent swallowing was already addressed with a `console.warn`.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| extensions/cornerstone/src/components/ViewportDataOverlaySettingMenu/utils.ts | Adds `getImageIdsFromDisplaySet` and `isValidVolumeDisplaySet` helpers to guard against crashes when metadata is unavailable; replaces direct `csUtils.isValidVolume` calls with the safe wrapper throughout `getEnhancedDisplaySets`. |
| extensions/cornerstone/src/services/CornerstoneCacheService/CornerstoneCacheService.ts | One-line typo fix: `imagesIds` → `imageIds` so the populated property is actually readable by downstream consumers via `displaySet.imageIds`. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["Update extensions/cornerstone/src/compon..."](https://github.com/ohif/viewers/commit/81cf2e71641a19492958183ca134a2caee3898aa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38477098)</sub>

<!-- /greptile_comment -->