### PR TITLE
fix: pnpm related dependency bugs - nothing funcitonal

### DIFF
--- a/platform/docs/package.json
+++ b/platform/docs/package.json
@@ -84,6 +84,10 @@
     "typescript": "5.5.4",
     "url-loader": "4.1.1"
   },
+  "devDependencies": {
+    "@ohif/core": "workspace:*",
+    "@ohif/ui-next": "workspace:*"
+  },
   "browserslist": {
     "production": [
       ">0.5%",

--- a/platform/ui-next/package.json
+++ b/platform/ui-next/package.json
@@ -70,8 +70,5 @@
     "@babel/plugin-transform-private-property-in-object": "7.29.7",
     "cross-env": "7.0.3"
   },
-  "peerDependencies": {
-    "@ohif/core": "workspace:*"
-  },
   "keywords": []
 }

--- a/platform/ui-next/package.json
+++ b/platform/ui-next/package.json
@@ -70,5 +70,8 @@
     "@babel/plugin-transform-private-property-in-object": "7.29.7",
     "cross-env": "7.0.3"
   },
+  "peerDependencies": {
+    "@ohif/core": "workspace:*"
+  },
   "keywords": []
 }

--- a/platform/ui-next/src/contextProviders/ViewportGridProvider.tsx
+++ b/platform/ui-next/src/contextProviders/ViewportGridProvider.tsx
@@ -9,6 +9,17 @@ import React, {
 import merge from 'lodash.merge';
 
 import PropTypes from 'prop-types';
+// NOTE: `@ohif/core` is intentionally NOT declared in this package's
+// package.json (neither as a dependency nor a peerDependency). It is treated as
+// an implicit peer, satisfied by the consuming application via the monorepo
+// workspace. Declaring it as `"@ohif/core": "workspace:*"` was tried and
+// reverted: the release/publish process does not rewrite `workspace:*` ranges
+// inside `peerDependencies`, so the published tarball shipped a literal
+// `workspace:*` peer that non-pnpm package managers (npm/yarn) cannot resolve.
+// A plain `"*"` range would be an acceptable workaround if we ever want it
+// declared, but for now it stays undeclared. Note: the docs site (platform/docs)
+// must therefore add `@ohif/core` as a devDependency itself, because pulling in
+// the ui-next barrel reaches this module and nothing else anchors the import.
 import { ViewportGridService, utils } from '@ohif/core';
 
 const DEFAULT_STATE: AppTypes.ViewportGrid.State = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1954,9 +1954,6 @@ importers:
 
   platform/ui-next:
     dependencies:
-      '@ohif/core':
-        specifier: workspace:*
-        version: link:../core
       '@radix-ui/react-accordion':
         specifier: 1.2.11
         version: 1.2.11(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1795,6 +1795,13 @@ importers:
       url-loader:
         specifier: 4.1.1
         version: 4.1.1(file-loader@6.2.0(webpack@5.105.0(@swc/core@1.15.13(@swc/helpers@0.5.21))))(webpack@5.105.0(@swc/core@1.15.13(@swc/helpers@0.5.21)))
+    devDependencies:
+      '@ohif/core':
+        specifier: workspace:*
+        version: link:../core
+      '@ohif/ui-next':
+        specifier: workspace:*
+        version: link:../ui-next
 
   platform/i18n:
     dependencies:
@@ -1947,6 +1954,9 @@ importers:
 
   platform/ui-next:
     dependencies:
+      '@ohif/core':
+        specifier: workspace:*
+        version: link:../core
       '@radix-ui/react-accordion':
         specifier: 1.2.11
         version: 1.2.11(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)


### PR DESCRIPTION
### Context
pnpm was missing some dependencies that it is more strict about than the yarn version

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] OS: <!--[e.g. Windows 10, macOS 10.15.4]-->
- [] Node version: <!--[e.g. 18.16.1]-->
- [] Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated development dependencies for the documentation site.

* **Documentation**
  * Added clarification regarding dependency resolution in the codebase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes pnpm-specific dependency resolution issues caused by pnpm's stricter hoisting rules compared to Yarn. The core fix declares `@ohif/core` and `@ohif/ui-next` as `devDependencies` in `platform/docs/package.json` so pnpm can anchor the transitive `@ohif/core` import in `ViewportGridProvider.tsx`, and adds a detailed inline comment explaining why `@ohif/core` is deliberately left undeclared in `platform/ui-next/package.json`.

- **`platform/docs/package.json`**: Adds `@ohif/core` and `@ohif/ui-next` as `workspace:*` `devDependencies`. This is safe because `ohif-docs` is `private: true`, so pnpm never publishes it and never needs to rewrite the `workspace:*` range.
- **`platform/ui-next/src/contextProviders/ViewportGridProvider.tsx`**: Adds a comment-only block explaining the intentional omission of `@ohif/core` from `ui-next`'s manifest — specifically that `workspace:*` in `peerDependencies` was reverted because the publish pipeline did not rewrite it, leaving a literal `workspace:*` in the released tarball.
- **`pnpm-lock.yaml`**: Regenerated automatically to reflect the above changes.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are limited to dependency declarations in a private package and an explanatory code comment; no runtime logic is altered.

The only code-level change is a comment block in ViewportGridProvider.tsx. The package.json edit adds workspace devDependencies to a private, never-published package, which is the correct fix for pnpm's stricter resolution. The lockfile is auto-generated. Nothing functional is touched.

No files require special attention, though confirming the lockfile is stable with a fresh pnpm install is a good sanity check.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| platform/docs/package.json | Adds @ohif/core and @ohif/ui-next as devDependencies (workspace:*) so pnpm can resolve the implicit transitive import in ViewportGridProvider; safe because this package is private:true |
| platform/ui-next/src/contextProviders/ViewportGridProvider.tsx | Adds a detailed block comment explaining why @ohif/core is intentionally omitted from ui-next's package.json; no logic changes |
| pnpm-lock.yaml | Auto-generated lockfile regenerated after the dependency changes; should be verified with a fresh pnpm install to confirm it is stable |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["Undo peer dependency due to non-pnpm int..."](https://github.com/ohif/viewers/commit/f5500b79fb8d4c0b20655c533da68b19ebd08b54) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38668029)</sub>

<!-- /greptile_comment -->