### PR TITLE
fix: Release deploy of docs

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -112,9 +112,13 @@ jobs:
         run: pnpm --filter ohif-docs run build
 
       - name: Deploy to Netlify
-        run: |
-          cd platform/docs
-          npx netlify-cli deploy --dir=./build --prod
+        # The docs are already built by the "Build docs" step above, so pass
+        # --no-build: `netlify deploy` runs the build command by default, which
+        # would otherwise pick up the repo-root netlify.toml (configured for the
+        # main viewer app) and build the wrong project. --dir is resolved
+        # relative to the repo root (the netlify.toml base), not the cwd, so it
+        # must be the full path to the prebuilt docs output.
+        run: npx netlify-cli deploy --dir=platform/docs/build --prod --no-build
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}


### PR DESCRIPTION
No functional change, just deploy the docs in the newer pnpm world

### Context

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] OS: <!--[e.g. Windows 10, macOS 10.15.4]-->
- [] Node version: <!--[e.g. 18.16.1]-->
- [] Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized documentation deployment configuration to improve build consistency and prevent redundant build steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the docs deployment step in the GitHub Actions workflow to work correctly in the pnpm monorepo. The old approach `cd`-ed into `platform/docs` before invoking `netlify-cli`, but without `--no-build` the CLI would still attempt to run its own build using the repo-root `netlify.toml` (which targets the main viewer app, not the docs).

- The deploy step now uses `--no-build` so netlify-cli deploys the already-built output without triggering a second build, and `--dir` is updated to the repo-root-relative path `platform/docs/build` to match the new working directory assumption.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a targeted, well-explained one-liner fix with no functional side-effects on the rest of the workflow.

The only touched file is the docs deploy step of a GitHub Actions workflow. The fix is minimal and correct: it prevents netlify-cli from running a redundant (and wrong) build by adding `--no-build`, and adjusts the `--dir` path to be repo-root-relative to match the new invocation context. Secrets remain properly sourced from environment variables, and the rest of the workflow is untouched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/build-docs.yml | Replaces a two-step `cd + npx netlify-cli deploy` invocation with a single-line deploy using `--no-build` and a repo-root-relative `--dir`, preventing netlify-cli from re-running the wrong build via the root `netlify.toml`. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: Release deploy of docs"](https://github.com/ohif/viewers/commit/8ca2647f0fe624b0052f9f8ad4e8d1de34fe2a2e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38682670)</sub>

<!-- /greptile_comment -->