### PR TITLE
test(segmentation): switch getSegmentCount to expect(rows).toHaveCount in panel specs

### DIFF
--- a/tests/ContourSegmentColorChange.spec.ts
+++ b/tests/ContourSegmentColorChange.spec.ts
@@ -152,8 +152,7 @@ test('duplicated contour will be generated with a new color', async ({
   );
 
   // duplicate the segment
-  const initialCount = await panel.getSegmentCount();
-  expect(initialCount, 'Expected to start with 4 segments').toBe(4);
+  await expect(panel.rows, 'Expected to start with 4 segments').toHaveCount(4);
   await segment0.actions.duplicate();
   await segment0.toggleVisibility(); // toggle original segment 0 visibility off to be able to grab the duplicated segment's path
 

--- a/tests/ContourSegmentDelete.spec.ts
+++ b/tests/ContourSegmentDelete.spec.ts
@@ -20,16 +20,14 @@ test('should delete a contour segment and remove its row from the panel', async 
 }) => {
   const panel = rightPanelPageObject.contourSegmentationPanel.panel;
 
-  const initialCount = await panel.getSegmentCount();
-  expect(initialCount, 'Expected to load with 4 segments').toBe(4);
+  await expect(panel.rows, 'Expected to load with 4 segments').toHaveCount(4);
 
   const segment0 = panel.nthSegment(0);
   await expect(segment0.title).toHaveText(defaultSegment0Name);
 
   await segment0.actions.delete();
 
-  const countAfterDelete = await panel.getSegmentCount();
-  expect(countAfterDelete, 'Expected one fewer segment row after deleting').toBe(3);
+  await expect(panel.rows, 'Expected one fewer segment row after deleting').toHaveCount(3);
   // The deleted segment's label should no longer be present anywhere in the panel
   await expect(
     panel.getSegmentLabels().filter({ hasText: defaultSegment0Name }),
@@ -46,16 +44,13 @@ test('should delete a contour segment and remove its row from the panel', async 
 test('should delete multiple contour segments sequentially', async ({ rightPanelPageObject }) => {
   const panel = rightPanelPageObject.contourSegmentationPanel.panel;
 
-  const initialCount = await panel.getSegmentCount();
-  expect(initialCount, 'Expected to load with 4 segments').toBe(4);
+  await expect(panel.rows, 'Expected to load with 4 segments').toHaveCount(4);
 
   await panel.nthSegment(0).actions.delete();
-  const countAfterFirstDelete = await panel.getSegmentCount();
-  expect(countAfterFirstDelete, 'Expected 3 segments after first delete').toBe(3);
+  await expect(panel.rows, 'Expected 3 segments after first delete').toHaveCount(3);
 
   await panel.nthSegment(0).actions.delete();
-  const countAfterSecondDelete = await panel.getSegmentCount();
-  expect(countAfterSecondDelete, 'Expected 2 segments after second delete').toBe(2);
+  await expect(panel.rows, 'Expected 2 segments after second delete').toHaveCount(2);
 
   await expect(
     panel.getSegmentLabels().filter({ hasText: defaultSegment0Name }),

--- a/tests/ContourSegmentDuplicate.spec.ts
+++ b/tests/ContourSegmentDuplicate.spec.ts
@@ -25,19 +25,20 @@ test('should duplicate a contour segment and add a new row to the panel', async 
 }) => {
   const panel = rightPanelPageObject.contourSegmentationPanel.panel;
 
-  const initialCount = await panel.getSegmentCount();
-  expect(initialCount, 'Expected to load with 4 segments').toBe(4);
+  await expect(panel.rows, 'Expected to load with 4 segments').toHaveCount(4);
 
   const segment0 = panel.nthSegment(0);
   await expect(segment0.title).toHaveText(defaultSegment0Name);
 
   await segment0.actions.duplicate();
 
-  const countAfterDuplicate = await panel.getSegmentCount();
-  expect(countAfterDuplicate, 'Expected one additional segment row after duplicating').toBe(5);
+  await expect(
+    panel.rows,
+    'Expected one additional segment row after duplicating'
+  ).toHaveCount(5);
 
   //New segment's default name is formatted as "Segment {segmentCount}"
-  const newSegmentLocator = panel.nthSegment(initialCount).title;
+  const newSegmentLocator = panel.nthSegment(4).title;
   await expect(newSegmentLocator, 'Expected correct title for duplicated segment').toHaveText(
     `Segment 5`
   );
@@ -53,10 +54,10 @@ test('should duplicate the same segment multiple times', async ({ rightPanelPage
   const segment0 = panel.nthSegment(0);
 
   await segment0.actions.duplicate();
-  expect(
-    await panel.getSegmentCount(),
+  await expect(
+    panel.rows,
     'Expected one additional segment row after duplicating'
-  ).toBe(5);
+  ).toHaveCount(5);
 
   const firstDuplicateTitleLocator = panel.nthSegment(4).title;
   await expect(
@@ -65,10 +66,10 @@ test('should duplicate the same segment multiple times', async ({ rightPanelPage
   ).toHaveText(`Segment 5`);
 
   await segment0.actions.duplicate();
-  expect(
-    await panel.getSegmentCount(),
+  await expect(
+    panel.rows,
     'Expected another segment row after duplicating the same segment again'
-  ).toBe(6);
+  ).toHaveCount(6);
 
   const secondDuplicateTitleLocator = panel.nthSegment(5).title;
   await expect(

--- a/tests/SEGHydrationDeleteAndReload.spec.ts
+++ b/tests/SEGHydrationDeleteAndReload.spec.ts
@@ -34,7 +34,7 @@ test('should fully remove segmentation overlay after repeated load-and-delete cy
   await rightPanelPageObject.labelMapSegmentationPanel.panel.moreMenu.delete();
   await viewportRenderCycle;
 
-  expect(await rightPanelPageObject.labelMapSegmentationPanel.panel.getSegmentCount()).toBe(0);
+  await expect(rightPanelPageObject.labelMapSegmentationPanel.panel.rows).toHaveCount(0);
 
   // reload SEG series
   viewportRenderCycle = waitForViewportRenderCycle(page);
@@ -57,7 +57,7 @@ test('should fully remove segmentation overlay after repeated load-and-delete cy
   await rightPanelPageObject.labelMapSegmentationPanel.panel.moreMenu.delete();
   await viewportRenderCycle;
 
-  expect(await rightPanelPageObject.labelMapSegmentationPanel.panel.getSegmentCount()).toBe(0);
+  await expect(rightPanelPageObject.labelMapSegmentationPanel.panel.rows).toHaveCount(0);
 
   await checkForScreenshot(
     page,

--- a/tests/SEGHydrationThen3DOnly.spec.ts
+++ b/tests/SEGHydrationThen3DOnly.spec.ts
@@ -23,7 +23,8 @@ test.beforeEach(
 );
 
 test('should list segments in side panel for 3D only view', async ({ rightPanelPageObject }) => {
-  const numberOfSegments =
-    await rightPanelPageObject.labelMapSegmentationPanel.panel.getSegmentCount();
-  expect(numberOfSegments, 'The side panel should list 13 segments for the 3D only view.').toBe(13);
+  await expect(
+    rightPanelPageObject.labelMapSegmentationPanel.panel.rows,
+    'The side panel should list 13 segments for the 3D only view.'
+  ).toHaveCount(13);
 });

--- a/tests/pages/RightPanelPageObject.ts
+++ b/tests/pages/RightPanelPageObject.ts
@@ -255,6 +255,11 @@ export class RightPanelPageObject {
       // Retrying-friendly locator for `expect(...).toHaveCount(n)` — prefer this
       // over the one-shot getSegmentCount() when asserting row counts.
       rows: page.getByTestId('data-row'),
+      /**
+       * @deprecated One-shot count that races the render. Prefer
+       * `expect(panel.rows).toHaveCount(n)` for assertions. Use this only to
+       * capture a stable baseline value (e.g. for a delta).
+       */
       getSegmentCount: async () => {
         return await page.getByTestId('data-row').count();
       },


### PR DESCRIPTION
### Context

The segmentation-panel E2E specs asserted row counts with the one-shot `panel.getSegmentCount()` helper, which reads the row count a single time. Because segment rows render asynchronously after add/delete/duplicate/hydration, that read raced the render and was intermittently flaky (occasionally returning `0`).

This PR switches those assertions to Playwright's retrying `expect(panel.rows).toHaveCount(n)`, which polls until the expected count is reached (or times out).

### Changes & Results

- `RightPanelPageObject` exposes a `panel.rows` locator and marks `getSegmentCount()` `@deprecated`, kept only as an escape hatch for capturing a stable baseline value (e.g. for a delta).
- Migrated all `getSegmentCount()` assertion call sites to `await expect(panel.rows).toHaveCount(n)`:
  - `ContourSegmentDelete.spec.ts`
  - `ContourSegmentDuplicate.spec.ts` (also replaced `nthSegment(initialCount)` with the literal `nthSegment(4)`, matching the sibling test)
  - `ContourSegmentColorChange.spec.ts`
  - `SEGHydrationThen3DOnly.spec.ts`
  - `SEGHydrationDeleteAndReload.spec.ts`
- No production code changed — this is test-infrastructure only.

**Before**

```ts
const count = await panel.getSegmentCount();
expect(count).toBe(4);
```

**After**

```ts
await expect(panel.rows).toHaveCount(4);
```

### Testing

Run the affected specs:

```bash
TEST_ENV=true pnpm exec playwright test \
  tests/ContourSegmentDelete.spec.ts \
  tests/ContourSegmentDuplicate.spec.ts \
  tests/ContourSegmentColorChange.spec.ts \
  tests/SEGHydrationThen3DOnly.spec.ts \
  tests/SEGHydrationDeleteAndReload.spec.ts
```

All 13 tests pass locally (`13 passed (38.0s)`).

### Checklist

#### PR

- [x] My Pull Request title is descriptive, accurate and follows the semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments, etc.)

#### Public Documentation Updates

- [x] The documentation page has been updated as necessary for any public API additions or removals. (N/A — test-only change, no public API affected.)

#### Tested Environment

- [x] OS: macOS (Darwin 25.5.0)
- [x] Node version: v25.4.0
- [x] Browser: Chromium (Playwright 1.56.1 bundled)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated segmentation-panel checks to use the displayed row list for count verification, improving reliability across delete, duplicate, hydration, and 3D-only scenarios.
* **Documentation**
  * Marked one count helper as deprecated and clarified the preferred way to verify visible rows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->