### PR TITLE
fix(ci): deploy docs with Netlify CLI monorepo filter

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -117,8 +117,9 @@ jobs:
         # would otherwise pick up the repo-root netlify.toml (configured for the
         # main viewer app) and build the wrong project. --dir is resolved
         # relative to the repo root (the netlify.toml base), not the cwd, so it
-        # must be the full path to the prebuilt docs output.
-        run: npx netlify-cli deploy --dir=platform/docs/build --prod --no-build
+        # must be the full path to the prebuilt docs output. --filter selects
+        # the ohif-docs package so Netlify CLI does not abort on monorepo detection.
+        run: npx netlify-cli deploy --filter ohif-docs --dir=platform/docs/build --prod --no-build
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}


### PR DESCRIPTION
## Summary
- Adds `--filter ohif-docs` to the Netlify deploy step in `build-docs.yml`
- Fixes docs CI publish failures since #6095, where Netlify CLI 26 refuses to deploy from the monorepo root without a project filter

## Context
The Build and Deploy Docs workflow has been failing at the deploy step with:

```
We've detected multiple projects inside your repository
Error: Projects detected: @ohif/app, @ohif/cli, @ohif/core, ohif-docs, ...
```

Docs build succeeds; only deploy is blocked. The last successful publish was June 10.

## Test plan
- [ ] Merge to `master`
- [ ] Confirm the Build and Deploy Docs workflow completes the "Deploy to Netlify" step
- [ ] Verify https://docs.ohif.org reflects the latest master content


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the documentation deployment workflow to better handle the monorepo setup.
  * Netlify now targets the correct docs workspace and uses the prebuilt docs output more reliably, helping prevent deployment failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->