### PR TITLE
fix: Several new worklist issues

### DIFF
--- a/extensions/default/src/commandsModule.ts
+++ b/extensions/default/src/commandsModule.ts
@@ -833,6 +833,33 @@ const commandsModule = ({
         }
       };
     },
+
+    /**
+     * Launches a workflow (mode) for a study from the worklist. This is the
+     * default `workList.onStudyDoubleClick` command.
+     *
+     * @param study - the StudyRow the action applies to
+     * @param workflows - the workflows applicable to the study, in menu order;
+     *   each has `id`, `displayName`, `isDefault` and `launchWithStudy(study)`
+     * @param defaultWorkflow - the user's default workflow when it applies to
+     *   the study
+     * @param workflowId - command option to force a specific workflow (mode id)
+     *   instead of the default/first applicable one
+     */
+    launchDefaultMode: ({ study, workflows = [], defaultWorkflow, workflowId }) => {
+      const workflow = workflowId
+        ? workflows.find(w => w.id === workflowId)
+        : (defaultWorkflow ?? workflows[0]);
+      if (!workflow) {
+        console.warn(
+          workflowId
+            ? `launchDefaultMode: workflow '${workflowId}' is not applicable to the study`
+            : 'launchDefaultMode: no workflow is applicable to the study'
+        );
+        return;
+      }
+      workflow.launchWithStudy(study);
+    },
   };
 
   const definitions = {
@@ -862,6 +889,10 @@ const commandsModule = ({
     addDisplaySetAsLayer: actions.addDisplaySetAsLayer,
     removeDisplaySetLayer: actions.removeDisplaySetLayer,
     createStoreFunction: actions.createStoreFunction,
+    launchDefaultMode: {
+      commandFn: actions.launchDefaultMode,
+      context: 'WORKLIST',
+    },
   };
 
   return {

--- a/extensions/default/src/customizations/workListCustomization.ts
+++ b/extensions/default/src/customizations/workListCustomization.ts
@@ -67,18 +67,27 @@ import { StudyList } from '@ohif/ui-next';
  *   `<StudyList.PreviewContainer>` layout is used.
  *   Currently only applies when `workList.variant` is `'default'`.
  *
- * - `workList.onStudyDoubleClick`: `(study, context) => void` (default: undefined)
- *   Replaces the built-in double-click action on a study row. By default a
- *   double click selects the row and launches the default workflow (mode), or
- *   the first workflow applicable to the study when no default is set. When a
- *   function is provided it is called instead (the row is still selected
- *   first) with:
+ * - `workList.onStudyDoubleClick`: command run input (default:
+ *   `{ commandName: 'launchDefaultMode' }`)
+ *   The command(s) run when a study row is double-clicked (the row is selected
+ *   first). Accepts anything `commandsManager.run` does: a command name string,
+ *   `{ commandName, commandOptions, context }`, an array of those, or a plain
+ *   function. At call time these are merged into the command options (a plain
+ *   function receives them as its single argument):
  *   - `study`: the double-clicked `StudyRow`.
- *   - `context.workflows`: the workflows applicable to the study, in the same
- *     order as the row's Launch Workflow menu. Each has `id`, `displayName`,
+ *   - `workflows`: the workflows applicable to the study, in the same order as
+ *     the row's Launch Workflow menu. Each has `id`, `displayName`,
  *     `isDefault`, and `launchWithStudy(study)`.
- *   - `context.defaultWorkflow`: the user's default workflow when it applies
- *     to the study, else `undefined`.
+ *   - `defaultWorkflow`: the user's default workflow when it applies to the
+ *     study, else `undefined`.
+ *   The default `launchDefaultMode` command launches `defaultWorkflow`,
+ *   falling back to the first applicable workflow. Override the options to
+ *   always launch a specific mode:
+ *   `{ commandName: 'launchDefaultMode', commandOptions: { workflowId: 'segmentation' } }`.
+ *   Modes can contribute their own commands for this via a `getCommandsModule`
+ *   export on the mode definition, registered at app init in the 'WORKLIST'
+ *   context — before any mode route is entered. When set to a falsy value the
+ *   built-in StudyList.Table double-click behavior applies.
  *   Currently only applies when `workList.variant` is `'default'`.
  *
  * - `workList.settingsMenuItems`: `(defaults) => SettingsMenuItem[]` (default: identity)
@@ -96,7 +105,7 @@ export default function getWorkListCustomization() {
     'workList.previewSeriesView': 'all',
     'workList.columns': StudyList.defaultColumns,
     'workList.renderPreviewContent': undefined,
-    'workList.onStudyDoubleClick': undefined,
+    'workList.onStudyDoubleClick': { commandName: 'launchDefaultMode' },
     'workList.settingsMenuItems': (defaults: unknown) => defaults,
   };
 }

--- a/extensions/default/src/customizations/workListCustomization.ts
+++ b/extensions/default/src/customizations/workListCustomization.ts
@@ -67,6 +67,20 @@ import { StudyList } from '@ohif/ui-next';
  *   `<StudyList.PreviewContainer>` layout is used.
  *   Currently only applies when `workList.variant` is `'default'`.
  *
+ * - `workList.onStudyDoubleClick`: `(study, context) => void` (default: undefined)
+ *   Replaces the built-in double-click action on a study row. By default a
+ *   double click selects the row and launches the default workflow (mode), or
+ *   the first workflow applicable to the study when no default is set. When a
+ *   function is provided it is called instead (the row is still selected
+ *   first) with:
+ *   - `study`: the double-clicked `StudyRow`.
+ *   - `context.workflows`: the workflows applicable to the study, in the same
+ *     order as the row's Launch Workflow menu. Each has `id`, `displayName`,
+ *     `isDefault`, and `launchWithStudy(study)`.
+ *   - `context.defaultWorkflow`: the user's default workflow when it applies
+ *     to the study, else `undefined`.
+ *   Currently only applies when `workList.variant` is `'default'`.
+ *
  * - `workList.settingsMenuItems`: `(defaults) => SettingsMenuItem[]` (default: identity)
  *   Builds the items in the WorkList settings popover. Receives the default
  *   items (`about`, `userPreferences`, and `logout` when OIDC is configured)
@@ -82,6 +96,7 @@ export default function getWorkListCustomization() {
     'workList.previewSeriesView': 'all',
     'workList.columns': StudyList.defaultColumns,
     'workList.renderPreviewContent': undefined,
+    'workList.onStudyDoubleClick': undefined,
     'workList.settingsMenuItems': (defaults: unknown) => defaults,
   };
 }

--- a/platform/app/src/appInit.js
+++ b/platform/app/src/appInit.js
@@ -130,19 +130,39 @@ async function appInit(appConfigOrFunc, defaultExtensions, defaultModes) {
     }
     const { id } = mode;
 
-    if (mode.modeFactory) {
-      // If the appConfig contains configuration for this mode, use it.
-      const modeConfiguration =
-        appConfig.modesConfiguration && appConfig.modesConfiguration[id]
-          ? appConfig.modesConfiguration[id]
-          : {};
-
-      mode = await mode.modeFactory({ modeConfiguration, loadModules });
-    }
-
     if (modesById.has(id)) {
       continue;
     }
+
+    // If the appConfig contains configuration for this mode, use it.
+    const modeConfiguration =
+      appConfig.modesConfiguration && appConfig.modesConfiguration[id]
+        ? appConfig.modesConfiguration[id]
+        : {};
+
+    // Mirrors the extension commands path for modes, but registers before the
+    // mode is instantiated so the commands are usable on the worklist, ahead
+    // of any mode route being entered. Definitions land in the 'WORKLIST'
+    // context unless the module (or an individual command) declares its own.
+    if (typeof mode.getCommandsModule === 'function') {
+      extensionManager.registerCommandsModule(
+        mode.getCommandsModule({
+          appConfig,
+          commandsManager,
+          servicesManager,
+          serviceProvidersManager,
+          hotkeysManager,
+          extensionManager,
+          modeConfiguration,
+        }),
+        'WORKLIST'
+      );
+    }
+
+    if (mode.modeFactory) {
+      mode = await mode.modeFactory({ modeConfiguration, loadModules });
+    }
+
     // Prevent duplication
     modesById.add(id);
     if (!mode || typeof mode !== 'object') {

--- a/platform/app/src/routes/WorkList/WorkList.tsx
+++ b/platform/app/src/routes/WorkList/WorkList.tsx
@@ -9,7 +9,7 @@ import {
   Icons,
   InvestigationalUseDialog,
   type StudyRow,
-  type Workflow,
+  type OnStudyDoubleClick,
 } from '@ohif/ui-next';
 import { StudyListSettingsPopover } from './StudyListSettingsPopover';
 import { SidePanelPreview } from './SidePanelPreview';
@@ -57,9 +57,7 @@ export default function WorkList({
   // (launch the default workflow, falling back to the first applicable one).
   const customOnStudyDoubleClick = customizationService.getCustomization(
     'workList.onStudyDoubleClick'
-  ) as
-    | ((study: StudyRow, context: { defaultWorkflow?: Workflow; workflows: Workflow[] }) => void)
-    | undefined;
+  ) as OnStudyDoubleClick | undefined;
 
   const columns = useMemo(() => {
     // `workList.columns` is registered as a value (StudyList.defaultColumns) and

--- a/platform/app/src/routes/WorkList/WorkList.tsx
+++ b/platform/app/src/routes/WorkList/WorkList.tsx
@@ -4,7 +4,13 @@ import { useAppConfig } from '@state';
 import { preserveQueryParameters } from '../../utils/preserveQueryParameters';
 import { useStudyListStateSync, useWorkListToolbarActions } from '../../hooks';
 
-import { StudyList, Icons, InvestigationalUseDialog, type StudyRow } from '@ohif/ui-next';
+import {
+  StudyList,
+  Icons,
+  InvestigationalUseDialog,
+  type StudyRow,
+  type Workflow,
+} from '@ohif/ui-next';
 import { StudyListSettingsPopover } from './StudyListSettingsPopover';
 import { SidePanelPreview } from './SidePanelPreview';
 
@@ -46,6 +52,14 @@ export default function WorkList({
 
   const [selected, setSelected] = useState<StudyRow | null>(null);
   const [isPreviewOpen, setPreviewOpen] = useState(true);
+
+  // `workList.onStudyDoubleClick` replaces the built-in double-click action
+  // (launch the default workflow, falling back to the first applicable one).
+  const customOnStudyDoubleClick = customizationService.getCustomization(
+    'workList.onStudyDoubleClick'
+  ) as
+    | ((study: StudyRow, context: { defaultWorkflow?: Workflow; workflows: Workflow[] }) => void)
+    | undefined;
 
   const columns = useMemo(() => {
     // `workList.columns` is registered as a value (StudyList.defaultColumns) and
@@ -122,6 +136,11 @@ export default function WorkList({
                 )
               }
               title={'Study List'}
+              onStudyDoubleClick={
+                typeof customOnStudyDoubleClick === 'function'
+                  ? customOnStudyDoubleClick
+                  : undefined
+              }
               onSelectionChange={sel => setSelected((sel as StudyRow[])[0] ?? null)}
               toolbarLeftComponent={logoComponent}
               toolbarRightActionsComponent={toolbarActions}

--- a/platform/app/src/routes/WorkList/WorkList.tsx
+++ b/platform/app/src/routes/WorkList/WorkList.tsx
@@ -1,6 +1,7 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { useAppConfig } from '@state';
+import type { RunInput } from '@ohif/core/src/classes/CommandsManager';
 import { preserveQueryParameters } from '../../utils/preserveQueryParameters';
 import { useStudyListStateSync, useWorkListToolbarActions } from '../../hooks';
 
@@ -32,6 +33,7 @@ export default function WorkList({
   onRefresh,
   servicesManager,
   extensionManager,
+  commandsManager,
 }: Props) {
   const [appConfig] = useAppConfig();
   const { customizationService } = servicesManager.services;
@@ -53,11 +55,21 @@ export default function WorkList({
   const [selected, setSelected] = useState<StudyRow | null>(null);
   const [isPreviewOpen, setPreviewOpen] = useState(true);
 
-  // `workList.onStudyDoubleClick` replaces the built-in double-click action
-  // (launch the default workflow, falling back to the first applicable one).
-  const customOnStudyDoubleClick = customizationService.getCustomization(
+  // `workList.onStudyDoubleClick` is the command (or command list) run when a
+  // study row is double-clicked — by default `launchDefaultMode`, which
+  // launches the default workflow, falling back to the first applicable one.
+  // The study and its applicable workflows are merged into the command options
+  // at call time, so an override only needs to name a command and any static
+  // options (e.g. a specific `workflowId`).
+  const studyDoubleClickCommand = customizationService.getCustomization(
     'workList.onStudyDoubleClick'
-  ) as OnStudyDoubleClick | undefined;
+  ) as RunInput;
+  const onStudyDoubleClick = useCallback<OnStudyDoubleClick>(
+    (study, { defaultWorkflow, workflows }) => {
+      commandsManager.run(studyDoubleClickCommand, { study, defaultWorkflow, workflows });
+    },
+    [commandsManager, studyDoubleClickCommand]
+  );
 
   const columns = useMemo(() => {
     // `workList.columns` is registered as a value (StudyList.defaultColumns) and
@@ -134,11 +146,7 @@ export default function WorkList({
                 )
               }
               title={'Study List'}
-              onStudyDoubleClick={
-                typeof customOnStudyDoubleClick === 'function'
-                  ? customOnStudyDoubleClick
-                  : undefined
-              }
+              onStudyDoubleClick={studyDoubleClickCommand ? onStudyDoubleClick : undefined}
               onSelectionChange={sel => setSelected((sel as StudyRow[])[0] ?? null)}
               toolbarLeftComponent={logoComponent}
               toolbarRightActionsComponent={toolbarActions}

--- a/platform/app/src/routes/index.tsx
+++ b/platform/app/src/routes/index.tsx
@@ -131,7 +131,7 @@ const createRoutes = ({
     path: '/',
     children: DataSourceWrapper,
     private: true,
-    props: { children: WorkListComponent, servicesManager, extensionManager },
+    props: { children: WorkListComponent, servicesManager, extensionManager, commandsManager },
   };
 
   const customRoutes = customizationService.getCustomization('routes.customRoutes');

--- a/platform/core/src/extensions/ExtensionManager.ts
+++ b/platform/core/src/extensions/ExtensionManager.ts
@@ -615,6 +615,24 @@ export default class ExtensionManager extends PubSubService {
   }
 
   /**
+   * Registers a commands module produced outside the extension registration
+   * path — e.g. a mode's `getCommandsModule`, registered at app init so its
+   * commands are available before any mode route is entered (worklist time).
+   *
+   * @param commandsModule - as returned by a `getCommandsModule` function
+   * @param defaultContext - context used when the module does not declare one
+   */
+  public registerCommandsModule(
+    commandsModule: CommandsModule,
+    defaultContext: string = 'VIEWER'
+  ): void {
+    this._initCommandsModule({
+      ...commandsModule,
+      defaultContext: commandsModule.defaultContext || defaultContext,
+    });
+  }
+
+  /**
    *
    * @private
    * @param {Object[]} commandDefinitions

--- a/platform/docs/docs/platform/services/customization-service/sampleCustomizations.tsx
+++ b/platform/docs/docs/platform/services/customization-service/sampleCustomizations.tsx
@@ -525,6 +525,50 @@ window.config = {
   `,
   },
   {
+    id: 'workList.onStudyDoubleClick',
+    description: (
+      <>
+        Replaces the built-in double-click action on a study row. By default, double-clicking a
+        row selects it and launches the default workflow (mode), falling back to the first
+        workflow applicable to the study when no default is set. When a function is provided it
+        is called instead (the row is still selected first) with:
+        <ul>
+          <li>
+            <code>study</code>: the double-clicked <code>StudyRow</code>.
+          </li>
+          <li>
+            <code>context.workflows</code>: the workflows applicable to the study, in the same
+            order as the row's Launch Workflow menu. Each has <code>id</code>,{' '}
+            <code>displayName</code>, <code>isDefault</code>, and{' '}
+            <code>launchWithStudy(study)</code>.
+          </li>
+          <li>
+            <code>context.defaultWorkflow</code>: the user's default workflow when it applies to
+            the study, else <code>undefined</code>.
+          </li>
+        </ul>
+        Currently only applies when <code>workList.variant</code> is <code>'default'</code>.
+      </>
+    ),
+    default: 'undefined',
+    configuration: `
+window.config = {
+  // rest of window config
+  customizationService: [
+    {
+      'workList.onStudyDoubleClick': {
+        // Always launch a specific mode on double click, regardless of the default.
+        $set: (study, { workflows }) => {
+          const viewer = workflows.find((w) => w.id === '@ohif/mode-longitudinal');
+          (viewer ?? workflows[0])?.launchWithStudy(study);
+        },
+      },
+    },
+  ],
+};
+  `,
+  },
+  {
     id: 'workList.settingsMenuItems',
     description: (
       <>

--- a/platform/docs/docs/platform/services/customization-service/sampleCustomizations.tsx
+++ b/platform/docs/docs/platform/services/customization-service/sampleCustomizations.tsx
@@ -528,29 +528,33 @@ window.config = {
     id: 'workList.onStudyDoubleClick',
     description: (
       <>
-        Replaces the built-in double-click action on a study row. By default, double-clicking a
-        row selects it and launches the default workflow (mode), falling back to the first
-        workflow applicable to the study when no default is set. When a function is provided it
-        is called instead (the row is still selected first) with:
+        The command run when a study row is double-clicked (the row is selected first). Accepts
+        anything <code>commandsManager.run</code> does: a command name string,{' '}
+        <code>{"{ commandName, commandOptions, context }"}</code>, an array of those, or a plain
+        function. At call time the following are merged into the command options (a plain
+        function receives them as its single argument):
         <ul>
           <li>
             <code>study</code>: the double-clicked <code>StudyRow</code>.
           </li>
           <li>
-            <code>context.workflows</code>: the workflows applicable to the study, in the same
-            order as the row's Launch Workflow menu. Each has <code>id</code>,{' '}
-            <code>displayName</code>, <code>isDefault</code>, and{' '}
-            <code>launchWithStudy(study)</code>.
+            <code>workflows</code>: the workflows applicable to the study, in the same order as
+            the row's Launch Workflow menu. Each has <code>id</code>, <code>displayName</code>,{' '}
+            <code>isDefault</code>, and <code>launchWithStudy(study)</code>.
           </li>
           <li>
-            <code>context.defaultWorkflow</code>: the user's default workflow when it applies to
-            the study, else <code>undefined</code>.
+            <code>defaultWorkflow</code>: the user's default workflow when it applies to the
+            study, else <code>undefined</code>.
           </li>
         </ul>
+        The default <code>launchDefaultMode</code> command launches the default workflow, falling
+        back to the first applicable one. Modes can contribute their own commands via a{' '}
+        <code>getCommandsModule</code> export on the mode definition — these are registered at
+        app init in the <code>WORKLIST</code> context, before any mode route is entered.
         Currently only applies when <code>workList.variant</code> is <code>'default'</code>.
       </>
     ),
-    default: 'undefined',
+    default: "{ commandName: 'launchDefaultMode' }",
     configuration: `
 window.config = {
   // rest of window config
@@ -558,9 +562,9 @@ window.config = {
     {
       'workList.onStudyDoubleClick': {
         // Always launch a specific mode on double click, regardless of the default.
-        $set: (study, { workflows }) => {
-          const viewer = workflows.find((w) => w.id === '@ohif/mode-longitudinal');
-          (viewer ?? workflows[0])?.launchWithStudy(study);
+        $set: {
+          commandName: 'launchDefaultMode',
+          commandOptions: { workflowId: '@ohif/mode-longitudinal' },
         },
       },
     },

--- a/platform/ui-next/src/components/InputMultiSelect/InputMultiSelect.tsx
+++ b/platform/ui-next/src/components/InputMultiSelect/InputMultiSelect.tsx
@@ -77,9 +77,19 @@ function InputMultiSelectRoot({ options, value, onChange, children }: InputMulti
   const filtered = React.useMemo(() => {
     const q = query.trim().toLowerCase();
     if (!q) return normalized;
-    return normalized.filter(
-      opt => opt.label.toLowerCase().includes(q) || opt.value.toLowerCase().includes(q)
-    );
+    // Prefix matches rank above substring matches (typing "PT" lists PT before CTPT).
+    const prefixMatches: NormalizedOption[] = [];
+    const substringMatches: NormalizedOption[] = [];
+    for (const opt of normalized) {
+      const label = opt.label.toLowerCase();
+      const value = opt.value.toLowerCase();
+      if (label.startsWith(q) || value.startsWith(q)) {
+        prefixMatches.push(opt);
+      } else if (label.includes(q) || value.includes(q)) {
+        substringMatches.push(opt);
+      }
+    }
+    return [...prefixMatches, ...substringMatches];
   }, [normalized, query]);
 
   React.useEffect(() => {

--- a/platform/ui-next/src/components/StudyList/components/Layout.tsx
+++ b/platform/ui-next/src/components/StudyList/components/Layout.tsx
@@ -135,6 +135,7 @@ function Table({
   toolbarRightActionsComponent,
   isLoading,
   loadingComponent,
+  onStudyDoubleClick,
   children,
 }: TableProps) {
   const { defaultPreviewSizePercent } = useLayout();
@@ -168,6 +169,7 @@ function Table({
             filters={filters}
             isLoading={isLoading}
             loadingComponent={loadingComponent}
+            onStudyDoubleClick={onStudyDoubleClick}
           />
         </div>
       </div>

--- a/platform/ui-next/src/components/StudyList/components/Table.tsx
+++ b/platform/ui-next/src/components/StudyList/components/Table.tsx
@@ -10,6 +10,17 @@ import { tokenizeModalities } from '../utils/tokenizeModalities';
 import { useWorkflows, type Workflow } from './WorkflowsProvider';
 import { COLUMN_IDS } from '../columns/defaultColumns';
 
+/**
+ * Replaces the built-in double-click action (launch the default workflow,
+ * falling back to the first applicable one). The row is selected before this
+ * is called. `workflows` are the workflows applicable to the study, in menu
+ * order; `defaultWorkflow` is the user's default when it applies to the study.
+ */
+export type OnStudyDoubleClick = (
+  study: StudyRow,
+  context: { defaultWorkflow?: Workflow; workflows: Workflow[] }
+) => void;
+
 export type TableProps = Omit<DataTableProps<StudyRow>, 'children' | 'getRowId'> & {
   title?: ReactNode;
   showColumnVisibility?: boolean;
@@ -19,16 +30,7 @@ export type TableProps = Omit<DataTableProps<StudyRow>, 'children' | 'getRowId'>
   toolbarRightComponent?: ReactNode;
   isLoading?: boolean;
   loadingComponent?: ReactNode;
-  /**
-   * Replaces the built-in double-click action (launch the default workflow,
-   * falling back to the first applicable one). The row is selected before this
-   * is called. `workflows` are the workflows applicable to the study, in menu
-   * order; `defaultWorkflow` is the user's default when it applies to the study.
-   */
-  onStudyDoubleClick?: (
-    study: StudyRow,
-    context: { defaultWorkflow?: Workflow; workflows: Workflow[] }
-  ) => void;
+  onStudyDoubleClick?: OnStudyDoubleClick;
 };
 
 export function Table({

--- a/platform/ui-next/src/components/StudyList/components/Table.tsx
+++ b/platform/ui-next/src/components/StudyList/components/Table.tsx
@@ -7,7 +7,7 @@ import { DatePickerWithRange } from '../../DateRange';
 import { InputMultiSelect } from '../../InputMultiSelect';
 import type { StudyDateRangeFilter, StudyRow } from '../types/types';
 import { tokenizeModalities } from '../utils/tokenizeModalities';
-import { useWorkflows } from './WorkflowsProvider';
+import { useWorkflows, type Workflow } from './WorkflowsProvider';
 import { COLUMN_IDS } from '../columns/defaultColumns';
 
 export type TableProps = Omit<DataTableProps<StudyRow>, 'children' | 'getRowId'> & {
@@ -19,6 +19,16 @@ export type TableProps = Omit<DataTableProps<StudyRow>, 'children' | 'getRowId'>
   toolbarRightComponent?: ReactNode;
   isLoading?: boolean;
   loadingComponent?: ReactNode;
+  /**
+   * Replaces the built-in double-click action (launch the default workflow,
+   * falling back to the first applicable one). The row is selected before this
+   * is called. `workflows` are the workflows applicable to the study, in menu
+   * order; `defaultWorkflow` is the user's default when it applies to the study.
+   */
+  onStudyDoubleClick?: (
+    study: StudyRow,
+    context: { defaultWorkflow?: Workflow; workflows: Workflow[] }
+  ) => void;
 };
 
 export function Table({
@@ -42,6 +52,7 @@ export function Table({
   isLoading,
   loadingComponent,
   manualFiltering,
+  onStudyDoubleClick,
 }: TableProps) {
   return (
     <DataTable<StudyRow>
@@ -68,6 +79,7 @@ export function Table({
         toolbarRightComponent={toolbarRightComponent}
         isLoading={isLoading}
         loadingComponent={loadingComponent}
+        onStudyDoubleClick={onStudyDoubleClick}
       />
     </DataTable>
   );
@@ -82,6 +94,7 @@ function TableContent({
   toolbarRightComponent,
   isLoading,
   loadingComponent,
+  onStudyDoubleClick,
 }: {
   title?: ReactNode;
   showColumnVisibility?: boolean;
@@ -91,6 +104,7 @@ function TableContent({
   toolbarRightComponent?: ReactNode;
   isLoading?: boolean;
   loadingComponent?: ReactNode;
+  onStudyDoubleClick?: TableProps['onStudyDoubleClick'];
 }) {
   const { t } = useTranslation('StudyList');
   const { table } = useDataTable<StudyRow>();
@@ -102,7 +116,7 @@ function TableContent({
     return Array.from(new Set(tokens)).sort();
   }, [table.options?.data]);
   // Access workflow provider for default workflow + launch
-  const { getDefaultWorkflowForStudy } = useWorkflows();
+  const { getDefaultWorkflowForStudy, getWorkflowsForStudy } = useWorkflows();
 
   return (
     <div className="flex h-full flex-col">
@@ -198,10 +212,12 @@ function TableContent({
             className: 'group cursor-pointer',
             onClick: row => {
               const original = row.original as StudyRow;
-              const defaultWorkflow = getDefaultWorkflowForStudy(original);
-              // When a default workflow is set, do not allow a second click to unselect.
-              // Always select on click; otherwise toggle selection.
-              if (defaultWorkflow) {
+              const canDoubleClickLaunch =
+                Boolean(onStudyDoubleClick) ||
+                getWorkflowsForStudy(original).length > 0;
+              // When a double click can launch, the second click must not read
+              // as an unselect — clicking only ever selects. Otherwise toggle.
+              if (canDoubleClickLaunch) {
                 if (!row.getIsSelected()) {
                   row.toggleSelected(true);
                 }
@@ -211,15 +227,20 @@ function TableContent({
             },
             onDoubleClick: row => {
               const original = row.original as StudyRow;
+              const workflows = getWorkflowsForStudy(original);
               const defaultWorkflow = getDefaultWorkflowForStudy(original);
-              if (!defaultWorkflow) {
-                return;
-              }
-              // Ensure the row is selected, then launch with the default workflow
+              // Ensure the row is selected before launching
               if (!row.getIsSelected()) {
                 row.toggleSelected(true);
               }
-              defaultWorkflow.launchWithStudy(original);
+              if (onStudyDoubleClick) {
+                onStudyDoubleClick(original, { defaultWorkflow, workflows });
+                return;
+              }
+              // Launch the default workflow, or fall back to the first
+              // applicable one (the top entry of the row's workflow menu).
+              const workflow = defaultWorkflow ?? workflows[0];
+              workflow?.launchWithStudy(original);
             },
           }}
         />

--- a/platform/ui-next/src/components/StudyList/index.ts
+++ b/platform/ui-next/src/components/StudyList/index.ts
@@ -17,6 +17,7 @@ import { WorkflowsProvider } from './components/WorkflowsProvider';
 // Types
 export * from './types/types';
 export type { Workflow } from './components/WorkflowsProvider';
+export type { OnStudyDoubleClick } from './components/Table';
 
 // Column ID constants
 export { COLUMN_IDS, FILTERABLE_COLUMN_IDS, TEXT_FILTER_COLUMN_IDS };

--- a/platform/ui-next/src/components/StudyList/index.ts
+++ b/platform/ui-next/src/components/StudyList/index.ts
@@ -16,6 +16,7 @@ import { WorkflowsProvider } from './components/WorkflowsProvider';
 
 // Types
 export * from './types/types';
+export type { Workflow } from './components/WorkflowsProvider';
 
 // Column ID constants
 export { COLUMN_IDS, FILTERABLE_COLUMN_IDS, TEXT_FILTER_COLUMN_IDS };


### PR DESCRIPTION
### Context

The previous worklist preferred prefix-matching inputs for the modalities over other matches.  That is almost always what a user wants so that if they type "PT" and hit enter, they DONT get "CTPT" as the value selected.
As well, added double-click behaviour so that the row doesn't disappear on a double click, and instead launches the default instance.  I believe that had been agreed on but didn't get implemented.  Made that customizeable, although I'd prefer to allow a cusotmization that specifies a command instead of a function.

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://docs.ohif.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] OS: <!--[e.g. Windows 10, macOS 10.15.4]-->
- [] Node version: <!--[e.g. 18.16.1]-->
- [] Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `workList.onStudyDoubleClick` customization to control what happens when double-clicking a study row in the default Work List.
  - Double-click can now launch the configured command/workflow, with smart fallback to an applicable default/first workflow when needed.
  - Improved study-row selection and double-click flow so the row is selected before actions run.
  - Added a built-in workflow launcher command (`launchDefaultMode`) for double-click behavior.
- **Documentation**
  - Updated customization samples and descriptions with the new `workList.onStudyDoubleClick` option and default configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->