### PR TITLE
feat(customization): typed customization registry via AppTypes.Customizations

### DIFF
--- a/CUSTOMIZATION_TYPING_PLAN.md
+++ b/CUSTOMIZATION_TYPING_PLAN.md
@@ -1,0 +1,130 @@
+# Typed Customizations: Design and Rollout Plan
+
+This document accompanies the PR that introduces the `AppTypes.Customizations`
+registry and describes the follow-up work needed to make every customization id
+in OHIF fully typed and discoverable.
+
+## Problem
+
+`customizationService.getCustomization(id)` accepts any string and returns the
+`Customization` union, which is broad enough to be effectively untyped. As a
+result:
+
+- There is no way to discover which customization ids exist from the code; the
+  docs table (`platform/docs/docs/platform/services/customization-service/sampleCustomizations.tsx`)
+  is hand-maintained and already drifts from the registered keys.
+- Consumers cast at the call site (`as unknown as ColorbarCustomization`,
+  `as string`, `as any`, ...) — roughly 20 such casts exist across the repo.
+- `setCustomizations` payloads (including `$set` / `$push` / `$merge` command
+  specs used by modes and app config) are not checked at all.
+
+## Design (implemented in this PR)
+
+A declaration-merged registry, following the same pattern already used for
+`AppTypes.Services` and `PresentationIds`:
+
+1. `platform/core/src/types/AppTypes.ts` seeds an empty global interface:
+
+   ```ts
+   declare global {
+     namespace AppTypes {
+       export interface Customizations {}
+     }
+   }
+   ```
+
+2. Each extension (in-tree or third-party) merges the keys it owns:
+
+   ```ts
+   declare global {
+     namespace AppTypes {
+       interface Customizations {
+         'viewportOverlay.topLeft': OverlayItem[];
+         'panelSegmentation.disableEditing': boolean;
+       }
+     }
+   }
+   ```
+
+3. The service API is overloaded so registered ids get autocomplete and precise
+   types, while unregistered ids (dynamic keys such as
+   `` `${buttonSectionId}.config` ``, third-party keys that have not been
+   declared) keep working through a plain-string fallback:
+
+   - `getCustomization('viewportOverlay.topLeft')` returns `OverlayItem[]`.
+   - `getCustomization('some.dynamic.key')` returns `Customization | undefined`
+     exactly as before.
+   - `setCustomizations({...})` checks registered ids against their declared
+     value type, either as a direct value or as an immutability-helper spec
+     (`{ $set: ... }`, `{ $push: [...] }`, the custom `$filter`, ...), via the
+     `CustomizationEntries` type in
+     `platform/core/src/services/CustomizationService/types.ts`.
+   - `CustomizationPhaseInput` (the `bootstrap` / `global` / `mode` blocks of
+     `appConfig.customizationService`) reuses `CustomizationEntries`, so
+     phase-tagged config written in TypeScript is checked the same way.
+
+Nothing about the runtime changes; this is purely additive typing.
+
+### Conventions for declaring keys
+
+- The extension that registers a key's default owns its type declaration.
+  Export the value type from the `*Customization.ts` file that produces the
+  default, and add the registry entry in the extension's `types/AppTypes.ts`.
+- Declare a key with `| undefined` when no default is shipped for it, so strict
+  consumers must handle its absence. (Note: the repo's own tsconfig does not
+  enable `strictNullChecks`, so this protects downstream strict consumers.)
+- Declared types describe the resolved value after `inheritsFrom` /
+  `transform`, i.e. what `getCustomization` actually returns.
+
+## Next steps
+
+### Phase 2: populate the registry for extension-default and extension-cornerstone
+
+The bulk of the value: these two extensions register roughly 75 of the ~90
+known ids. For each key:
+
+1. Export its value type from the producer file (most already have local
+   interfaces or obvious shapes).
+2. Add the entry to the extension's `types/AppTypes.ts` augmentation.
+3. Remove the now-redundant casts at consumer call sites; each removed cast is
+   a free correctness check.
+
+Suggested PR split: one PR per extension.
+
+### Phase 3: remaining extensions and the core-owned keys
+
+- `cornerstone-dicom-seg` (`segmentation.store.*`, `segmentation.segmentLabel`,
+  `cornerstone.segmentation.loadMultiframeAsPart10`), `cornerstone-dicom-sr`
+  (`onBeforeSRAddMeasurement`, `onBeforeDicomStore`, `codingValues`, ...),
+  `cornerstone-dicom-rt`, `cornerstone-dicom-pmap`, `dicom-microscopy`,
+  `measurement-tracking` (`measurement.prompt*`, `viewportNotification.*`),
+  `cornerstone-dynamic-volume`.
+- Keys consumed by `platform/core` / `platform/ui-next` but defaulted in
+  `extension-default` (`instanceSortingCriteria`, `sortingCriteria`,
+  `studyBrowser.sortFunctions`) must be declared in `platform/core` itself so
+  the dependency direction stays core -> extension-free; `extension-default`
+  imports those types from core.
+- Modes' `setCustomizations` calls in `onModeEnter` become checked
+  automatically once the keys they touch are declared.
+
+### Phase 4 (optional follow-ups)
+
+- Generate the docs customization table from the registry instead of the
+  hand-maintained `sampleCustomizations.tsx`, so docs cannot drift.
+- Generate a JSON Schema from `AppTypes.Customizations` to give editor
+  IntelliSense and validation for the JSONC `?customization=` files and the
+  `customizationService` section of config files.
+- Consider a lint rule nudging away from `getValue`-with-cast toward the typed
+  `getCustomization` overload.
+
+## Verification recipe used for this PR
+
+- `pnpm --filter @ohif/core exec jest src/services/CustomizationService` — all
+  68 unit tests pass.
+- Full-repo `npx tsc --noEmit --emitDeclarationOnly false -p tsconfig.json`
+  diffed against a pre-change baseline: three pre-existing false positives
+  fixed, zero new errors. (The repo has ~5.7k pre-existing tsc errors and no
+  tsc CI gate; diffing sorted error lists is the reliable check.)
+- A standalone compile-time smoke test exercised the mechanism end to end
+  (registry augmentation, typed reads, spec checking, string fallback) under
+  both the repo's compiler settings and `--strict`.

--- a/CUSTOMIZATION_TYPING_PLAN.md
+++ b/CUSTOMIZATION_TYPING_PLAN.md
@@ -4,6 +4,10 @@ This document accompanies the PR that introduces the `AppTypes.Customizations`
 registry and describes the follow-up work needed to make every customization id
 in OHIF fully typed and discoverable.
 
+User-facing instructions for declaring keys live in the docs:
+[Typing Customizations](platform/docs/docs/platform/services/customization-service/typing.md).
+This file is the design rationale and the rollout tracker.
+
 ## Problem
 
 `customizationService.getCustomization(id)` accepts any string and returns the
@@ -23,17 +27,9 @@ result:
 A declaration-merged registry, following the same pattern already used for
 `AppTypes.Services` and `PresentationIds`:
 
-1. `platform/core/src/types/AppTypes.ts` seeds an empty global interface:
+1. `platform/core/src/types/AppTypes.ts` seeds the global interface.
 
-   ```ts
-   declare global {
-     namespace AppTypes {
-       export interface Customizations {}
-     }
-   }
-   ```
-
-2. Each extension (in-tree or third-party) merges the keys it owns:
+2. Each package (in-tree or third-party) merges the keys it owns:
 
    ```ts
    declare global {
@@ -65,18 +61,117 @@ A declaration-merged registry, following the same pattern already used for
 
 Nothing about the runtime changes; this is purely additive typing.
 
+### Read-time markers are a write-side concern
+
+`$reference` and `$transform` are read-time markers, not update commands: the
+service substitutes/invokes them when a value is *read* (`_resolveReferences`,
+`transform`), and `hasDollarKey` deliberately exempts them from the
+immutability-helper path. A value may therefore be *authored* with a marker
+standing in wherever the resolver walks — as a whole value, as an array item (a
+referenced array is flattened into the surrounding list), or as a plain object's
+property value — while the value that comes back out of `getCustomization` never
+contains one.
+
+`Authorable<T>` in `types.ts` encodes exactly that, mirroring the resolver's
+walk: it recurses through arrays and plain objects and stops at the things
+`_resolveReferences` returns untouched (functions, constructors, React elements,
+`Date`, `RegExp`).
+
+The important structural decision is that `Authorable<T>` is applied **only** on
+the write side, in `CustomizationEntries`. The registry declares what a key
+*resolves to*, so `getCustomization`'s return type stays clean. Declaring marker
+unions in the registry instead — the other obvious option — would push
+`{ $reference }` into the type of every read site, which is both wrong and
+unusable.
+
+Without this, the highest-value keys could not be typed at all:
+`toolbarButtons`, `toolbarSections` and `toolGroupAdditions` are composed
+*exclusively* through `{ $reference }` markers.
+
+### Custom update commands are a registry too
+
+`$filter` is registered by the service itself; extensions can add more at
+runtime through `registerCustomUpdateCommand`. Those are declared the same way
+customization ids are, via `AppTypes.CustomizationUpdateCommands`, so a spec
+using a third-party command type-checks without a cast.
+
+One non-obvious constraint, worth not re-discovering: `Spec` surfaces custom
+commands through `C extends CustomCommands<infer O> ? O : never`, and `O` infers
+to the **whole** registry interface. The projection must therefore be
+`CustomCommands<Partial<...>>`. Without `Partial`, every spec would have to
+supply *all* registered commands at once, and a registry holding more than one
+command rejects a plain `{ $filter: ... }` outright with a misleading error. The
+single-command form this PR started with only worked because there was exactly
+one command.
+
 ### Conventions for declaring keys
 
-- The extension that registers a key's default owns its type declaration.
-  Export the value type from the `*Customization.ts` file that produces the
-  default, and add the registry entry in the extension's `types/AppTypes.ts`.
-- Declare a key with `| undefined` when no default is shipped for it, so strict
-  consumers must handle its absence. (Note: the repo's own tsconfig does not
-  enable `strictNullChecks`, so this protects downstream strict consumers.)
+- **The package that consumes a key declares its type**, next to that consumer.
+  This is usually also the package that registers the default, but not always —
+  see `studyBrowser.sortFunctions`, consumed by `platform/ui-next` and defaulted
+  by `extension-default`. Declaring at the consumer is what lets the provider's
+  default be checked against the contract.
+- Keys consumed by `platform/core` or `platform/ui-next` but defaulted in
+  `extension-default` (`sortingCriteria`, `instanceSortingCriteria`,
+  `studyBrowser.sortFunctions`) are declared in core/ui-next so the dependency
+  direction stays extension-free.
 - Declared types describe the resolved value after `inheritsFrom` /
-  `transform`, i.e. what `getCustomization` actually returns.
+  `$transform`, i.e. what `getCustomization` actually returns — not what may be
+  written for the key.
+- **A declaration without `| undefined` is a promise that a default is
+  registered.** Consumers may read it and use the value directly; that is how
+  existing consumers are already written (`StudyBrowserSort` indexes `[0]` with
+  no guard). Add `| undefined` only for keys that genuinely ship no default.
+
+  The residual risk is deliberate and worth stating: the promise is made by the
+  declaring package but kept by whichever package registers the default, so a
+  deployment whose `pluginConfig.json` omits that provider gets `undefined`
+  where the type says otherwise. That is already a runtime failure today, so the
+  type does not make it worse — but the invariant lives in convention rather
+  than in the compiler until the Phase 4 check below exists.
+
+## Known limitations
+
+These are accepted trade-offs of the fallback design, not bugs to fix. They are
+listed so reviewers and adopters do not have to rediscover them.
+
+- **`any`-typed keys degrade to `any`.** Once the registry is non-empty,
+  `getCustomization(k)` where `k` is `any` (e.g. destructured from an untyped
+  props bag) selects the generic overload and returns `any`, so *all* checking
+  at that call site is lost — including the `Customization | undefined` it used
+  to get. This is inherent to making the method generic over the key; the
+  single-signature conditional-return form does not avoid it. The fix is at the
+  call site: annotate the key as `string`. Two such sites exist today
+  (`MoreDropdownMenu`, `DataSourceConfigurationComponent`) and are Phase 2 work.
+- **Typos in registered ids pass silently.** The `[customizationId: string]:
+  unknown` fallback in `CustomizationEntries` disables excess-property checking,
+  so `'panelSegmentation.disabledEditing'` is accepted as an unregistered
+  dynamic key. Unavoidable while undeclared ids must keep working.
+- **`getValue`'s fallback is not checked.** A wrong-typed `fallbackValue` on a
+  registered id falls through to the loose string overload and returns that
+  wrong type rather than erroring. Overload fallthrough; would need
+  `getValue` restructured into with-/without-fallback overloads.
+- **`$transform`'s return type is not checked.** `Spec` already admits a bare
+  `(value: T) => T` form, so a `$transform` is validated as a function but not
+  against `T`. Acceptable for a dynamic escape hatch whose `this` is untyped.
 
 ## Next steps
+
+### Phase 1 (this PR): infrastructure + a cross-package proof
+
+Beyond the types themselves, three keys are declared so the mechanism is
+exercised in-tree rather than only in a scratch project, and so Phase 2 has a
+copyable reference:
+
+- `platform/core/src/types/AppTypes.ts` — `sortingCriteria`,
+  `instanceSortingCriteria`.
+- `platform/ui-next/src/types/AppTypes.ts` — `studyBrowser.sortFunctions`.
+
+Together these prove the declaration crosses package boundaries in both
+directions: `sortingCriteria` is declared in core, defaulted in
+`extension-default`, and consumed in core *and* `platform/app` (deleting the
+identical cast in both); `studyBrowser.sortFunctions` is declared and consumed
+in `ui-next` while being defaulted in `extension-default`.
 
 ### Phase 2: populate the registry for extension-default and extension-cornerstone
 
@@ -88,10 +183,13 @@ known ids. For each key:
 2. Add the entry to the extension's `types/AppTypes.ts` augmentation.
 3. Remove the now-redundant casts at consumer call sites; each removed cast is
    a free correctness check.
+4. Annotate any dynamic key feeding `getCustomization` as `string` rather than
+   leaving it `any` — otherwise declaring keys silently converts those sites to
+   `any` (see Known limitations).
 
 Suggested PR split: one PR per extension.
 
-### Phase 3: remaining extensions and the core-owned keys
+### Phase 3: remaining extensions
 
 - `cornerstone-dicom-seg` (`segmentation.store.*`, `segmentation.segmentLabel`,
   `cornerstone.segmentation.loadMultiframeAsPart10`), `cornerstone-dicom-sr`
@@ -99,18 +197,23 @@ Suggested PR split: one PR per extension.
   `cornerstone-dicom-rt`, `cornerstone-dicom-pmap`, `dicom-microscopy`,
   `measurement-tracking` (`measurement.prompt*`, `viewportNotification.*`),
   `cornerstone-dynamic-volume`.
-- Keys consumed by `platform/core` / `platform/ui-next` but defaulted in
-  `extension-default` (`instanceSortingCriteria`, `sortingCriteria`,
-  `studyBrowser.sortFunctions`) must be declared in `platform/core` itself so
-  the dependency direction stays core -> extension-free; `extension-default`
-  imports those types from core.
 - Modes' `setCustomizations` calls in `onModeEnter` become checked
   automatically once the keys they touch are declared.
 
 ### Phase 4 (optional follow-ups)
 
+- Add a committed compile-time test (`// @ts-expect-error` assertions, or
+  `tsd` / `expectTypeOf`) run by a script. The mechanism is purely
+  compile-time, so the unit tests cover none of it and the repo has no tsc CI
+  gate — without this it can regress silently. The `Partial` constraint above
+  is exactly the kind of thing such a test pins down.
 - Generate the docs customization table from the registry instead of the
   hand-maintained `sampleCustomizations.tsx`, so docs cannot drift.
+- Reuse that same enumeration to assert every id declared **without**
+  `| undefined` actually has a default registered after `init()`. That closes
+  the residual risk in the nullability convention above, and does so by
+  catching the real failure (a missing default) rather than taxing every read
+  site with `?.`.
 - Generate a JSON Schema from `AppTypes.Customizations` to give editor
   IntelliSense and validation for the JSONC `?customization=` files and the
   `customizationService` section of config files.
@@ -119,12 +222,23 @@ Suggested PR split: one PR per extension.
 
 ## Verification recipe used for this PR
 
-- `pnpm --filter @ohif/core exec jest src/services/CustomizationService` — all
-  68 unit tests pass.
+- `npx jest platform/core/src/services/CustomizationService` — 79 tests across
+  7 suites pass.
 - Full-repo `npx tsc --noEmit --emitDeclarationOnly false -p tsconfig.json`
-  diffed against a pre-change baseline: three pre-existing false positives
-  fixed, zero new errors. (The repo has ~5.7k pre-existing tsc errors and no
-  tsc CI gate; diffing sorted error lists is the reliable check.)
-- A standalone compile-time smoke test exercised the mechanism end to end
-  (registry augmentation, typed reads, spec checking, string fallback) under
-  both the repo's compiler settings and `--strict`.
+  diffed against a pre-change baseline: 3341 -> 3337 errors, **zero new**.
+  (The repo has thousands of pre-existing tsc errors and no tsc CI gate;
+  diffing sorted error lists is the only reliable check.)
+
+  Of the four that cleared, two are genuine wins from the declared keys
+  (`StudyBrowserSort` losing `Property 'map' does not exist on type
+  'Customization'`, and `CustomizationService.transform`). The other two
+  (`MoreDropdownMenu`, `DataSourceConfigurationComponent`) are **not** wins —
+  they are the `any`-key degradation described under Known limitations, i.e.
+  checks being switched off rather than satisfied. Counting them as fixes would
+  be misleading.
+- A standalone compile-time smoke test exercised the mechanism end to end under
+  both the repo's compiler settings and `--strict`: registry augmentation from
+  another package, typed reads, direct values, `$set` / `$push` element
+  checking, `$filter`, a declaration-merged third-party command, all four
+  `$reference` marker positions, `$transform`, and the plain-string fallback —
+  each paired with a negative case asserting the wrong shape is still rejected.

--- a/modes/usAnnotation/src/index.ts
+++ b/modes/usAnnotation/src/index.ts
@@ -178,93 +178,90 @@ function modeFactory({ modeConfiguration }) {
         'WindowLevelRegion',
       ]);
 
-      customizationService.setCustomizations(
-        {
-          'panelSegmentation.disableEditing': {
-            $set: true,
-          },
-          autoCineModalities: {
-            $set: [],
-          },
-          'ohif.hotkeyBindings': {
-            $push: [
-              {
-                commandName: 'switchUSAnnotationToPleuraLine',
-                label: 'Add new pleura line',
-                keys: ['W'],
-              },
-              {
-                commandName: 'switchUSAnnotationToBLine',
-                label: 'Add new B-line',
-                keys: ['S'],
-              },
-              {
-                commandName: 'deleteLastPleuraAnnotation',
-                label: 'Delete last pleura line',
-                keys: ['E'],
-              },
-              {
-                commandName: 'deleteLastBLineAnnotation',
-                label: 'Delete last B-line',
-                keys: ['D'],
-              },
-              {
-                commandName: 'toggleDisplayFanAnnotation',
-                label: 'Toggle overlay',
-                keys: ['O'],
-              },
-            ],
-          },
-          measurementsContextMenu: {
-            inheritsFrom: 'ohif.contextMenu',
-            menus: [
-              // Get the items from the UI Customization for the menu name (and have a custom name)
-              {
-                id: 'forExistingMeasurement',
-                selector: ({ nearbyToolData }) => !!nearbyToolData,
-                items: [
-                  {
-                    label: 'Delete annotation',
-                    commands: 'removeMeasurement',
-                  },
-                ],
-              },
-            ],
-          },
-          'viewportOverlay.topLeft': [
+      customizationService.setCustomizations({
+        'panelSegmentation.disableEditing': {
+          $set: true,
+        },
+        autoCineModalities: {
+          $set: [],
+        },
+        'ohif.hotkeyBindings': {
+          $push: [
             {
-              id: 'BLinePleuraPercentage',
-              inheritsFrom: 'ohif.overlayItem',
-              label: '',
-              title: 'BLinePleuraPercentage',
-              condition: ({ referenceInstance }) =>
-                referenceInstance?.Modality.includes('US') && showPercentage,
-              contentF: () => {
-                const { viewportGridService, toolGroupService, cornerstoneViewportService } =
-                  servicesManager.services;
-                const activeViewportId = viewportGridService.getActiveViewportId();
-                const toolGroup = toolGroupService.getToolGroupForViewport(activeViewportId);
-                if (!toolGroup) {
-                  return 'B-Line/Pleura : N/A';
-                }
-                const usAnnotation = toolGroup.getToolInstance(UltrasoundPleuraBLineTool.toolName);
-                if (usAnnotation) {
-                  const viewport =
-                    cornerstoneViewportService.getCornerstoneViewport(activeViewportId);
-                  const percentage = usAnnotation.calculateBLinePleuraPercentage(viewport);
-                  if (percentage !== undefined) {
-                    return `B-Line/Pleura : ${percentage.toFixed(2)} %`;
-                  } else {
-                    return 'B-Line/Pleura : N/A';
-                  }
-                }
-                return 'B-Line/Pleura : N/A';
-              },
+              commandName: 'switchUSAnnotationToPleuraLine',
+              label: 'Add new pleura line',
+              keys: ['W'],
+            },
+            {
+              commandName: 'switchUSAnnotationToBLine',
+              label: 'Add new B-line',
+              keys: ['S'],
+            },
+            {
+              commandName: 'deleteLastPleuraAnnotation',
+              label: 'Delete last pleura line',
+              keys: ['E'],
+            },
+            {
+              commandName: 'deleteLastBLineAnnotation',
+              label: 'Delete last B-line',
+              keys: ['D'],
+            },
+            {
+              commandName: 'toggleDisplayFanAnnotation',
+              label: 'Toggle overlay',
+              keys: ['O'],
             },
           ],
         },
-        'mode'
-      );
+        measurementsContextMenu: {
+          inheritsFrom: 'ohif.contextMenu',
+          menus: [
+            // Get the items from the UI Customization for the menu name (and have a custom name)
+            {
+              id: 'forExistingMeasurement',
+              selector: ({ nearbyToolData }) => !!nearbyToolData,
+              items: [
+                {
+                  label: 'Delete annotation',
+                  commands: 'removeMeasurement',
+                },
+              ],
+            },
+          ],
+        },
+        'viewportOverlay.topLeft': [
+          {
+            id: 'BLinePleuraPercentage',
+            inheritsFrom: 'ohif.overlayItem',
+            label: '',
+            title: 'BLinePleuraPercentage',
+            condition: ({ referenceInstance }) =>
+              referenceInstance?.Modality.includes('US') && showPercentage,
+            contentF: () => {
+              const { viewportGridService, toolGroupService, cornerstoneViewportService } =
+                servicesManager.services;
+              const activeViewportId = viewportGridService.getActiveViewportId();
+              const toolGroup = toolGroupService.getToolGroupForViewport(activeViewportId);
+              if (!toolGroup) {
+                return 'B-Line/Pleura : N/A';
+              }
+              const usAnnotation = toolGroup.getToolInstance(UltrasoundPleuraBLineTool.toolName);
+              if (usAnnotation) {
+                const viewport =
+                  cornerstoneViewportService.getCornerstoneViewport(activeViewportId);
+                const percentage = usAnnotation.calculateBLinePleuraPercentage(viewport);
+                if (percentage !== undefined) {
+                  return `B-Line/Pleura : ${percentage.toFixed(2)} %`;
+                } else {
+                  return 'B-Line/Pleura : N/A';
+                }
+              }
+              return 'B-Line/Pleura : N/A';
+            },
+          },
+        ],
+      });
     },
     onModeExit: ({ servicesManager }: withAppTypes) => {
       appConfig.disableConfirmationPrompts = settingsSaved.disableConfirmationPrompts;

--- a/platform/app/src/routes/Mode/defaultRouteInit.ts
+++ b/platform/app/src/routes/Mode/defaultRouteInit.ts
@@ -34,10 +34,7 @@ export async function defaultRouteInit(
     const displaySets = displaySetService.getActiveDisplaySets();
     // The display sets are not necessarily in load order, even though the
     // series got started in load order, so re-sort them before hanging
-    const sortCriteria = customizationService.getCustomization('sortingCriteria') as (
-      a,
-      b
-    ) => number;
+    const sortCriteria = customizationService.getCustomization('sortingCriteria');
 
     if (!displaySets || !displaySets.length) {
       return;

--- a/platform/core/src/services/CustomizationService/CustomizationService.ts
+++ b/platform/core/src/services/CustomizationService/CustomizationService.ts
@@ -1,16 +1,13 @@
 import update, { extend } from 'immutability-helper';
 import JSON5 from 'json5';
 import { PubSubService } from '../_shared/pubSubServiceInterface';
-import type { Customization } from './types';
+import type { Customization, CustomizationEntries } from './types';
 import type { CommandsManager } from '../../classes';
 import type ExtensionManager from '../../extensions/ExtensionManager';
 import { getCustomizationUrlPolicy } from './customizationUrl';
 import { getUrlCustomizationModulePayload } from './getUrlCustomizationModulePayload';
 import { resolveCustomizationUrl } from './resolve';
-import {
-  parseCustomizationParams,
-  validateCustomizationRequests,
-} from './validate';
+import { parseCustomizationParams, validateCustomizationRequests } from './validate';
 import type { ValidatedCustomization } from './validate';
 import type { CustomizationUrlPolicy } from './customizationUrlDefaults';
 import type {
@@ -228,7 +225,10 @@ export default class CustomizationService extends PubSubService {
    * phase-tagged form (any of `requires` / `bootstrap` / `global` / `mode`)
    * and otherwise treats the value as legacy Global references.
    */
-  private _getCustomizationConfig(): { phased?: PhasedCustomizationConfig; legacyReferences?: unknown } {
+  private _getCustomizationConfig(): {
+    phased?: PhasedCustomizationConfig;
+    legacyReferences?: unknown;
+  } {
     if (!this._customizationConfig) {
       this._customizationConfig = normalizeCustomizationConfig(this.configuration);
     }
@@ -469,11 +469,19 @@ export default class CustomizationService extends PubSubService {
   /**
    * Unified getter for customizations.
    *
+   * Ids registered in `AppTypes.Customizations` (via declaration merging, see
+   * that interface) return their declared value type; any other string id
+   * falls back to the loose `Customization` union.
+   *
    * @param customizationId - The ID of the customization to retrieve.
    * @param scope - (Optional) The scope to retrieve from: 'global', 'mode', or 'default'.
    *                 If not specified, it retrieves based on priority: global > mode > default.
    * @returns The requested customization, or undefined if not found
    */
+  public getCustomization<K extends keyof AppTypes.Customizations>(
+    customizationId: K
+  ): AppTypes.Customizations[K];
+  public getCustomization(customizationId: string): Customization | undefined;
   public getCustomization(customizationId: string): Customization | undefined {
     const transformed = this.transformedCustomizations.get(customizationId);
 
@@ -579,9 +587,14 @@ export default class CustomizationService extends PubSubService {
   /**
    * Returns a customization value, or the provided fallback when unset.
    */
-  public getValue<T = Customization>(customizationId: string, fallbackValue?: T): T | undefined {
+  public getValue<K extends keyof AppTypes.Customizations>(
+    customizationId: K,
+    fallbackValue?: AppTypes.Customizations[K]
+  ): AppTypes.Customizations[K];
+  public getValue<T = Customization>(customizationId: string, fallbackValue?: T): T | undefined;
+  public getValue(customizationId: string, fallbackValue?: unknown): unknown {
     const value = this.getCustomization(customizationId);
-    return (value === undefined ? fallbackValue : (value as T)) as T | undefined;
+    return value === undefined ? fallbackValue : value;
   }
 
   /**
@@ -601,7 +614,7 @@ export default class CustomizationService extends PubSubService {
    *   customizationService.setCustomizations(['@ohif/extension-cornerstone-dicom-seg.customizationModule.dicom-seg-sorts'], CustomizationScope.Mode)
    */
   public setCustomizations(
-    customizations: string[] | Record<string, Customization>,
+    customizations: string[] | CustomizationEntries,
     scope: CustomizationScope = CustomizationScope.Mode
   ): void {
     if (Array.isArray(customizations)) {
@@ -610,7 +623,7 @@ export default class CustomizationService extends PubSubService {
       });
     } else {
       Object.entries(customizations).forEach(([key, value]) => {
-        this._setCustomization(key, value, scope);
+        this._setCustomization(key, value as Customization, scope);
       });
     }
   }
@@ -649,6 +662,8 @@ export default class CustomizationService extends PubSubService {
    *  Returns true if there is a mode customization.  Doesn't include defaults, but
    * does return global overrides.
    */
+  public hasCustomization<K extends keyof AppTypes.Customizations>(customizationId: K): boolean;
+  public hasCustomization(customizationId: string): boolean;
   public hasCustomization(customizationId: string) {
     return (
       this.globalCustomizations.has(customizationId) || this.modeCustomizations.has(customizationId)
@@ -1187,7 +1202,9 @@ export function normalizeCustomizationConfig(configuration: unknown): {
       const phased: PhasedCustomizationConfig = {};
       for (const key of PHASE_CONFIG_KEYS) {
         if (key in (configuration as object)) {
-          (phased as Record<string, unknown>)[key] = (configuration as Record<string, unknown>)[key];
+          (phased as Record<string, unknown>)[key] = (configuration as Record<string, unknown>)[
+            key
+          ];
         }
       }
       return { phased };

--- a/platform/core/src/services/CustomizationService/customizationUrlTypes.ts
+++ b/platform/core/src/services/CustomizationService/customizationUrlTypes.ts
@@ -1,15 +1,18 @@
 import type { CustomizationUrlPolicy } from './customizationUrlDefaults';
 import type { ValidatedCustomization } from './validate';
+import type { CustomizationEntries } from './types';
 
 /**
  * The value accepted by any single customization phase block. It is whatever
  * {@link CustomizationService.setCustomizations} accepts:
  *   - an object map of `customizationId -> customization` (with optional
- *     immutability-helper commands like `$set` / `$apply` / `$splice`), or
+ *     immutability-helper commands like `$set` / `$apply` / `$splice`), where
+ *     ids registered in `AppTypes.Customizations` are checked against their
+ *     declared value type, or
  *   - an array that mixes string references (extension module ids resolved via
  *     the ExtensionManager) and inline object maps.
  */
-export type CustomizationPhaseInput = string[] | Record<string, any>;
+export type CustomizationPhaseInput = string[] | CustomizationEntries;
 
 /**
  * Mode-phase customizations, keyed by mode. The reserved `*` key (see

--- a/platform/core/src/services/CustomizationService/types.ts
+++ b/platform/core/src/services/CustomizationService/types.ts
@@ -1,5 +1,6 @@
 import { Command } from '../../types/Command';
 import { ComponentType } from 'react';
+import type { Spec, CustomCommands } from 'immutability-helper';
 
 export type Obj = Record<string, unknown>;
 
@@ -46,7 +47,9 @@ export type Customization =
   | CodeCustomization
   | ComponentCustomization
   | CallbackCustomization
-  | string | number | boolean;
+  | string
+  | number
+  | boolean;
 
 export default Customization;
 
@@ -56,3 +59,44 @@ export type ComponentReturn = {
 };
 
 export type NestedStrings = string[] | NestedStrings[];
+
+/**
+ * Accepted shapes for the custom `$filter` update command registered by the
+ * CustomizationService (see the `extend('$filter', ...)` block there):
+ *   - a predicate function used to filter array items
+ *   - a string id, removing items whose `id` equals it
+ *   - `{ match, $merge }` merging into items whose properties match `match`
+ *   - `{ id, $merge }` merging into items whose `id` matches (backwards compat)
+ */
+export type FilterSpec =
+  | string
+  | ((item: any, index: number, array: any[]) => boolean)
+  | { match: Record<string, unknown>; $merge: Record<string, unknown> }
+  | { id: string; $merge: Record<string, unknown> };
+
+/**
+ * Update commands available in customization specs beyond the
+ * immutability-helper built-ins ($set, $push, $merge, $apply, ...).
+ * Commands added at runtime through `registerCustomUpdateCommand` are not
+ * represented here; specs using them need a cast at the call site.
+ */
+export type CustomizationUpdateCommands = CustomCommands<{ $filter: FilterSpec }>;
+
+type KnownCustomizationIds = keyof AppTypes.Customizations;
+
+/**
+ * The customization-id -> value map accepted by
+ * `customizationService.setCustomizations`. Ids registered in
+ * `AppTypes.Customizations` are checked against their declared value type,
+ * either as a direct value or as an immutability-helper spec over it
+ * (e.g. `{ $set: ... }`, `{ $push: [...] }`). Ids not in the registry
+ * (dynamic keys, third-party keys that have not been declared) are still
+ * accepted, with unconstrained value types.
+ */
+export type CustomizationEntries = {
+  [K in KnownCustomizationIds]?:
+    | AppTypes.Customizations[K]
+    | Spec<AppTypes.Customizations[K], CustomizationUpdateCommands>;
+} & {
+  [customizationId: string]: unknown;
+};

--- a/platform/core/src/services/CustomizationService/types.ts
+++ b/platform/core/src/services/CustomizationService/types.ts
@@ -74,13 +74,103 @@ export type FilterSpec =
   | { match: Record<string, unknown>; $merge: Record<string, unknown> }
   | { id: string; $merge: Record<string, unknown> };
 
+declare global {
+  namespace AppTypes {
+    /**
+     * Custom `$<command>` keys usable inside customization specs, beyond the
+     * immutability-helper built-ins ($set, $push, $merge, $apply, ...). Each
+     * entry maps the command name to the type of argument it accepts.
+     *
+     * The CustomizationService registers `$filter` itself (declared just
+     * below). Anything registered at runtime through
+     * `customizationService.registerCustomUpdateCommand` is declared the same
+     * way the customization ids themselves are — by whoever registers it:
+     *
+     * ```ts
+     * declare global {
+     *   namespace AppTypes {
+     *     interface CustomizationUpdateCommands {
+     *       $myCommand: MyCommandArg;
+     *     }
+     *   }
+     * }
+     * ```
+     */
+    interface CustomizationUpdateCommands {
+      /** See {@link FilterSpec}. */
+      $filter: FilterSpec;
+    }
+  }
+}
+
 /**
- * Update commands available in customization specs beyond the
- * immutability-helper built-ins ($set, $push, $merge, $apply, ...).
- * Commands added at runtime through `registerCustomUpdateCommand` are not
- * represented here; specs using them need a cast at the call site.
+ * The {@link AppTypes.CustomizationUpdateCommands} registry in the branded form
+ * `immutability-helper` expects for the `C` parameter of its `Spec` type.
+ *
+ * `Partial` is required, not cosmetic: `Spec` surfaces custom commands through
+ * `C extends CustomCommands<infer O> ? O : never`, and `O` infers to the whole
+ * registry — so without it every spec would have to supply *all* registered
+ * commands at once, and a registry with more than one command would reject
+ * `{ $filter: ... }` outright.
  */
-export type CustomizationUpdateCommands = CustomCommands<{ $filter: FilterSpec }>;
+export type CustomizationUpdateCommands = CustomCommands<
+  Partial<AppTypes.CustomizationUpdateCommands>
+>;
+
+/**
+ * A read-time `{ $reference: '<customization id>' }` marker. The service
+ * replaces it with the value of the referenced customization when the value is
+ * read (see `_resolveReferences`), so markers may stand in for a value
+ * anywhere the resolver walks: as a whole value, as an array item (a
+ * referenced array is flattened into the surrounding list), or as a plain
+ * object's property value.
+ */
+export type ReferenceMarker = { $reference: string };
+
+/**
+ * A read-time `{ $transform }` hook. `transform()` calls it with the service
+ * and uses the result as the value, so the object carrying it does not have to
+ * satisfy the declared value type itself — the sibling properties are the
+ * hook's input, read off `this` (see `contextMenuCustomization`).
+ *
+ * Note the return type is not enforced: `Spec` already admits a bare
+ * `(value: T) => T` function form, so a `$transform` is checked as a function
+ * but not against `T`. `$transform` is a dynamic escape hatch with an untyped
+ * `this`; the checked paths are direct values and `$set` / `$push` / ... specs.
+ */
+export type TransformMarker<T> = { $transform: (service: any) => T };
+
+/**
+ * Values `_resolveReferences` returns untouched rather than walking, so a
+ * `$reference` marker cannot be substituted inside them.
+ */
+type OpaqueValue =
+  | ((...args: any[]) => any)
+  | (abstract new (...args: any[]) => any)
+  | React.ReactElement
+  | Date
+  | RegExp;
+
+/**
+ * What may be *authored* in place of a customization value that resolves to
+ * `T`: the value itself, or any of the read-time markers above substituted at
+ * the positions the resolver walks.
+ *
+ * This transform is deliberately applied only on the write side
+ * ({@link CustomizationEntries}). `getCustomization` returns the resolved
+ * value, which never contains markers, so its declared type stays clean — the
+ * registry declares what a key resolves to, not what may be written for it.
+ */
+export type Authorable<T> =
+  | ReferenceMarker
+  | TransformMarker<T>
+  | (T extends OpaqueValue
+      ? T
+      : T extends readonly (infer U)[]
+        ? Authorable<U>[]
+        : T extends object
+          ? { [K in keyof T]: Authorable<T[K]> }
+          : T);
 
 type KnownCustomizationIds = keyof AppTypes.Customizations;
 
@@ -89,14 +179,15 @@ type KnownCustomizationIds = keyof AppTypes.Customizations;
  * `customizationService.setCustomizations`. Ids registered in
  * `AppTypes.Customizations` are checked against their declared value type,
  * either as a direct value or as an immutability-helper spec over it
- * (e.g. `{ $set: ... }`, `{ $push: [...] }`). Ids not in the registry
+ * (e.g. `{ $set: ... }`, `{ $push: [...] }`), in both cases allowing the
+ * read-time markers {@link Authorable} describes. Ids not in the registry
  * (dynamic keys, third-party keys that have not been declared) are still
  * accepted, with unconstrained value types.
  */
 export type CustomizationEntries = {
   [K in KnownCustomizationIds]?:
-    | AppTypes.Customizations[K]
-    | Spec<AppTypes.Customizations[K], CustomizationUpdateCommands>;
+    | Authorable<AppTypes.Customizations[K]>
+    | Spec<Authorable<AppTypes.Customizations[K]>, CustomizationUpdateCommands>;
 } & {
   [customizationId: string]: unknown;
 };

--- a/platform/core/src/types/AppTypes.ts
+++ b/platform/core/src/types/AppTypes.ts
@@ -64,6 +64,35 @@ declare global {
       extensionManager?: ExtensionManager;
     }
 
+    /**
+     * Registry mapping customization ids to their resolved value types.
+     *
+     * Seeded empty here; each extension (in-tree or third-party) merges the
+     * keys it owns via declaration merging, the same way `AppTypes.Services`
+     * is extended:
+     *
+     * ```ts
+     * declare global {
+     *   namespace AppTypes {
+     *     interface Customizations {
+     *       'viewportOverlay.topLeft': OverlayItem[];
+     *       'panelSegmentation.disableEditing': boolean;
+     *     }
+     *   }
+     * }
+     * ```
+     *
+     * Keys registered here get autocomplete and a precise return type on
+     * `customizationService.getCustomization` / value checking on
+     * `setCustomizations`. Ids not in the registry (e.g. dynamic, computed
+     * keys) still work through the plain-string fallback overloads.
+     *
+     * Declare a key's type with `| undefined` when no default is shipped for
+     * it, so consumers are forced to handle its absence.
+     */
+    // eslint-disable-next-line @typescript-eslint/no-empty-interface, @typescript-eslint/no-empty-object-type
+    export interface Customizations {}
+
     export interface Services {
       hangingProtocolService?: HangingProtocolServiceType;
       customizationService?: CustomizationServiceType;

--- a/platform/core/src/types/AppTypes.ts
+++ b/platform/core/src/types/AppTypes.ts
@@ -91,7 +91,20 @@ declare global {
      * it, so consumers are forced to handle its absence.
      */
     // eslint-disable-next-line @typescript-eslint/no-empty-interface, @typescript-eslint/no-empty-object-type
-    export interface Customizations {}
+    export interface Customizations {
+      /**
+       * Orders display sets within a study. Consumed by `createStudyBrowserTabs`
+       * here in core and by the viewer's `defaultRouteInit`; the default is
+       * registered by `extension-default`.
+       */
+      sortingCriteria: (a: DisplaySet, b: DisplaySet) => number;
+
+      /** Orders the instances of an image set. Consumed by `ImageSet.sort`. */
+      instanceSortingCriteria: {
+        defaultSortFunctionName?: string;
+        sortFunctions?: Record<string, (a: unknown, b: unknown) => number>;
+      };
+    }
 
     export interface Services {
       hangingProtocolService?: HangingProtocolServiceType;

--- a/platform/core/src/utils/createStudyBrowserTabs.ts
+++ b/platform/core/src/utils/createStudyBrowserTabs.ts
@@ -47,10 +47,7 @@ export function createStudyBrowserTabs(
       ds => ds.StudyInstanceUID === study.studyInstanceUid
     );
 
-    const sortCriteria = customizationService.getCustomization('sortingCriteria') as (
-      a,
-      b
-    ) => number;
+    const sortCriteria = customizationService.getCustomization('sortingCriteria');
     const sortedDisplaySets = displaySetsForStudy.sort((a, b) => {
       const displaySetA = displaySetService.getDisplaySetByUID(a.displaySetInstanceUID);
       const displaySetB = displaySetService.getDisplaySetByUID(b.displaySetInstanceUID);

--- a/platform/docs/docs/platform/services/customization-service/advanced.md
+++ b/platform/docs/docs/platform/services/customization-service/advanced.md
@@ -94,6 +94,12 @@ In this snippet, the `transform` function:
 
 ---
 
+**See also**
+- [Typing Customizations](./typing.md): declared types describe the value *after*
+  `inheritsFrom` and `$transform` have resolved, so a key can be typed as its
+  final shape while still being written with `inheritsFrom` / `$transform` /
+  `$reference`.
+
 **Key Points**
 - `inheritsFrom` is a reference to another customization’s ID.
 - If `transform` is defined, it always runs after inheritance is resolved.

--- a/platform/docs/docs/platform/services/customization-service/customizationService.md
+++ b/platform/docs/docs/platform/services/customization-service/customizationService.md
@@ -249,6 +249,7 @@ Use this introduction page for the core model (scope, priority, and syntax), the
 - [Measurements](./Measurements.md): Measurement-related customization surface.
 - [Segmentation](./Segmentation.md): Segmentation-specific customization options.
 - [Advanced Customization](./advanced.md): `inheritsFrom`, `$transform`, and compositional patterns.
+- [Typing Customizations](./typing.md): Declaring a customization id in `AppTypes.Customizations` so reads are typed, writes are checked, and call-site casts can be deleted.
 
 ## Customization Syntax
 
@@ -487,6 +488,8 @@ customizationService.setCustomizations({
 | `$apply`    | Compute the new value dynamically            | Apply a function to transform values |
 | `$filter`   | Find and update specific items in arrays     | Target nested structures             |
 | `$transform`| Apply a function to transform the customization | Apply a function to transform values |
+
+Extensions can register additional commands with `registerCustomUpdateCommand`. To have specs using them type-checked, declare them as described in [Typing Customizations](./typing.md#declaring-a-custom-update-command).
 
 ## Building Customizations Across Multiple Extensions
 

--- a/platform/docs/docs/platform/services/customization-service/typing.md
+++ b/platform/docs/docs/platform/services/customization-service/typing.md
@@ -1,0 +1,245 @@
+---
+sidebar_label: Typing Customizations
+title: Typing Customizations
+summary: How to declare the TypeScript type of a customization id in the AppTypes.Customizations registry so that reads are typed, writes are checked, and casts can be deleted.
+sidebar_position: 12
+---
+
+By default `getCustomization(id)` accepts any string and returns the loose
+`Customization` union, so call sites cast (`as string`, `as unknown as
+ColorbarCustomization`, ...) and `setCustomizations` payloads are not checked at
+all.
+
+You can opt a customization id into real typing by declaring it in the
+`AppTypes.Customizations` registry. Declaring an id gives you:
+
+- **autocomplete** for the id itself,
+- a **precise return type** from `getCustomization` / `getValue`, so the cast at
+  the call site can be deleted,
+- **checked writes** — `setCustomizations` validates the value against the
+  declared type, including `$set` / `$push` / `$merge` specs.
+
+Ids you do not declare keep working exactly as before. Nothing here changes
+runtime behavior.
+
+## Declaring a key
+
+The registry is a global interface extended by declaration merging, the same
+pattern already used for `AppTypes.Services`. Add a `types/AppTypes.ts` to your
+package (or extend the existing one) and merge in the ids you own:
+
+```ts
+// platform/ui-next/src/types/AppTypes.ts
+declare global {
+  namespace AppTypes {
+    interface Customizations {
+      /**
+       * Sort options offered by the study browser's sort dropdown. Read by
+       * `StudyBrowserSort`, which indexes `[0]` for its initial selection, so a
+       * default with at least one entry is expected.
+       */
+      'studyBrowser.sortFunctions': Array<{
+        label: string;
+        sortFunction: (a: AppTypes.DisplaySet, b: AppTypes.DisplaySet) => number;
+      }>;
+    }
+  }
+}
+
+export {};
+```
+
+That is the whole mechanism. `StudyBrowserSort` now reads the value without a
+cast and without `?.`:
+
+```tsx
+const sortFunctions = customizationService.getCustomization('studyBrowser.sortFunctions');
+
+const [selectedSort, setSelectedSort] = useState(sortFunctions[0]);
+// ...
+{sortFunctions.map(sort => <DropdownMenuItem key={sort.label}>{sort.label}</DropdownMenuItem>)}
+```
+
+For a value type of any real size, export it from the file that produces the
+default and reference it here rather than inlining the shape.
+
+## Where to declare it
+
+**The package that consumes a key declares its type**, next to the consumer.
+
+That is often also the package registering the default, but not always, and the
+difference matters. `studyBrowser.sortFunctions` above is declared in
+`platform/ui-next` because that is where it is read — but its default is
+registered by `extension-default`
+(`src/customizations/studyBrowserCustomization.ts`). Declaring at the consumer is
+what lets the provider's default be checked against the contract the consumer
+relies on.
+
+Keys read by `platform/core` are declared in core, so the dependency direction
+stays extension-free:
+
+```ts
+// platform/core/src/types/AppTypes.ts, inside the existing
+// `declare global { namespace AppTypes { ... } }` block
+export interface Customizations {
+  /**
+   * Orders display sets within a study. Consumed by `createStudyBrowserTabs`
+   * here in core and by the viewer's `defaultRouteInit`; the default is
+   * registered by `extension-default`.
+   */
+  sortingCriteria: (a: DisplaySet, b: DisplaySet) => number;
+
+  /** Orders the instances of an image set. Consumed by `ImageSet.sort`. */
+  instanceSortingCriteria: {
+    defaultSortFunctionName?: string;
+    sortFunctions?: Record<string, (a: unknown, b: unknown) => number>;
+  };
+}
+```
+
+Declaring `sortingCriteria` is what let this cast be deleted in *two* packages
+(`platform/core/src/utils/createStudyBrowserTabs.ts` and
+`platform/app/src/routes/Mode/defaultRouteInit.ts`), which had the same one:
+
+```diff
+- const sortCriteria = customizationService.getCustomization('sortingCriteria') as (a, b) => number;
++ const sortCriteria = customizationService.getCustomization('sortingCriteria');
+```
+
+Third-party extensions declare their own ids the same way, from outside the
+repo. Nothing needs to be registered centrally.
+
+## Declare the *resolved* value
+
+The declared type describes what `getCustomization` hands back — the value
+**after** `inheritsFrom` merging, `$transform`, and `$reference` expansion have
+run. It is not the shape you write.
+
+This distinction is what lets composition keys be typed at all. `toolbarButtons`
+resolves to a list of buttons, so that is what you declare:
+
+```ts
+interface Customizations {
+  toolbarButtons: Button[];
+}
+```
+
+...even though it is almost always *written* with `$reference` markers:
+
+```js
+// modes/basic/src/index.tsx
+toolbarButtons: [{ $reference: 'cornerstone.toolbarButtons' }],
+```
+
+Both are accepted. `setCustomizations` allows the read-time markers wherever the
+resolver walks — as a whole value, as an array item, or as a plain object's
+property value — while reads stay clean:
+
+```ts
+customizationService.setCustomizations({
+  // whole value
+  toolbarButtons: { $reference: 'cornerstone.toolbarButtons' },
+  // appended to the existing list
+  toolbarSections: { $push: [{ $reference: 'cornerstone.toolbarSections' }] },
+  // mixed with literal entries
+  toolGroupAdditions: { default: [{ $reference: 'x' }], mpr: [] },
+  // computed at read time from its siblings (must be a `function`, not an
+  // arrow -- `$transform` reads the sibling properties off `this`)
+  measurementsContextMenu: {
+    inheritsFrom: 'ohif.contextMenu',
+    $transform: function (customizationService) {
+      return { ...this, menus: this.menus.map(menu => ({ ...menu })) };
+    },
+  },
+});
+```
+
+Do **not** put markers into the declared type. `toolbarButtons: (Button |
+ReferenceMarker)[]` would force every read site to handle a marker that
+`getCustomization` never returns.
+
+## Nullability
+
+**A declaration without `| undefined` is a promise that a default is
+registered.** Consumers may then use the value directly, which is how existing
+consumers are already written — `StudyBrowserSort` indexes `sortFunctions[0]`
+with no guard.
+
+Add `| undefined` only for ids that genuinely ship no default:
+
+```ts
+interface Customizations {
+  // has a default registered by extension-default
+  'studyBrowser.sortFunctions': SortFunction[];
+  // no default; every consumer must handle absence
+  'studyBrowser.onDoubleClick': DoubleClickHandler | undefined;
+}
+```
+
+Note the repo's own `tsconfig.json` does not enable `strictNullChecks`, so
+`| undefined` is erased in-tree; it is a contract for downstream consumers that
+do compile strictly.
+
+## Declaring a custom update command
+
+`$filter` is registered by the service itself. If your extension registers more
+through `registerCustomUpdateCommand`, declare them in the parallel
+`AppTypes.CustomizationUpdateCommands` registry so specs using them type-check
+without a cast:
+
+```ts
+declare global {
+  namespace AppTypes {
+    interface CustomizationUpdateCommands {
+      /** Reorders toolbar entries by weight. */
+      $reweight: { id: string; weight: number };
+    }
+  }
+}
+```
+
+```ts
+customizationService.registerCustomUpdateCommand('reweight', (query, original) => ...);
+customizationService.setCustomizations({
+  toolbarButtons: { $reweight: { id: 'Zoom', weight: 3 } },
+});
+```
+
+## Gotchas
+
+**A key of type `any` disables all checking.** If the id you pass is `any` — for
+example destructured out of an untyped props bag — the call returns `any`, which
+is *weaker* than the `Customization | undefined` an undeclared id gets.
+Annotate the key as `string`:
+
+```ts
+// items: any -- no checking at all
+export default function MoreDropdownMenu(bindProps) {
+  const { menuItemsKey } = bindProps;
+  const items = customizationService.getCustomization(menuItemsKey);
+
+// items: Customization | undefined -- correct fallback
+export default function MoreDropdownMenu(bindProps) {
+  const { menuItemsKey }: { menuItemsKey: string } = bindProps;
+  const items = customizationService.getCustomization(menuItemsKey);
+```
+
+**Typos in a declared id are not caught.** Because undeclared ids must keep
+working, `setCustomizations` accepts any string key, so
+`'panelSegmentation.disabledEditing'` is silently treated as an unregistered
+dynamic key rather than reported as a misspelling of a declared one.
+
+**`$transform`'s return type is not checked** — it is validated as a function,
+but not against the declared value type.
+
+**`getValue`'s fallback is not checked.** Passing a `fallbackValue` whose type
+does not match the declaration does not error; the call resolves to the loose
+signature and returns the fallback's type. Prefer `getCustomization` for
+declared ids.
+
+## See also
+
+- [Advanced Customization](./advanced.md) — `inheritsFrom` and `$transform`
+  semantics.
+- [Customization Service](./customizationService.md) — the `$set` / `$push` /
+  `$filter` command syntax these types check.

--- a/platform/ui-next/src/types/AppTypes.ts
+++ b/platform/ui-next/src/types/AppTypes.ts
@@ -1,0 +1,24 @@
+/**
+ * Customization ids owned by `ui-next`: the component here is the consumer, so
+ * the shape it reads is declared here, next to that consumer. The default value
+ * is registered by `extension-default`
+ * (`src/customizations/studyBrowserCustomization.ts`) — declaring the type here
+ * is what lets that package's default be checked against this contract.
+ */
+declare global {
+  namespace AppTypes {
+    interface Customizations {
+      /**
+       * Sort options offered by the study browser's sort dropdown. Read by
+       * `StudyBrowserSort`, which indexes `[0]` for its initial selection, so a
+       * default with at least one entry is expected.
+       */
+      'studyBrowser.sortFunctions': Array<{
+        label: string;
+        sortFunction: (a: AppTypes.DisplaySet, b: AppTypes.DisplaySet) => number;
+      }>;
+    }
+  }
+}
+
+export {};


### PR DESCRIPTION
### Context

The CustomizationService exposes ~90 customization ids, but `getCustomization(id)` returns the loose `Customization` union for all of them. There is no discoverability of which ids exist or what shape each expects, and consumers compensate with ~20 `as unknown as X` / `as any` casts across the repo. `setCustomizations` payloads (including `$set` / `$push` command specs used by modes and app config) are not checked at all.

### Changes

This PR adds the typing infrastructure (no per-key population yet, and no runtime changes):

- **`AppTypes.Customizations` registry** — an empty, declaration-merged global interface in `platform/core/src/types/AppTypes.ts`, following the exact pattern already used by `AppTypes.Services` and `PresentationIds`. Each extension (in-tree or third-party) declares the ids it owns:

  ```ts
  declare global {
    namespace AppTypes {
      interface Customizations {
        'viewportOverlay.topLeft': OverlayItem[];
        'panelSegmentation.disableEditing': boolean;
      }
    }
  }
  ```

- **Typed overloads** on `getCustomization`, `getValue`, and `hasCustomization`: registered ids get autocomplete and their declared return type; any other string (dynamic keys, undeclared third-party keys) falls back to the existing `Customization | undefined` signature, so nothing breaks.

- **Checked `setCustomizations` payloads** via the new `CustomizationEntries` type: registered ids accept their declared value directly or as an immutability-helper spec (`{ $set: ... }`, `{ $push: [...] }`, the custom `$filter`, ...). `CustomizationPhaseInput` reuses it, so phase-tagged `appConfig.customizationService` blocks written in TypeScript are checked the same way.

- **Two small call-site fixes**: `usAnnotation` and `basic-test-mode` passed the raw string `'mode'` where the `CustomizationScope` enum is expected (Mode is already the default scope, so the argument is dropped; runtime behavior identical).

- **`CUSTOMIZATION_TYPING_PLAN.md`** documents the design, the conventions for declaring keys, and the follow-up phases (populating the registry per extension, then optionally generating the docs table and a JSON Schema for JSONC customization files from the registry).

### Testing

- All 68 CustomizationService unit tests pass.
- Full-repo `tsc` diffed against a pre-change baseline: three pre-existing false positives fixed (valid customization objects rejected by the old `Record<string, Customization>` input type), zero new errors.
- A standalone compile-time smoke test exercised the mechanism end to end (registry augmentation from an extension, typed reads, wrong-type reads rejected, `$push` of wrong element type rejected, `$filter` accepted, unknown keys and string module refs still compiling) under both the repo compiler settings and `--strict`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added typed and discoverable customization IDs with improved autocomplete and strongly typed lookups.
  * Enabled safer customization updates via a typed entries format, including support for additional update commands.
* **Bug Fixes**
  * Improved typing for sorting-related customization reads without changing behavior.
* **Documentation**
  * Added a rollout plan and expanded guidance on typing customizations, including how declared types relate to resolved values and how to handle edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->