### PR TITLE
test(core): use fake timers in Queue unit tests to stop CI flakes

### DIFF
--- a/platform/core/src/utils/Queue.test.js
+++ b/platform/core/src/utils/Queue.test.js
@@ -17,7 +17,21 @@ function timeout(delay) {
 
 const threshold = 2400;
 
+// Fake timers make these tests deterministic: with real timers the elapsed
+// assertions depend on wall-clock scheduling and flake on busy CI runners
+// (a 2400ms setTimeout can take more than 4800ms to fire under load).
+// jest's modern fake timers also mock Date.now, so advanceTimersByTime moves
+// the timers and the clock together and elapsed is exactly the timeout delay.
+
 describe('Queue', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   // Todo: comment due to wrong implementation
   // it('should bind functions to the queue', async () => {
   //   const queue = new Queue(2);
@@ -38,14 +52,14 @@ describe('Queue', () => {
     const timer = queue.bind(mockedTimeout);
     const start = Date.now();
     const promise = timer(threshold).then(time => time - start);
-    try {
-      await timer(threshold);
-    } catch (e) {
-      expect(Date.now() - start < threshold).toBe(true);
-      expect(e.message).toBe('Queue limit reached');
-    }
+    // The queue is full, so the second call rejects without waiting. Awaiting
+    // the rejection also flushes the microtasks that register the first
+    // task's setTimeout, so it can be advanced below.
+    await expect(timer(threshold)).rejects.toThrow('Queue limit reached');
+    expect(Date.now() - start < threshold).toBe(true);
+    jest.advanceTimersByTime(threshold);
     const elapsed = await promise;
-    expect(elapsed >= threshold && elapsed < 2 * threshold).toBe(true);
+    expect(elapsed).toBe(threshold);
     expect(mockedTimeout).toHaveBeenCalledTimes(1);
   });
   it('should safely bind tasks to the queue', async () => {
@@ -62,8 +76,9 @@ describe('Queue', () => {
       1,
       expect.objectContaining({ message: 'Queue limit reached' })
     );
+    jest.advanceTimersByTime(threshold);
     const elapsed = await promise;
-    expect(elapsed >= threshold && elapsed < 2 * threshold).toBe(true);
+    expect(elapsed).toBe(threshold);
     expect(mockedTimeout).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
### Context

The two Queue unit tests in `platform/core/src/utils/Queue.test.js` measure real `setTimeout` wall-clock time and assert `elapsed >= threshold && elapsed < 2 * threshold` with `threshold = 2400`. On a busy CI runner a 2400ms timer can take longer than 4800ms to fire, so the upper-bound assertion fails intermittently. We hit this in a cornerstone3D downstream-validation run against OHIF master (cornerstonejs/cornerstone3D#2780), where `Queue › should safely bind tasks to the queue` failed with no related code in the PR.

### Change

Switch the suite to jest's modern fake timers:

- `advanceTimersByTime(threshold)` moves the timers and the mocked `Date.now` together, so the measured elapsed time is exactly the timeout delay and the assertions become exact (`toBe(threshold)`) instead of a wall-clock range.
- The queue-limit rejection is asserted with `rejects.toThrow`, which also flushes the microtasks that register the first task's `setTimeout` before the clock is advanced.
- Side benefit: the suite no longer spends ~5 seconds of real time waiting on timers (runs in ~10ms).

No production code changes; the commented-out legacy test is left as-is.

### Testing

`npx jest src/utils/Queue.test.js` in `platform/core` — 2/2 pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved queue timing tests for more consistent and deterministic results.
  * Updated timeout and queue-limit checks to use controlled timer progression and precise assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->