### PR TITLE
fix(app): appearance modal provider scope, worklist preview persistence, and tag browser label overflow

### DIFF
--- a/extensions/default/src/DicomTagBrowser/DicomTagBrowser.tsx
+++ b/extensions/default/src/DicomTagBrowser/DicomTagBrowser.tsx
@@ -165,8 +165,11 @@ const DicomTagBrowser = ({
           </div>
           {shouldShowInstanceList && (
             <div className="mx-auto mt-0.5 flex w-1/4 flex-col">
-              <span className="text-muted-foreground flex h-6 items-center pb-2 text-base">
-                Instance Number ({instanceNumber} of {activeDisplaySet?.images?.length})
+              <span className="text-muted-foreground flex h-6 min-w-0 items-center whitespace-nowrap pb-2 text-base">
+                <span className="truncate">Instance Number</span>
+                <span className="shrink-0">
+                  &nbsp;({instanceNumber} of {activeDisplaySet?.images?.length})
+                </span>
               </span>
               <Slider
                 value={[instanceNumber]}

--- a/platform/app/src/App.tsx
+++ b/platform/app/src/App.tsx
@@ -129,12 +129,17 @@ function App({
     [ShepherdJourneyProvider],
   ];
 
-  // Loop through and register each of the service providers registered with the ServiceProvidersManager.
-  const providersFromManager = Object.entries(serviceProvidersManager.providers);
+  // Providers registered with the ServiceProvidersManager are inserted ahead of
+  // the dialog/modal providers: dialog and modal content renders at those
+  // providers' own level (as a sibling of their children, not inside the route
+  // tree), so any context a registered provider supplies must already be in
+  // scope there.
+  const providersFromManager = Object.entries(serviceProvidersManager.providers).map(
+    ([serviceName, provider]) => [provider, { service: servicesManager.services[serviceName] }]
+  );
   if (providersFromManager.length > 0) {
-    providersFromManager.forEach(([serviceName, provider]) => {
-      providers.push([provider, { service: servicesManager.services[serviceName] }]);
-    });
+    const dialogIndex = providers.findIndex(([component]) => component === DialogProvider);
+    providers.splice(dialogIndex, 0, ...providersFromManager);
   }
 
   const CombinedProviders = ({ children }) => Compose({ components: providers, children });

--- a/platform/app/src/routes/WorkList/WorkList.tsx
+++ b/platform/app/src/routes/WorkList/WorkList.tsx
@@ -9,6 +9,7 @@ import {
   StudyList,
   Icons,
   InvestigationalUseDialog,
+  useSessionStorage,
   type StudyRow,
   type OnStudyDoubleClick,
 } from '@ohif/ui-next';
@@ -53,7 +54,19 @@ export default function WorkList({
   const defaultSorting = useMemo(() => [{ id: 'studyDateTime', desc: true }], []);
 
   const [selected, setSelected] = useState<StudyRow | null>(null);
-  const [isPreviewOpen, setPreviewOpen] = useState(true);
+
+  // Persist the preview panel open/closed state so it survives navigating
+  // into a study and back. The hook only handles objects, hence the wrapper.
+  const [previewState, updatePreviewState] = useSessionStorage({
+    key: 'studyList.previewOpen',
+    defaultValue: { open: true },
+    clearOnUnload: false,
+  });
+  const isPreviewOpen = previewState.open !== false;
+  const setPreviewOpen = useCallback(
+    (open: boolean) => updatePreviewState({ open }),
+    [updatePreviewState]
+  );
 
   // `workList.onStudyDoubleClick` is the command (or command list) run when a
   // study row is double-clicked — by default `launchDefaultMode`, which


### PR DESCRIPTION
### Fixes three UI issues

**1. Appearance modal crashed with `useActiveTheme must be used within an ActiveThemeProvider`**

`ModalProvider` renders modal content as a sibling of its children, but providers registered through the `ServiceProvidersManager` (including `ActiveThemeProvider`) were appended after it in `App.tsx`, so modal content could never see those contexts. Opening Settings > Appearance from the worklist gear menu or the viewer header threw and rendered nothing. Manager-registered providers are now inserted ahead of the dialog/modal providers so dialog and modal content is within their scope.

**2. Worklist preview panel did not remember its closed state**

The open/closed state was a plain `useState(true)`, so closing the panel, opening a study, and navigating back reopened it. The state is now persisted with the existing `useSessionStorage` hook (key `studyList.previewOpen`) and survives navigation for the lifetime of the tab.

**3. DICOM tag browser instance number label wrapped and clipped**

With 3-digit instance counts (e.g. `Instance Number (189 of 295)`) the fixed-height label wrapped to a second line and got cut off. The label now stays on one line: the words truncate with an ellipsis when space runs short and the digits are always fully visible.

### Testing

- Worklist gear menu > Appearance and viewer header > Appearance open the theme picker (config with `customizationModule.theme`, e.g. `config/dev.js`)
- Close the worklist preview panel, open a study, navigate back: panel stays closed
- Tag browser at narrow widths with a large series: instance count digits never clip

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved formatting of the DICOM “Instance Number” display to prevent text overflow.
  * Preserved the worklist preview panel’s open or closed state when navigating within the application.
  * Improved the integration and ordering of dynamically registered services for more consistent application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->