### PR TITLE
fix(cornerstone): share one color LUT across a segmentation's viewport representations

### DIFF
--- a/extensions/cornerstone/src/services/SegmentationService/SegmentationService.test.ts
+++ b/extensions/cornerstone/src/services/SegmentationService/SegmentationService.test.ts
@@ -1352,6 +1352,30 @@ describe('SegmentationService', () => {
       expect(cstSegmentation.state.addColorLUT).toHaveBeenCalledWith([[0, 0, 0, 0]]);
       expect(service['_segmentationIdToColorLUTIndexMap'].get(segmentationId)).toBe(7);
     });
+
+    it('should keep the existing color LUT when called again with the same segmentation id', async () => {
+      const displaySet = {
+        imageIds: ['imageId'],
+        isDynamicVolume: false,
+        SeriesNumber: 1,
+        SeriesDescription: 'Series Description',
+      } as unknown as AppTypes.DisplaySet;
+
+      jest
+        .spyOn(imageLoader, 'createAndCacheDerivedLabelmapImages')
+        .mockReturnValue([{ imageId: 'imageId' }] as csTypes.IImage[]);
+      jest.spyOn(cstSegmentation.state, 'getSegmentations').mockReturnValue([]);
+      jest.spyOn(service, 'addOrUpdateSegmentation').mockReturnValue(undefined);
+      jest.mocked(cstSegmentation.state.addColorLUT).mockReturnValueOnce(7).mockReturnValueOnce(8);
+
+      const segmentationId = await service.createLabelmapForDisplaySet(displaySet);
+      await service.createLabelmapForDisplaySet(displaySet, { segmentationId });
+
+      // Updating an existing segmentation must not strand the representations
+      // already rendering it on the previous LUT.
+      expect(cstSegmentation.state.addColorLUT).toHaveBeenCalledTimes(1);
+      expect(service['_segmentationIdToColorLUTIndexMap'].get(segmentationId)).toBe(7);
+    });
   });
 
   describe('createSegmentationForSEGDisplaySet', () => {

--- a/extensions/cornerstone/src/services/SegmentationService/SegmentationService.test.ts
+++ b/extensions/cornerstone/src/services/SegmentationService/SegmentationService.test.ts
@@ -1331,6 +1331,27 @@ describe('SegmentationService', () => {
 
       expect(retrievedSegmentationId).toEqual(segmentationId);
     });
+
+    it('should create a dedicated color LUT and remember its index so every viewport representation reuses it', async () => {
+      const displaySet = {
+        imageIds: ['imageId'],
+        isDynamicVolume: false,
+        SeriesNumber: 1,
+        SeriesDescription: 'Series Description',
+      } as unknown as AppTypes.DisplaySet;
+
+      jest
+        .spyOn(imageLoader, 'createAndCacheDerivedLabelmapImages')
+        .mockReturnValue([{ imageId: 'imageId' }] as csTypes.IImage[]);
+      jest.spyOn(cstSegmentation.state, 'getSegmentations').mockReturnValue([]);
+      jest.spyOn(service, 'addOrUpdateSegmentation').mockReturnValue(undefined);
+      jest.mocked(cstSegmentation.state.addColorLUT).mockReturnValue(7);
+
+      const segmentationId = await service.createLabelmapForDisplaySet(displaySet);
+
+      expect(cstSegmentation.state.addColorLUT).toHaveBeenCalledWith([[0, 0, 0, 0]]);
+      expect(service['_segmentationIdToColorLUTIndexMap'].get(segmentationId)).toBe(7);
+    });
   });
 
   describe('createSegmentationForSEGDisplaySet', () => {

--- a/extensions/cornerstone/src/services/SegmentationService/SegmentationService.ts
+++ b/extensions/cornerstone/src/services/SegmentationService/SegmentationService.ts
@@ -512,6 +512,14 @@ class SegmentationService extends PubSubService implements ISegmentationServiceI
       },
     };
 
+    // Create a dedicated color LUT up front and remember its index so that every
+    // representation of this segmentation (one per viewport) reuses the same LUT.
+    // Otherwise each viewport would get its own default LUT copy and editing a
+    // segment color on one viewport would not be reflected on the others (the
+    // segment color appears to revert to the default when interacting elsewhere).
+    const colorLUTIndex = addColorLUT([[0, 0, 0, 0]] as csTypes.ColorLUT);
+    this._segmentationIdToColorLUTIndexMap.set(segmentationId, colorLUTIndex);
+
     this.addOrUpdateSegmentation(segmentationPublicInput);
     return segmentationId;
   }

--- a/extensions/cornerstone/src/services/SegmentationService/SegmentationService.ts
+++ b/extensions/cornerstone/src/services/SegmentationService/SegmentationService.ts
@@ -517,8 +517,13 @@ class SegmentationService extends PubSubService implements ISegmentationServiceI
     // Otherwise each viewport would get its own default LUT copy and editing a
     // segment color on one viewport would not be reflected on the others (the
     // segment color appears to revert to the default when interacting elsewhere).
-    const colorLUTIndex = addColorLUT([[0, 0, 0, 0]] as csTypes.ColorLUT);
-    this._segmentationIdToColorLUTIndexMap.set(segmentationId, colorLUTIndex);
+    // The caller may pass the id of an existing segmentation, which this method
+    // updates rather than replaces; keep its LUT so representations already
+    // rendering it don't diverge from the ones created afterwards.
+    if (!this._segmentationIdToColorLUTIndexMap.has(segmentationId)) {
+      const colorLUTIndex = addColorLUT([[0, 0, 0, 0]] as csTypes.ColorLUT);
+      this._segmentationIdToColorLUTIndexMap.set(segmentationId, colorLUTIndex);
+    }
 
     this.addOrUpdateSegmentation(segmentationPublicInput);
     return segmentationId;


### PR DESCRIPTION
### Context

Editing a segment's color on a labelmap segmentation created by `createLabelmapForDisplaySet` (i.e. a segmentation the user creates in the viewer, as opposed to one loaded from a SEG or RT display set) does not stick: as soon as a drawing tool is used in another viewport, the segment reverts to its default color.

The cause is that `createLabelmapForDisplaySet` never creates a **dedicated color LUT** for the segmentation. The SEG and RT paths both do — they call `addColorLUT` and record the index in `_segmentationIdToColorLUTIndexMap` — but the labelmap path does not. With no index recorded, every viewport that renders the segmentation ends up with its own copy of the default LUT. A color edit therefore mutates only the LUT belonging to the viewport it was made in, and any other viewport keeps rendering the old default.

### Changes & Results

`extensions/cornerstone/src/services/SegmentationService/SegmentationService.ts`:

- In `createLabelmapForDisplaySet`, create a dedicated color LUT up front and record its index in `_segmentationIdToColorLUTIndexMap`, mirroring what `createSegmentationForSEGDisplaySet` and `createSegmentationForRTDisplaySet` already do.
- Every viewport representation of the segmentation then resolves to that same LUT, so a color edit made in one viewport is reflected in all of them.

**Before:** change a segment's colour, then draw in another viewport → the segment reverts to the default colour.
**After:** the edited colour is retained across all viewports.

This is 8 lines and does not change the SEG/RT paths or the LUT plumbing itself; it just brings the labelmap path in line with them.

### Testing

`extensions/cornerstone/src/services/SegmentationService/SegmentationService.test.ts` — new case in the `createLabelmapForDisplaySet` block asserting that a dedicated color LUT is created and its index recorded against the segmentation id. It is a genuine regression test: it fails on `master` (`addColorLUT` is never called) and passes with this change.

```
cd extensions/cornerstone && jest src/services/SegmentationService/SegmentationService.test.ts
```

The full `SegmentationService` suite passes (86 tests).

Manually:

1. Create a labelmap segmentation on a study displayed in a multi-viewport layout.
2. Change a segment's colour from the segmentation panel.
3. Use a drawing tool (e.g. the brush) in a **different** viewport.
4. **Before:** the segment reverts to its default colour. **After:** the edited colour is retained.

### Checklist

#### PR

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] OS: macOS 15 (Darwin 25.5.0)
- [x] Node version: 24.3.0
- [x] Browser: Chrome 138

---

This fix is contributed by the **University of Calgary**, who are donating it back to OHIF. It was co-authored with Ron Leisti.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved segmentation display consistency across multiple viewports by reusing a dedicated color lookup table per segmentation ID.
  * Initialized newly created segmentation color lookup tables with a transparent entry to ensure consistent rendering.
* **Tests**
  * Added unit tests to verify color lookup tables are created only once and reused on subsequent labelmap creation for the same segmentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->