### PR TITLE
fix(deps): pin websocket-driver to 0.7.5

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,7 @@ overrides:
   minimatch@>=10.0.0 <10.2.3: 10.2.5
   picomatch@<2.3.2: 2.3.2
   picomatch@>=4.0.0 <4.0.4: 4.0.4
+  websocket-driver@<0.7.5: 0.7.5
 
 importers:
 
@@ -13597,8 +13598,8 @@ packages:
       webpack:
         optional: true
 
-  websocket-driver@0.7.4:
-    resolution: {integrity: sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==}
+  websocket-driver@0.7.5:
+    resolution: {integrity: sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==}
     engines: {node: '>=0.8.0'}
 
   websocket-extensions@0.1.4:
@@ -22732,7 +22733,7 @@ snapshots:
 
   faye-websocket@0.11.4:
     dependencies:
-      websocket-driver: 0.7.4
+      websocket-driver: 0.7.5
 
   fb-watchman@2.0.2:
     dependencies:
@@ -28421,7 +28422,7 @@ snapshots:
     dependencies:
       faye-websocket: 0.11.4
       uuid: 8.3.2
-      websocket-driver: 0.7.4
+      websocket-driver: 0.7.5
 
   sonner@1.7.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -29578,7 +29579,7 @@ snapshots:
       '@rspack/core': 1.7.11(@swc/helpers@0.5.21)
       webpack: 5.105.0(@swc/core@1.15.13(@swc/helpers@0.5.21))
 
-  websocket-driver@0.7.4:
+  websocket-driver@0.7.5:
     dependencies:
       http-parser-js: 0.5.10
       safe-buffer: 5.2.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -89,3 +89,7 @@ overrides:
   'minimatch@>=10.0.0 <10.2.3': 10.2.5
   'picomatch@<2.3.2': 2.3.2
   'picomatch@>=4.0.0 <4.0.4': 4.0.4
+  # websocket-driver <0.7.5 reaches the tree only via platform/docs
+  # (@docusaurus/core > webpack-dev-server > sockjs > faye-websocket). 0.7.5
+  # patches GHSA-xv26-6w52-cph6 (message corruption via protocol length headers).
+  'websocket-driver@<0.7.5': 0.7.5


### PR DESCRIPTION
## Summary

Pins `websocket-driver` to **0.7.5** via the `pnpm-workspace.yaml` `overrides` block.

`websocket-driver <0.7.5` currently resolves to `0.7.4` in the tree, reached **only via `platform/docs`** (`@docusaurus/core` > `webpack-dev-server` > `sockjs` > `faye-websocket`) — dev/docs-site tooling, not viewer runtime. Both consumers (`faye-websocket` `>=0.5.1`, `sockjs` `^0.7.4`) accept `0.7.5`, so the bump is transparent.

This clears the high-risk audit gate in the `BUILD_PACKAGES_QUICK` CI job, which runs `pnpm audit --audit-level high` whenever `pnpm-lock.yaml` changes. That gate is skipped on lockfile-untouched PRs (and on master's own build, since its self-diff is empty), so this pre-existing item only surfaces on PRs that regenerate the lockfile.

Advisory: [GHSA-xv26-6w52-cph6](https://github.com/advisories/GHSA-xv26-6w52-cph6).

## Changes

- `pnpm-workspace.yaml`: add `'websocket-driver@<0.7.5': 0.7.5` to `overrides`.
- `pnpm-lock.yaml`: regenerated (`websocket-driver` 0.7.4 -> 0.7.5).

## Testing

- `pnpm install` resolves `websocket-driver@0.7.5` at both tree locations.
- `pnpm audit --audit-level high` exits **0** (was exit 1). Count drops 21 -> 19; criticals 2 -> 1, and the one remaining critical is the already-ignored `decompress` advisory (`GHSA-mp2f-45pm-3cg9`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a transitive dependency version to address a known security vulnerability.
  * Added dependency resolution guidance for the documentation platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->