### PR TITLE
fix(crosshairs): keep Crosshairs active alongside brush/zoom/pan in MPR

### DIFF
--- a/modes/preclinical-4d/src/initToolGroups.tsx
+++ b/modes/preclinical-4d/src/initToolGroups.tsx
@@ -109,6 +109,17 @@ function _initToolGroups(toolNames, Enums, toolGroupService, commandsManager, se
     disabled: [
       {
         toolName: toolNames.Crosshairs,
+        // Bind Crosshairs to Primary+Shift (matching the longitudinal/tmtv
+        // modes) so it has its own mouse binding. Without a binding it activates
+        // on plain Primary and, being `disableOnPassive`, gets disabled the
+        // moment another Primary tool (brush/zoom/pan in the same group) is
+        // activated from the toolbar, making them mutually exclusive.
+        bindings: [
+          {
+            mouseButton: Enums.MouseBindings.Primary,
+            modifierKey: Enums.KeyboardBindings.Shift,
+          },
+        ],
         configuration: {
           viewportIndicators: true,
           viewportIndicatorsConfig: {

--- a/modes/segmentation/src/initToolGroups.ts
+++ b/modes/segmentation/src/initToolGroups.ts
@@ -198,6 +198,18 @@ function initMPRToolGroup(extensionManager, toolGroupService, commandsManager) {
   tools.disabled.push(
     {
       toolName: utilityModule.exports.toolNames.Crosshairs,
+      // Bind Crosshairs to Primary+Shift (matching the longitudinal/tmtv modes)
+      // so it lives on its own mouse binding. Without a binding it activates on
+      // plain Primary and, being `disableOnPassive`, gets disabled the moment
+      // another Primary tool (brush/zoom/pan, all in this `mpr` group) is
+      // activated from the toolbar — making Crosshairs mutually exclusive with
+      // them. On its own binding it stays active alongside those tools.
+      bindings: [
+        {
+          mouseButton: utilityModule.exports.Enums.MouseBindings.Primary,
+          modifierKey: utilityModule.exports.Enums.KeyboardBindings.Shift,
+        },
+      ],
       configuration: {
         viewportIndicators: true,
         viewportIndicatorsConfig: {

--- a/modes/usAnnotation/src/initToolGroups.js
+++ b/modes/usAnnotation/src/initToolGroups.js
@@ -239,6 +239,17 @@ function initMPRToolGroup(extensionManager, toolGroupService, commandsManager) {
     disabled: [
       {
         toolName: toolNames.Crosshairs,
+        // Bind Crosshairs to Primary+Shift (matching the longitudinal/tmtv
+        // modes) so it has its own mouse binding. Without a binding it activates
+        // on plain Primary and, being `disableOnPassive`, gets disabled the
+        // moment another Primary tool (brush/zoom/pan in the same group) is
+        // activated from the toolbar, making them mutually exclusive.
+        bindings: [
+          {
+            mouseButton: Enums.MouseBindings.Primary,
+            modifierKey: Enums.KeyboardBindings.Shift,
+          },
+        ],
         configuration: {
           viewportIndicators: true,
           viewportIndicatorsConfig: {


### PR DESCRIPTION
Fixes #6152.

## Problem
In the `segmentation`, `usAnnotation`, and `preclinical-4d` modes, the MPR Crosshairs tool was configured with **no mouse binding** and `disableOnPassive: true`. Without a binding it activates on plain Primary, so activating another Primary tool in the same `mpr` tool group (brush, zoom, pan) makes `setToolActive` evict Crosshairs and — because of `disableOnPassive` — fully disable it. The two tools therefore can't be active at the same time. Measurement tools were unaffected only because they aren't members of the `mpr` group.

## Fix
Bind Crosshairs to **Primary + Shift** (matching the `longitudinal`/`tmtv` modes) so it lives on its own mouse binding and stays active alongside brush/zoom/pan. Three mode `initToolGroups` files, +34 lines.

## Testing
Open a study in segmentation mode → MPR → enable Crosshairs → activate the brush (then zoom, then pan): Crosshairs stays active (Shift+drag to move it), and toggling between them no longer disables the other.