### PR TITLE
fix(colorPicker): keep Hex input available with alpha

### DIFF
--- a/extensions/default/src/utils/colorPickerDialog.css
+++ b/extensions/default/src/utils/colorPickerDialog.css
@@ -2,3 +2,30 @@
   background: transparent !important;
   box-shadow: none !important;
 }
+
+.color-picker-hex-field {
+  margin: 0 16px 12px;
+  font-family: Menlo, monospace;
+}
+
+.color-picker-hex-input {
+  box-sizing: border-box;
+  width: 100%;
+  height: 21px;
+  border: none;
+  border-radius: 2px;
+  box-shadow: inset 0 0 0 1px #dadada;
+  color: #333;
+  font-size: 11px;
+  text-align: center;
+}
+
+.color-picker-hex-label {
+  display: block;
+  margin-top: 12px;
+  color: #969696;
+  font-size: 11px;
+  line-height: 11px;
+  text-align: center;
+  text-transform: uppercase;
+}

--- a/extensions/default/src/utils/colorPickerDialog.tsx
+++ b/extensions/default/src/utils/colorPickerDialog.tsx
@@ -1,14 +1,40 @@
-import React, { useState } from 'react';
+import React, { useId, useState } from 'react';
 import { ChromePicker } from 'react-color';
 import { FooterAction } from '@ohif/ui-next';
 
 import './colorPickerDialog.css';
 
+const rgbToHex = ({ r, g, b }) =>
+  `#${[r, g, b]
+    .map(channel => Math.round(channel).toString(16).padStart(2, '0'))
+    .join('')
+    .toUpperCase()}`;
+
 function ColorPickerDialog({ value, hide, onSave }) {
   const [color, setColor] = useState(value);
+  const [hex, setHex] = useState(() => rgbToHex(value));
+  const hexInputId = useId();
 
-  const handleChange = color => {
-    setColor(color.rgb);
+  const handleChange = nextColor => {
+    setColor(nextColor.rgb);
+    setHex(rgbToHex(nextColor.rgb));
+  };
+
+  const handleHexChange = event => {
+    const nextHex = event.target.value;
+    const normalizedHex = nextHex.replace(/^#/, '');
+    setHex(nextHex);
+
+    if (!/^[0-9a-f]{6}$/i.test(normalizedHex)) {
+      return;
+    }
+
+    setColor(currentColor => ({
+      ...currentColor,
+      r: Number.parseInt(normalizedHex.slice(0, 2), 16),
+      g: Number.parseInt(normalizedHex.slice(2, 4), 16),
+      b: Number.parseInt(normalizedHex.slice(4, 6), 16),
+    }));
   };
 
   return (
@@ -19,6 +45,24 @@ function ColorPickerDialog({ value, hide, onSave }) {
         presetColors={[]}
         width={300}
       />
+      {color.a !== undefined && color.a !== 1 && (
+        <div className="color-picker-hex-field">
+          <input
+            id={hexInputId}
+            aria-label="hex"
+            className="color-picker-hex-input"
+            data-cy="color-picker-hex-input"
+            value={hex}
+            onChange={handleHexChange}
+          />
+          <label
+            className="color-picker-hex-label"
+            htmlFor={hexInputId}
+          >
+            Hex
+          </label>
+        </div>
+      )}
       <FooterAction>
         <FooterAction.Right>
           <FooterAction.Secondary

--- a/extensions/default/src/utils/colorPickerDialog.tsx
+++ b/extensions/default/src/utils/colorPickerDialog.tsx
@@ -10,6 +10,8 @@ const rgbToHex = ({ r, g, b }) =>
     .join('')
     .toUpperCase()}`;
 
+const isValidHex = value => /^#?[0-9a-f]{6}$/i.test(value);
+
 function ColorPickerDialog({ value, hide, onSave }) {
   const [color, setColor] = useState(value);
   const [hex, setHex] = useState(() => rgbToHex(value));
@@ -73,6 +75,7 @@ function ColorPickerDialog({ value, hide, onSave }) {
           </FooterAction.Secondary>
           <FooterAction.Primary
             dataCY="color-picker-save-btn"
+            disabled={!isValidHex(hex)}
             onClick={() => {
               hide();
               onSave(color);

--- a/tests/ContourSegmentColorChange.spec.ts
+++ b/tests/ContourSegmentColorChange.spec.ts
@@ -44,6 +44,48 @@ test('opens the color edit popup when "Change Color" is clicked', async ({
   );
 });
 
+test('keeps the Hex field available after saving and reopening the color dialog', async ({
+  page,
+  rightPanelPageObject,
+  DOMOverlayPageObject,
+}) => {
+  const segment = rightPanelPageObject.contourSegmentationPanel.panel.nthSegment(0);
+  const colorPicker = DOMOverlayPageObject.dialog.colorPicker;
+
+  await page.evaluate(() => {
+    const { segmentationService, viewportGridService } = (window as any).services;
+    const segmentation = segmentationService.getSegmentations()[0];
+    const segmentIndex = Number(
+      Object.keys(segmentation.segments).find(index => Number(index) > 0)
+    );
+    const viewportId = viewportGridService.getActiveViewportId();
+    const [r, g, b] = segmentationService.getSegmentColor(
+      viewportId,
+      segmentation.segmentationId,
+      segmentIndex
+    );
+
+    segmentationService.setSegmentColor(viewportId, segmentation.segmentationId, segmentIndex, [
+      r,
+      g,
+      b,
+      127.5,
+    ]);
+  });
+
+  await segment.actions.openChangeColor();
+  await expect(colorPicker.hexInput).toHaveValue(THRESHOLD_CONTOUR_DEFAULT_HEX);
+
+  await colorPicker.fillHex(NEW_HEX);
+  await expect(colorPicker.alphaInput).toHaveValue('0.5');
+  await colorPicker.save();
+
+  await segment.actions.openChangeColor();
+
+  await expect(colorPicker.hexInput).toHaveValue(NEW_HEX);
+  await expect(colorPicker.alphaInput).toHaveValue('0.5');
+});
+
 test('changes the contour color when the user saves the edits', async ({
   viewportPageObject,
   rightPanelPageObject,

--- a/tests/ContourSegmentColorChange.spec.ts
+++ b/tests/ContourSegmentColorChange.spec.ts
@@ -76,8 +76,22 @@ test('keeps the Hex field available after saving and reopening the color dialog'
   await segment.actions.openChangeColor();
   await expect(colorPicker.hexInput).toHaveValue(THRESHOLD_CONTOUR_DEFAULT_HEX);
 
+  await colorPicker.hexInput.fill('#12');
+  await expect(colorPicker.hexInput).toHaveValue('#12');
+  await expect(colorPicker.saveButton).toBeDisabled();
+
+  await colorPicker.fillHex(THRESHOLD_CONTOUR_DEFAULT_HEX);
+  await expect(colorPicker.saveButton).toBeEnabled();
+
   await colorPicker.fillHex(NEW_HEX);
   await expect(colorPicker.alphaInput).toHaveValue('0.5');
+  await colorPicker.cancel();
+
+  await segment.actions.openChangeColor();
+  await expect(colorPicker.hexInput).toHaveValue(THRESHOLD_CONTOUR_DEFAULT_HEX);
+  await expect(colorPicker.alphaInput).toHaveValue('0.5');
+
+  await colorPicker.fillHex(NEW_HEX);
   await colorPicker.save();
 
   await segment.actions.openChangeColor();

--- a/tests/pages/DOMOverlayPageObject.ts
+++ b/tests/pages/DOMOverlayPageObject.ts
@@ -63,11 +63,13 @@ export class DOMOverlayPageObject {
       get colorPicker() {
         const locator = page.getByTestId('color-picker-dialog');
         const hexInput = locator.getByLabel('hex');
+        const alphaInput = locator.getByLabel('a');
         const saveButton = locator.getByTestId('color-picker-save-btn');
         const cancelButton = locator.getByTestId('color-picker-cancel-btn');
         return {
           locator,
           hexInput,
+          alphaInput,
           saveButton,
           cancelButton,
           fillHex: async (hex: string) => {


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- 🕮 Read our guide about our Contributing Guide here https://docs.ohif.org/development/contributing -->
<!-- :hand: Thank you for starting this amazing contribution! -->

### Context

Fixes #6150.

`react-color` switches away from its Hex field when alpha is below `1` and does not allow cycling back to Hex while the color remains translucent. That left segment colors with alpha editable only through RGBA/HSL fields.

### Changes & Results

- Show an OHIF-owned Hex input only when the upstream picker suppresses its own.
- Keep that input synchronized with picker changes.
- Apply Hex edits to RGB channels while preserving the existing alpha.
- Add Playwright coverage for editing, saving, and reopening a translucent segment color.

Opaque colors continue to use the existing `ChromePicker` Hex field. Translucent colors now keep both Hex editing and their original alpha.

### Testing

- `TEST_ENV=true pnpm exec playwright test tests/ContourSegmentColorChange.spec.ts` — 5 passed using Google Chrome 150 as the Playwright executable.
- `pnpm --filter @ohif/extension-default run build` — passed with the existing bundle-size warnings.
- `pnpm exec prettier --check extensions/default/src/utils/colorPickerDialog.tsx extensions/default/src/utils/colorPickerDialog.css tests/pages/DOMOverlayPageObject.ts` — passed.
- `git diff --check` — passed.

Manual verification:

1. Open an RTSTRUCT study in segmentation mode.
2. Open a segment's **Change Color** dialog and set alpha below `1`.
3. Edit the Hex value, save, and reopen the dialog.
4. Confirm the Hex value remains available and the alpha value is unchanged.

### Checklist

#### PR

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] OS: macOS 26.5.2
- [x] Node version: 24.16.0
- [x] Browser: Google Chrome 150.0.7871.182

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added hex color input support to the color picker dialog.
  * Hex values can be edited directly, validated as you type, and synchronized with the color preview.
  * Hex input is shown for semi-transparent colors, preserving the existing alpha behavior.
  * Save is disabled when the entered hex value is invalid.
* **Tests**
  * Added an end-to-end flow test for editing, canceling, and reopening the contour segment color dialog while verifying hex/alpha persistence.
  * Extended the color picker dialog page object to support interacting with the alpha input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->