### PR TITLE
fix(worklist): make staticWado study filtering case-insensitive

### DIFF
--- a/extensions/default/src/DicomWebDataSource/utils/StaticWadoClient.ts
+++ b/extensions/default/src/DicomWebDataSource/utils/StaticWadoClient.ts
@@ -190,6 +190,13 @@ export default class StaticWadoClient extends api.DICOMwebClient {
       );
     }
 
+    // Worklist filtering is expected to be case-insensitive regardless of
+    // fuzzy matching support (e.g. MRN, description, accession number).
+    if (typeof actual === 'string' && typeof desired === 'string') {
+      actual = actual.toLowerCase();
+      desired = desired.toLowerCase();
+    }
+
     if (typeof actual == 'string') {
       if (actual.length === 0) {
         return true;


### PR DESCRIPTION
### Context

Fixes #6029

If you open the study list on a staticWado-backed data source (the default AWS demo data, deploy previews, etc.) and type a filter value in lowercase — say `chest` in the Description field — you get "No studies available", even though plenty of studies have "CHEST" in their description. Type the same thing in uppercase and it works. That's surprising behavior for a worklist search box, and it affects MRN, Description, and Accession Number alike.

### Changes & Results

**Why this happens:** staticWado sources can't run real server-side queries, so `StaticWadoClient` fetches the full study list and filters it client-side in `compareValues()`. That function has two paths: a fuzzy-matching path that normalizes case, and a plain path that compares strings exactly as typed. The fuzzy path only ever applies to patient-name fields, and it was recently disabled on the default sources anyway (#6163) — so MRN, Description, and Accession Number always go through the case-sensitive path.

**The fix:** lowercase both the typed filter value and the stored attribute right before the plain string comparison, so matching is case-insensitive in both directions (lowercase input matches "CHEST", uppercase input matches "Chest CT Routine"). Wildcard handling (`*`) keeps working on the normalized strings, and date-range comparisons are unaffected since those are digit strings.

```ts
// Worklist filtering is expected to be case-insensitive regardless of
// fuzzy matching support (e.g. MRN, description, accession number).
if (typeof actual === 'string' && typeof desired === 'string') {
  actual = actual.toLowerCase();
  desired = desired.toLowerCase();
}
```

One thing worth flagging for reviewers: strict QIDO-RS matching is case-sensitive for non-PN attributes. Since this filter is a client-side worklist convenience rather than a real QIDO implementation, case-insensitive feels like the right default — but happy to gate it behind a config flag if you'd prefer.

**Before** (lowercase `chest` → no results) / **After** (same input → all CHEST studies match):
<!-- screenshots: before-lowercase-chest-no-results.png / after-lowercase-chest-matches.png -->

### Testing

1. `pnpm dev` with the default (staticWado AWS) data source
2. In the Study List, type `chest` (lowercase) into the Description filter
3. Before: no studies returned. After: all studies with CHEST/Chest/chest in the description are listed
4. Repeat with uppercase `CHEST` — mixed-case descriptions like "Chest CT Routine" still match

### Screenshots

##### 6029-before-lowercase-chest-no-results
<img width="1200" height="1159" alt="6029-before-lowercase-chest-no-results" src="https://github.com/user-attachments/assets/88fb6c17-6b13-42bb-b653-15bfded261be" />

##### 6029-after-lowercase-chest-matches
<img width="1200" height="1159" alt="6029-after-lowercase-chest-matches" src="https://github.com/user-attachments/assets/968523aa-0f5c-4cd5-961b-98295ee40d5d" />



### Checklist

#### PR

- [x] My Pull Request title is descriptive, accurate and follows the
      semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
      etc.)

#### Public Documentation Updates

- [x] The documentation page has been updated as necessary. (no doc changes needed)

#### Tested Environment

- [x] "OS: macOS 25.5.0
- [x] "Node version: 24.x
- [x] "Browser: Chromium (Playwright)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Worklist filtering is now case-insensitive when comparing text values.
  * Wildcard and fuzzy matching provide more consistent results regardless of letter casing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->