### PR TITLE
fix(cornerstone): keep arrow annotation when saving an empty label

### DIFF
--- a/extensions/cornerstone/src/commandsModule.ts
+++ b/extensions/cornerstone/src/commandsModule.ts
@@ -880,6 +880,11 @@ function commandsModule({
     arrowTextCallback: async ({ callback, data }) => {
       const labelConfig = customizationService.getCustomization('measurementLabels');
       const renderContent = customizationService.getCustomization('ui.labellingComponent');
+      // ArrowAnnotateTool removes a just-drawn annotation when its text
+      // callback returns a falsy label. Saving an empty label should keep
+      // the arrow (same as Cancel), so skip the callback for new
+      // annotations (no `data` means the annotation is new, not edited).
+      const isNewAnnotation = !data;
 
       if (!labelConfig) {
         const label = await callInputDialog({
@@ -889,6 +894,9 @@ function commandsModule({
           defaultValue: data?.data?.label || '',
         });
 
+        if (isNewAnnotation && !label) {
+          return;
+        }
         callback?.(label);
         return;
       }
@@ -898,6 +906,9 @@ function commandsModule({
         labelConfig,
         renderContent,
       });
+      if (isNewAnnotation && !value) {
+        return;
+      }
       callback?.(value);
     },
 


### PR DESCRIPTION
### Context

Fixes #6060

If you draw an arrow annotation and the "Edit Arrow Text" dialog pops up, you'd expect Save and Cancel to both leave your arrow on the image when you haven't typed anything — after all, an arrow without a label is still a perfectly useful pointer. Today, Cancel keeps the arrow but Save deletes it. Same empty value, opposite outcomes.

### Changes & Results

**Why this happens:** Cornerstone3D's `ArrowAnnotateTool` treats a falsy label returned from its text callback as "the user didn't want this annotation" and removes the just-drawn arrow. OHIF's `arrowTextCallback` command relays whatever the dialog resolves with — including the empty string from Save. Cancel only *appears* to work because the dialog promise never resolves on Cancel, so the tool callback never fires at all.

**The fix:** in `arrowTextCallback` (extensions/cornerstone/src/commandsModule.ts), skip the tool callback when a *new* annotation resolves with an empty label — making empty-Save behave exactly like Cancel. The command distinguishes new-vs-edit by the presence of `data` (the edit path passes the existing annotation, the creation path doesn't), and the edit path is deliberately left untouched so clearing an existing label still works.

```ts
// ArrowAnnotateTool removes a just-drawn annotation when its text
// callback returns a falsy label. Saving an empty label should keep
// the arrow (same as Cancel), so skip the callback for new
// annotations (no `data` means the annotation is new, not edited).
const isNewAnnotation = !data;
// ...
if (isNewAnnotation && !label) {
  return;
}
callback?.(label);
```

Fixing it in this one command covers every mode that registers ArrowAnnotate (basic, tmtv, usAnnotation, basic-test, and the segmentation-mode annotation tools) since they all route through it.

**Before** (Save with empty text → arrow gone) / **After** (arrow stays, same as Cancel):
<!-- screenshots: 6060-before-arrow-deleted-on-empty-save.png / 6060-after-arrow-kept-on-empty-save.png -->

### Testing

1. Open any study in the basic viewer
2. Pick **Annotation** (arrow) from the measurement tools dropdown and draw an arrow
3. Leave the text field empty and click **Save** → the arrow stays (before this fix it disappeared)
4. Draw another arrow, type a label, Save → labeled arrow works as before
5. Double-click that arrow, clear the text, Save → label clears but the arrow remains

Verified all three flows in Chromium via Playwright against the local dev server; annotation state inspected through `cornerstoneTools.annotation.state` before/after each save.

### Screenshots

##### 6060-before-arrow-deleted-on-empty-save
<img width="2400" height="2318" alt="6060-before-arrow-deleted-on-empty-save" src="https://github.com/user-attachments/assets/ae214e46-6c69-4bf7-a2bb-0b139e2a1116" />

##### 6060-after-arrow-kept-on-empty-save
<img width="2400" height="2318" alt="6060-after-arrow-kept-on-empty-save" src="https://github.com/user-attachments/assets/28e2e194-1a21-4748-af1e-3be54254fb62" />


### Checklist

#### PR

- [x] My Pull Request title is descriptive, accurate and follows the
      semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
      etc.)

#### Public Documentation Updates

- [x] The documentation page has been updated as necessary. (no doc changes needed)

#### Tested Environment

- [x] "OS: macOS 25.5.0
- [x] "Node version: 24.x
- [x] "Browser: Chromium (Playwright)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented empty labels from being saved when creating new arrow annotations.
  * Preserved existing behavior when editing annotations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->