### PR TITLE
fix(ui): keep hex input available in the segment color picker

### DIFF
--- a/extensions/default/src/utils/colorPickerDialog.tsx
+++ b/extensions/default/src/utils/colorPickerDialog.tsx
@@ -5,10 +5,15 @@ import { FooterAction } from '@ohif/ui-next';
 import './colorPickerDialog.css';
 
 function ColorPickerDialog({ value, hide, onSave }) {
-  const [color, setColor] = useState(value);
+  // ChromePicker hides its hex input (and blocks toggling back to it)
+  // whenever the color's alpha is not exactly 1, so keep alpha out of the
+  // picker entirely and return the caller's alpha untouched on save.
+  const { a: alpha, ...rgbValue } = value ?? {};
+  const [color, setColor] = useState(rgbValue);
 
   const handleChange = color => {
-    setColor(color.rgb);
+    const { a: _a, ...rgb } = color.rgb;
+    setColor(rgb);
   };
 
   return (
@@ -16,6 +21,7 @@ function ColorPickerDialog({ value, hide, onSave }) {
       <ChromePicker
         color={color}
         onChange={handleChange}
+        disableAlpha={true}
         presetColors={[]}
         width={300}
       />
@@ -31,7 +37,7 @@ function ColorPickerDialog({ value, hide, onSave }) {
             dataCY="color-picker-save-btn"
             onClick={() => {
               hide();
-              onSave(color);
+              onSave({ ...color, a: alpha ?? 1 });
             }}
           >
             Save


### PR DESCRIPTION
### Context

Fixes #6150

The Segment Color dialog greets you with a hex input the first time you open it — but it doesn't take much to lose it. Touch the opacity slider and the editor silently switches to RGBA fields with no way to toggle back to hex. Save in that state and the hex input is gone for good: every time you reopen the dialog for that segment you only get RGBA, so there's no way to paste in a hex color code anymore.

### Changes & Results

**Why this happens:** the dialog uses `ChromePicker` from react-color, and ChromePicker has a quirk: whenever the current color's alpha is anything other than exactly 1, it hides the hex input and refuses to toggle back to it (the internal view is forced from `hex` to `rgb`, and the toggle only re-enables hex at alpha === 1). OHIF round-trips the segment's alpha through the dialog, so once alpha dips below 1 — by touching the slider, or because a stored color already had alpha < 255 — the hex view is locked out permanently.

**The fix** (in `extensions/default/src/utils/colorPickerDialog.tsx`): keep alpha out of the picker entirely. The dialog strips the `a` channel before handing the color to ChromePicker, passes `disableAlpha` so the redundant opacity slider disappears, and returns the caller's original alpha untouched on save. Segment opacity already has a proper home — the segmentation panel's fill/outline opacity settings — so nothing is lost, and existing segments whose alpha was already "corrupted" by this bug heal on their next color save.

```tsx
// ChromePicker hides its hex input (and blocks toggling back to it)
// whenever the color's alpha is not exactly 1, so keep alpha out of the
// picker entirely and return the caller's alpha untouched on save.
const { a: alpha, ...rgbValue } = value ?? {};
...
<ChromePicker color={color} disableAlpha={true} ... />
...
onSave({ ...color, a: alpha ?? 1 });
```

**Before** (alpha touched → RGBA-only, persists after Save) / **After** (hex always available, view toggle cycles hex → rgb → hsl → hex):
<!-- screenshots: 6150-before-rgba-after-alpha.png, 6150-before-save-reopen-no-hex.png / 6150-after-first-open.png, 6150-after-save-reopen-hex-still-visible.png -->

### Testing

1. Open a study in Segmentation mode and add a segmentation
2. Segment row → "…" menu → **Change Color**: hex input shows
3. Pick a color anywhere in the editor, **Save**, reopen: hex input still shows (before this fix, adjusting opacity switched the editor to RGBA-only and saving made that permanent)
4. The up/down toggle next to the fields cycles hex → rgb → hsl → hex

Verified in Chromium via Playwright against the local dev server; reproduced the lockout on unpatched code and confirmed input fields before/after each step.

### Screenshots  

##### 6150-before-save-reopen-no-hex
<img width="3308" height="2318" alt="6150-before-save-reopen-no-hex" src="https://github.com/user-attachments/assets/a1558ac7-e4d3-4c5f-a266-db4ce98153cc" />

##### 6150-before-rgba-locked
<img width="3308" height="2318" alt="6150-before-rgba-locked" src="https://github.com/user-attachments/assets/dc7f72cb-406e-477a-9219-ee9505eb67bd" />

##### 6150-before-rgba-after-alpha
<img width="3308" height="2318" alt="6150-before-rgba-after-alpha" src="https://github.com/user-attachments/assets/61cde105-9d4d-4571-a3cb-40ef7c6859c9" />

##### 6150-after-save-reopen-hex-still-visible
<img width="3308" height="2318" alt="6150-after-save-reopen-hex-still-visible" src="https://github.com/user-attachments/assets/cda1f278-4adb-4635-a564-611b6f1495e9" />

##### 6150-after-first-open
<img width="3308" height="2318" alt="6150-after-first-open" src="https://github.com/user-attachments/assets/eee05b30-2620-44bb-b968-d322ea7481a2" />


### Checklist

#### PR

- [x] My Pull Request title is descriptive, accurate and follows the
      semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
      etc.)

#### Public Documentation Updates

- [x] The documentation page has been updated as necessary. (no doc changes needed)

#### Tested Environment

- [x] "OS: macOS 25.5.0
- [x] "Node version: 24.x
- [x] "Browser: Chromium (Playwright)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the color picker to use RGB colors only, keeping transparency controls out of the picker.
  * Preserved the original transparency value when saving color changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->