### PR TITLE
feat(measurement): implement Change Color for measurements

### DIFF
--- a/extensions/cornerstone/src/commandsModule.ts
+++ b/extensions/cornerstone/src/commandsModule.ts
@@ -118,6 +118,28 @@ const segmentAI = new ONNXSegmentationController({
 });
 let segmentAIEnabled = false;
 
+/**
+ * Converts a CSS color (hex or rgb/rgba string) to the { r, g, b, a }
+ * object shape the color picker dialog expects.
+ */
+function _cssColorToRgba(cssColor: string): { r: number; g: number; b: number; a: number } {
+  const rgbMatch = cssColor.match(/rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*(?:,\s*([\d.]+)\s*)?\)/);
+  if (rgbMatch) {
+    return {
+      r: Number(rgbMatch[1]),
+      g: Number(rgbMatch[2]),
+      b: Number(rgbMatch[3]),
+      a: rgbMatch[4] !== undefined ? Number(rgbMatch[4]) : 1,
+    };
+  }
+  const hexMatch = cssColor.match(/^#?([0-9a-f]{6})$/i);
+  if (hexMatch) {
+    const hex = parseInt(hexMatch[1], 16);
+    return { r: (hex >> 16) & 255, g: (hex >> 8) & 255, b: hex & 255, a: 1 };
+  }
+  return { r: 255, g: 255, b: 0, a: 1 };
+}
+
 function commandsModule({
   servicesManager,
   commandsManager,
@@ -782,6 +804,48 @@ function commandsModule({
         }
       }
       measurementService.update(updatedMeasurement.uid, updatedMeasurement, true);
+    },
+
+    /**
+     * Opens a color picker for the measurement and applies the chosen color
+     * to the annotation (and its text box) via per-annotation styles.
+     */
+    changeMeasurementColor: ({ uid }) => {
+      const measurement = measurementService.getMeasurement(uid);
+      if (!measurement) {
+        console.warn('No measurement found to change color', uid);
+        return;
+      }
+
+      const currentColor =
+        annotation.config.style.getStyleProperty('color', {
+          annotationUID: uid,
+          toolName: measurement.toolName,
+        }) || 'rgb(255, 255, 0)';
+
+      uiDialogService.show({
+        content: colorPickerDialog,
+        title: i18n.t('Tools:Measurement Color'),
+        contentProps: {
+          value: _cssColorToRgba(currentColor),
+          onSave: newRgbaColor => {
+            const cssColor = `rgb(${newRgbaColor.r}, ${newRgbaColor.g}, ${newRgbaColor.b})`;
+            actions.updateMeasurement({
+              uid,
+              style: {
+                color: cssColor,
+                colorHighlighted: cssColor,
+                colorSelected: cssColor,
+                colorLocked: cssColor,
+                textBoxColor: cssColor,
+                textBoxColorHighlighted: cssColor,
+                textBoxColorSelected: cssColor,
+                textBoxColorLocked: cssColor,
+              },
+            });
+          },
+        },
+      });
     },
 
     /**
@@ -2454,6 +2518,9 @@ function commandsModule({
     },
     updateMeasurement: {
       commandFn: actions.updateMeasurement,
+    },
+    changeMeasurementColor: {
+      commandFn: actions.changeMeasurementColor,
     },
     jumpToMeasurement: actions.jumpToMeasurement,
     removeMeasurement: {


### PR DESCRIPTION
### Context

Fixes #6059

Every measurement row in the panel has a "…" menu with a **Change Color** option — but clicking it does absolutely nothing. No dialog, no error, nothing. As the issue notes, it wasn't even clear whether the feature was ever implemented. It turns out: it wasn't.

### Changes & Results

**Why this happens:** the ui-next `MeasurementTable` wires its Change Color menu item to run a command called `changeMeasurementColor` — but no extension ever registered a command by that name, so the commands manager silently drops it.

**The change:** implement `changeMeasurementColor` in the cornerstone extension's commands module, reusing pieces that already exist:

- The shared **color picker dialog** (the same one the segmentation panel uses for segment colors), seeded with the measurement's current effective color read from cornerstone's style hierarchy (`annotation.config.style.getStyleProperty`)
- The existing **`updateMeasurement`** action, which already knows how to apply per-annotation styles (`setAnnotationStyles`) and trigger a viewport re-render

On save, the chosen color is applied to the annotation line and its text box across all interaction states (default / highlighted / selected / locked), so the measurement keeps its color when hovered or selected.

**Before** (Change Color → nothing) / **After** (color picker opens; measurement and label re-render in the chosen color immediately):
<!-- screenshots: 6059-before-nothing-happens.png / 6059-after-dialog-open.png, 6059-after-annotation-recolored.png -->

### Testing

1. Open a study in the basic viewer and draw a measurement (e.g. Length)
2. In the measurements panel, open the row's "…" menu → **Change Color**
3. A color picker opens showing the measurement's current color; pick a new color and **Save**
4. The measurement and its text label recolor immediately and stay recolored across hover/selection

Verified in Chromium via Playwright: dialog opens, per-annotation styles are set (checked via `annotation.config.style.getAnnotationToolStyles`), and the viewport renders the new color. Also confirmed the pre-fix behavior (menu click is a silent no-op).

### Screenshots  

##### 6059-before-nothing-happens
<img width="3308" height="2430" alt="6059-before-nothing-happens" src="https://github.com/user-attachments/assets/6aab840d-f8f8-4af9-b849-045f907cc194" />

##### 6059-after-dialog-open
<img width="3308" height="2430" alt="6059-after-dialog-open" src="https://github.com/user-attachments/assets/ce306983-e597-4c88-8be7-91bc5d7ce619" />

##### 6059-after-annotation-recolored
<img width="3308" height="2430" alt="6059-after-annotation-recolored" src="https://github.com/user-attachments/assets/a1133ca2-1285-41ac-92b3-354432c80795" />


### Checklist

#### PR

- [x] My Pull Request title is descriptive, accurate and follows the
      semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
      etc.)

#### Public Documentation Updates

- [x] The documentation page has been updated as necessary. (no doc changes needed)

#### Tested Environment

- [x] "OS: macOS 25.5.0
- [x] "Node version: 24.x
- [x] "Browser: Chromium (Playwright)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to change the color of individual measurements.
  * A color picker now opens with the measurement’s current color and applies the selected color across the measurement and its text box.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->