### PR TITLE
fix(cornerstone): guard against non-finite slice counts crashing the viewer

### DIFF
--- a/extensions/cornerstone/src/Viewport/Overlays/ViewportSliceProgressScrollbar/hooks.ts
+++ b/extensions/cornerstone/src/Viewport/Overlays/ViewportSliceProgressScrollbar/hooks.ts
@@ -146,7 +146,9 @@ export function useViewportSliceSync({
       if (nextImageIndex == null) {
         return;
       }
-      const nextNumberOfSlices = viewport.getNumberOfSlices();
+      // Same guarded count as the initial seed — a raw getNumberOfSlices()
+      // can return a non-finite value for degenerate volumes.
+      const nextNumberOfSlices = getViewportSliceCount(viewportData, viewport);
 
       pushSliceData(nextImageIndex, nextNumberOfSlices);
     };

--- a/extensions/cornerstone/src/utils/viewportDataShape.ts
+++ b/extensions/cornerstone/src/utils/viewportDataShape.ts
@@ -78,8 +78,12 @@ export function getViewportSliceCount(
   viewport: { getNumberOfSlices: () => number }
 ): number {
   const firstData = getPrimaryViewportDatum(viewportData);
-  return (
+  const count =
     (!isVolumeViewportData(viewportData) && firstData?.imageIds?.length) ||
-    viewport.getNumberOfSlices()
-  );
+    viewport.getNumberOfSlices();
+  // getNumberOfSlices() returns Infinity when the volume's spacing in the
+  // camera's normal direction degenerates to 0 (seen with some SEG-derived
+  // volumes in multi-viewport layouts); a non-finite count is unusable for
+  // slice-indexed UI and crashes typed-array allocation downstream.
+  return Number.isFinite(count) && count > 0 ? count : 0;
 }

--- a/platform/ui-next/src/components/SmartScrollbar/useByteArray.ts
+++ b/platform/ui-next/src/components/SmartScrollbar/useByteArray.ts
@@ -22,6 +22,9 @@ export interface ByteArrayHandle {
  *                          for immediate re-renders on every write.
  */
 export function useByteArray(size: number, batchIntervalMs = 0): ByteArrayHandle {
+  // A non-finite or negative size (e.g. a degenerate volume reporting
+  // Infinity slices) must not crash the Uint8Array allocation.
+  size = Number.isFinite(size) && size > 0 ? Math.floor(size) : 0;
   const bytesRef = useRef(new Uint8Array(size));
   const countRef = useRef(0);
   const [version, setVersion] = useState(0);


### PR DESCRIPTION
### Context

Fixes #6174

Open the segmentation mode with the study from the issue (TCIA `…285242291560760827564488897577`), load or create a segmentation while the default 2×2 layout is active, and the whole viewer goes blank with:

```
RangeError: Invalid typed array length: Infinity
    at new Uint8Array (<anonymous>)
    ...
    at isFullMode
```

The `isFullMode` frame in the minified stack pointed at the slice progress scrollbar, and that's exactly where it is — this turns out to be an OHIF-side crash, not a cornerstone3D one.

### Changes & Results

**Why this happens:** cornerstone's `viewport.getNumberOfSlices()` computes the count as `(max − min) / spacingInNormalDirection + 1`. For some SEG-derived volumes in the segmentation mode's multi-viewport layouts, the spacing in the camera's normal direction comes back as **0**, so the division yields **Infinity**. The `ViewportSliceProgressScrollbar` feeds that number straight into `new Uint8Array(size)` (via the `useByteArray` hook that tracks per-slice loaded/viewed state), which throws, and the route error boundary blanks the entire app.

**The fix** — guard at three layers so no path can feed a non-finite count into an allocation:

1. `getViewportSliceCount` (extensions/cornerstone/src/utils/viewportDataShape.ts) clamps non-finite or negative counts to 0
2. The scrollbar's slice-event handler (`hooks.ts`) now routes through that same guarded helper instead of calling `getNumberOfSlices()` raw
3. `useByteArray` (platform/ui-next) defensively sanitizes its `size` so no other consumer can crash the `Uint8Array` allocation either

With the guard, the degenerate viewport simply renders without a slice scrollbar instead of taking down the viewer. The underlying "why is the spacing 0 for this volume" question belongs upstream in cornerstone3D — `getNumberOfSlices()` arguably should never return Infinity — and I'm happy to file that issue with the captured details as a follow-up.

**Before** (blank app after the RangeError) / **After** (SEG loads in the 2×2 layout, segments hydrate normally):
<!-- screenshots: 6174-before-crash-blank-app.png / 6174-after-seg-loaded-no-crash.png -->

### Testing

1. `pnpm dev` → open `/segmentation?StudyInstanceUIDs=1.3.6.1.4.1.14519.5.2.1.3098.5025.285242291560760827564488897577`
2. Keep the default multi-viewport layout
3. Load the "SEG AIMI lung and FDG tumor AI segmentation" series (or click **Add segmentation**)
4. Before: RangeError + blank viewer. After: segmentation loads, both segments ("Lung", "FDG-Avid Tumor") appear in the panel, all viewports stay interactive with zero page errors

Reproduced the crash on unpatched master and verified the fix in Chromium via Playwright (page-error listener attached — no errors after the fix).

### Screenshots

##### 6174-before-crash-blank-app
<img width="1200" height="1159" alt="6174-before-crash-blank-app" src="https://github.com/user-attachments/assets/28d35943-2be9-4d56-8373-30334e4c2e7d" />

##### 6174-after-no-crash
<img width="3308" height="2430" alt="6174-after-no-crash" src="https://github.com/user-attachments/assets/00acf4fc-f117-42ca-b853-d9c9126d453e" />

##### 6174-after-seg-loaded-no-crash
<img width="3308" height="2430" alt="6174-after-seg-loaded-no-crash" src="https://github.com/user-attachments/assets/8515eada-205c-46a6-b49a-ee2beaaffc7f" />



### Checklist

#### PR

- [x] My Pull Request title is descriptive, accurate and follows the
      semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
      etc.)

#### Public Documentation Updates

- [x] The documentation page has been updated as necessary. (no doc changes needed)

#### Tested Environment

- [x] "OS: macOS 25.5.0
- [x] "Node version: 24.x
- [x] "Browser: Chromium (Playwright)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scrollbar stability for edge-case and degenerate volumes.
  * Prevented invalid slice counts from causing viewport synchronization issues.
  * Fixed potential crashes caused by invalid scrollbar sizes, including infinite values.
  * Ensured slice and scrollbar calculations remain consistent when data is unavailable or invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->