### PR TITLE
fix(Toolbar): honor hideWhenDisabled on array evaluators

### DIFF
--- a/platform/core/src/services/ToolBarService/ToolbarService.ts
+++ b/platform/core/src/services/ToolBarService/ToolbarService.ts
@@ -718,7 +718,20 @@ export default class ToolbarService extends PubSubService {
         return evaluateFunction;
       });
 
-      const evaluateProps = props.evaluate;
+      // Object entries in the array carry per-evaluator options such as
+      // `hideWhenDisabled`. Merge those options into a flat object: assigning the
+      // array itself left `evaluateProps.hideWhenDisabled` permanently undefined,
+      // so the flag was silently ignored for every multi-evaluator button.
+      const evaluateProps = evaluate.reduce((acc, evaluator) => {
+        if (typeof evaluator !== 'object' || evaluator === null) {
+          return acc;
+        }
+        // `name` selects which evaluator to run; it is not an option, and it has no
+        // single value once several evaluators are merged.
+        const { name: _name, ...options } = evaluator;
+        return { ...acc, ...options };
+      }, {});
+
       props.evaluate = args => {
         const results = evaluators.map(evaluator => evaluator(args)).filter(Boolean);
 

--- a/platform/core/src/services/ToolBarService/__tests__/ToolbarService.evaluateProps.test.ts
+++ b/platform/core/src/services/ToolBarService/__tests__/ToolbarService.evaluateProps.test.ts
@@ -88,3 +88,89 @@ describe('ToolbarService.handleEvaluate — evaluateProps', () => {
     expect(props.evaluateProps.hideWhenDisabled).toBe(true);
   });
 });
+
+/**
+ * The suite above pins how `evaluateProps` is derived. This one covers the effect the
+ * issue actually reports: a button with `hideWhenDisabled` on an array evaluator must
+ * disappear from the toolbar once it evaluates as disabled.
+ */
+describe('ToolbarService.refreshToolbarState — hideWhenDisabled visibility', () => {
+  const US_ONLY_EVALUATORS = {
+    'evaluate.cornerstoneTool': () => ({ disabled: false }),
+    // Stands in for evaluate.modality.supported: disabled unless the study is US.
+    'evaluate.modality.supported': ({ modality, supportedModalities }) =>
+      supportedModalities?.includes(modality)
+        ? undefined
+        : { disabled: true, disabledText: 'Not supported for this modality' },
+  };
+
+  const usDirectionalButton = (extra = {}) => ({
+    id: 'UltrasoundDirectionalTool',
+    props: {
+      evaluate: [
+        'evaluate.cornerstoneTool',
+        {
+          name: 'evaluate.modality.supported',
+          supportedModalities: ['US'],
+          hideWhenDisabled: true,
+        },
+      ],
+      ...extra,
+    },
+  });
+
+  const build = button => {
+    const service = new ToolbarService(undefined as never, undefined as never, undefined as never);
+    // @ts-expect-error private registry, so the test needs no extension manager
+    service._evaluateFunction = US_ONLY_EVALUATORS;
+    service.register([button] as never);
+    return service;
+  };
+
+  it('hides the button on a non-US study', () => {
+    const service = build(usDirectionalButton());
+
+    service.refreshToolbarState({ modality: 'CT' });
+
+    const props = service.getButtonProps('UltrasoundDirectionalTool');
+    expect(props.disabled).toBe(true);
+    expect(props.visible).toBe(false);
+  });
+
+  it('shows the button on a US study', () => {
+    const service = build(usDirectionalButton());
+
+    service.refreshToolbarState({ modality: 'US' });
+
+    const props = service.getButtonProps('UltrasoundDirectionalTool');
+    expect(props.disabled).toBe(false);
+    expect(props.visible).toBe(true);
+  });
+
+  it('leaves a disabled button visible when the flag is absent', () => {
+    const service = build({
+      id: 'UltrasoundDirectionalTool',
+      props: {
+        evaluate: [
+          'evaluate.cornerstoneTool',
+          { name: 'evaluate.modality.supported', supportedModalities: ['US'] },
+        ],
+      },
+    });
+
+    service.refreshToolbarState({ modality: 'CT' });
+
+    const props = service.getButtonProps('UltrasoundDirectionalTool');
+    expect(props.disabled).toBe(true);
+    expect(props.visible).toBe(true);
+  });
+
+  it('still honours the flag when set at the props level', () => {
+    // The pre-existing escape hatch must keep working.
+    const service = build(usDirectionalButton({ hideWhenDisabled: true }));
+
+    service.refreshToolbarState({ modality: 'CT' });
+
+    expect(service.getButtonProps('UltrasoundDirectionalTool').visible).toBe(false);
+  });
+});

--- a/platform/core/src/services/ToolBarService/__tests__/ToolbarService.evaluateProps.test.ts
+++ b/platform/core/src/services/ToolBarService/__tests__/ToolbarService.evaluateProps.test.ts
@@ -1,0 +1,90 @@
+import ToolbarService from '../ToolbarService';
+
+/**
+ * `hideWhenDisabled` is read off `props.evaluateProps` in refreshToolbarState.
+ * When `evaluate` is an array, `evaluateProps` used to be the array itself, so
+ * `evaluateProps.hideWhenDisabled` was always undefined and the flag was ignored
+ * for every multi-evaluator button (OHIF#5587).
+ */
+describe('ToolbarService.handleEvaluate — evaluateProps', () => {
+  const createService = (evaluators: Record<string, (args) => unknown>) => {
+    // handleEvaluate only touches the evaluator registry, so the managers can be
+    // omitted; _getButtonUITypes is reached only when `options` is a string.
+    const service = new ToolbarService(undefined as never, undefined as never, undefined as never);
+    // @ts-expect-error reaching into the private registry keeps the test free of
+    // an extension manager.
+    service._evaluateFunction = evaluators;
+    return service;
+  };
+
+  it('merges evaluator options so hideWhenDisabled survives an array', () => {
+    const service = createService({
+      'evaluate.cornerstoneTool': () => ({ disabled: false }),
+      'evaluate.modality.supported': () => ({ disabled: true }),
+    });
+
+    const props = {
+      evaluate: [
+        'evaluate.cornerstoneTool',
+        {
+          name: 'evaluate.modality.supported',
+          supportedModalities: ['US'],
+          hideWhenDisabled: true,
+        },
+      ],
+    };
+
+    service.handleEvaluate(props);
+
+    expect(props.evaluateProps.hideWhenDisabled).toBe(true);
+    expect(props.evaluateProps.supportedModalities).toEqual(['US']);
+  });
+
+  it('drops name, which identifies the evaluator rather than configuring it', () => {
+    const service = createService({ a: () => ({}), b: () => ({}) });
+    const props = {
+      evaluate: [
+        { name: 'a', hideWhenDisabled: true },
+        { name: 'b', disabledText: 'nope' },
+      ],
+    };
+
+    service.handleEvaluate(props);
+
+    expect(props.evaluateProps).toEqual({ hideWhenDisabled: true, disabledText: 'nope' });
+    expect(props.evaluateProps).not.toHaveProperty('name');
+  });
+
+  it('yields an empty object when every entry is a bare evaluator name', () => {
+    const service = createService({ a: () => ({}), b: () => ({}) });
+    const props = { evaluate: ['a', 'b'] };
+
+    service.handleEvaluate(props);
+
+    expect(props.evaluateProps).toEqual({});
+    expect(props.evaluateProps.hideWhenDisabled).toBeUndefined();
+  });
+
+  it('still runs every evaluator and disables when any one disables', () => {
+    const service = createService({
+      a: () => ({ disabled: false, className: 'from-a' }),
+      b: () => ({ disabled: true }),
+    });
+    const props = { evaluate: ['a', { name: 'b', hideWhenDisabled: true }] };
+
+    service.handleEvaluate(props);
+    const result = props.evaluate({});
+
+    expect(result.disabled).toBe(true);
+    expect(result.className).toBe('from-a');
+  });
+
+  it('keeps working for the single-object form, which was never broken', () => {
+    const service = createService({ a: () => ({ disabled: true }) });
+    const props = { evaluate: { name: 'a', hideWhenDisabled: true } };
+
+    service.handleEvaluate(props);
+
+    expect(props.evaluateProps.hideWhenDisabled).toBe(true);
+  });
+});


### PR DESCRIPTION
### Context

Fixes #5587.

`refreshToolbarState` reads the flag off `props.evaluateProps`:

```ts
const evaluateProps = props.evaluateProps;
const hideWhenDisabled = evaluateProps?.hideWhenDisabled || props.hideWhenDisabled;
```

But in `handleEvaluate`, the **array** branch assigned the array itself:

```ts
const evaluateProps = props.evaluate;   // <- this is the array
props.evaluate = args => { /* ... */ };
props.evaluateProps = evaluateProps;
```

An array has no `hideWhenDisabled` property, so that lookup was always `undefined` and the flag was silently ignored — for **every** button whose `evaluate` is an array, not just `UltrasoundDirectionalTool`. The reporter suspected the problem was more general, and it is.

The single-object branch a few lines below assigns an object:

```ts
const { name, ...options } = evaluate;
const evaluateProps = props.evaluate;   // <- an object, so the lookup works
```

which is why that form works and the bug looked tool-specific.

### Changes & Results

The array branch now merges the option objects into a flat object. `name` is dropped: it selects which evaluator to run rather than configuring it, and has no single value once several evaluators are merged.

`props.evaluateProps` has exactly one consumer in the codebase (the `hideWhenDisabled` lookup above), so reshaping it from array to object affects nothing else.

**Before / after** for the exact config in the issue:

```ts
evaluate: [
  'evaluate.cornerstoneTool',
  { name: 'evaluate.modality.supported', supportedModalities: ['US'], hideWhenDisabled: true },
]
```

| | `evaluateProps` | `hideWhenDisabled` | tool on a non-US study |
|---|---|---|---|
| before | the array | `undefined` | visible in More Tools |
| after | `{ supportedModalities: ['US'], hideWhenDisabled: true }` | `true` | hidden |

### Testing

Added `platform/core/src/services/ToolBarService/__tests__/ToolbarService.evaluateProps.test.ts` (5 cases).

```
cd platform/core && npx jest src/services/ToolBarService
# Test Suites: 1 passed, Tests: 5 passed
```

Reverting only the source change and re-running gives **3 failed, 2 passed** — the three array-form assertions fail, while the single-object case and the evaluator-merging behaviour still pass. So the test pins the actual regression rather than restating the implementation.

Full `platform/core` suite: **357 passed, 39/40 suites**. The one failing suite is `src/utils/absoluteUrl.test.js` with `SecurityError: Cannot initialize local storage without a --localstorage-file path` — reproduced on an unmodified checkout, so it is pre-existing and unrelated (a Node 25 vs `jest-environment-node` artifact; this repo declares `node >=24`).

To verify in the app, apply the `hideWhenDisabled: true` snippet from the issue to `UltrasoundDirectionalTool` in a mode's `toolbarButtons.ts`, load a non-US study, and confirm the tool no longer appears in the More Tools menu.

### Checklist

#### PR

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

<!-- No public API changed: `hideWhenDisabled` is already documented behaviour;
this makes it work in the array form. Happy to add a docs note if you would like
the array-vs-object distinction called out explicitly. -->

#### Tested Environment

- [x] OS: macOS 15 (Darwin 25.4.0, Apple Silicon)
- [x] Node version: 25.2.0, pnpm 11.5.2
- [x] Browser: not required — unit-tested at the service layer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed toolbar buttons with multiple evaluators so evaluator configuration options (e.g., `hideWhenDisabled`) are correctly carried through.
  - Prevented evaluator names from being treated as persisted configuration properties.
  - Improved disabled-state handling so a disabled result from any evaluator updates the toolbar state as expected.
  - Maintained existing behavior for single-evaluator configurations.

- **Tests**
  - Added coverage for multi-evaluator and single-evaluator toolbar behavior, including visibility changes driven by evaluation results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->