### PR TITLE
fix(tmtv): stop Rectangle ROI Threshold erasing other segments

### DIFF
--- a/extensions/tmtv/jest.config.js
+++ b/extensions/tmtv/jest.config.js
@@ -1,0 +1,9 @@
+const base = require('../../jest.config.base.js');
+
+module.exports = {
+  ...base,
+  moduleNameMapper: {
+    ...base.moduleNameMapper,
+    '@ohif/(.*)': '<rootDir>/../../platform/$1/src',
+  },
+};

--- a/extensions/tmtv/jest.config.js
+++ b/extensions/tmtv/jest.config.js
@@ -4,6 +4,9 @@ module.exports = {
   ...base,
   moduleNameMapper: {
     ...base.moduleNameMapper,
+    // Extension packages live under extensions/, so this must be matched before the
+    // generic @ohif/* rule below, which resolves into platform/.
+    '^@ohif/extension-(.*)$': '<rootDir>/../../extensions/$1/src',
     '@ohif/(.*)': '<rootDir>/../../platform/$1/src',
   },
 };

--- a/extensions/tmtv/src/commandsModule.test.ts
+++ b/extensions/tmtv/src/commandsModule.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Command-level cover for #5476.
+ *
+ * The helper tests alone would still pass if this command cleared the wrong volume or
+ * kept sending `overwrite: true`, so assert the wiring: which segment gets cleared,
+ * what reaches cornerstone, and that a throw does not leave the segment erased.
+ */
+
+jest.mock('@ohif/core', () => ({
+  __esModule: true,
+  default: {},
+  classes: { MetadataProvider: { get: jest.fn() } },
+  utils: { formatPN: (v: string) => v },
+}));
+
+jest.mock('@ohif/i18n', () => ({ __esModule: true, default: { t: (k: string) => k } }));
+
+jest.mock('@ohif/extension-cornerstone', () => ({
+  getViewportFocalPoint: jest.fn(),
+}));
+
+jest.mock('@cornerstonejs/core', () => ({
+  cache: {
+    getVolume: jest.fn(),
+    getVolumeContainingImageId: jest.fn(),
+  },
+  getEnabledElement: jest.fn(),
+}));
+
+jest.mock('@cornerstonejs/tools', () => ({
+  Enums: { SegmentationRepresentations: { Labelmap: 'Labelmap' } },
+  segmentation: { state: { getSegmentation: jest.fn() } },
+  annotation: { selection: { getAnnotationsSelectedByToolName: jest.fn() } },
+  utilities: { segmentation: { rectangleROIThresholdVolumeByRange: jest.fn() } },
+}));
+
+jest.mock('./utils/getThresholdValue', () => ({
+  __esModule: true,
+  default: () => ({ ptLower: 1, ptUpper: 2, ctLower: 3, ctUpper: 4 }),
+}));
+
+jest.mock('./utils/createAndDownloadTMTVReport', () => ({ __esModule: true, default: jest.fn() }));
+jest.mock('./utils/dicomRTAnnotationExport/RTStructureSet', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+import * as cs from '@cornerstonejs/core';
+import * as csTools from '@cornerstonejs/tools';
+import commandsModule from './commandsModule';
+
+// jest.mock is hoisted above const declarations, so reach the mocks through the
+// mocked module rather than closing over variables that are not initialised yet.
+const mockRectangleROIThreshold = csTools.utilities.segmentation
+  .rectangleROIThresholdVolumeByRange as unknown as jest.Mock;
+const mockGetAnnotationsSelected = csTools.annotation.selection
+  .getAnnotationsSelectedByToolName as unknown as jest.Mock;
+
+const SEG_VOLUME_ID = 'seg-volume';
+
+/** Labelmap holding segment 1 at indices 0-1 and segment 2 at index 3. */
+const makeLabelmap = () => {
+  const data = [1, 1, 0, 2];
+  return {
+    data,
+    voxelManager: {
+      getScalarDataLength: () => data.length,
+      getAtIndex: (i: number) => data[i],
+      setAtIndex: (i: number, v: number) => {
+        data[i] = v;
+      },
+    },
+  };
+};
+
+function setup() {
+  const labelmap = makeLabelmap();
+
+  (csTools.segmentation.state.getSegmentation as jest.Mock).mockReturnValue({
+    representationData: { Labelmap: { volumeId: SEG_VOLUME_ID } },
+  });
+  (cs.cache.getVolume as jest.Mock).mockReturnValue(labelmap);
+  (cs.cache.getVolumeContainingImageId as jest.Mock).mockReturnValue({ volume: { id: 'v' } });
+  mockGetAnnotationsSelected.mockImplementation(toolName =>
+    toolName === 'RectangleROIThreshold' ? ['annotation-1'] : []
+  );
+
+  const displaySet = { displaySetInstanceUID: 'ds', imageIds: ['image-1'] };
+  const servicesManager = {
+    services: {
+      viewportGridService: { getState: () => ({ activeViewportId: 'v1' }) },
+      uiNotificationService: { show: jest.fn(), error: jest.fn() },
+      displaySetService: { getDisplaySetByUID: () => displaySet },
+      hangingProtocolService: {
+        getMatchDetails: () => ({
+          displaySetMatchDetails: new Map([
+            ['ctDisplaySet', { displaySetInstanceUID: 'ds' }],
+            ['ptDisplaySet', { displaySetInstanceUID: 'ds' }],
+          ]),
+        }),
+      },
+      toolGroupService: {},
+      cornerstoneViewportService: {},
+      segmentationService: {},
+    },
+  };
+  const extensionManager = {
+    getModuleEntry: () => ({ exports: { getEnabledElement: jest.fn() } }),
+    getDataSources: () => [{ getImageIdsForDisplaySet: () => ['image-1'] }],
+  };
+
+  const { actions } = commandsModule({
+    servicesManager,
+    commandsManager: { run: jest.fn() },
+    extensionManager,
+  } as never) as never as { actions: Record<string, (args) => unknown> };
+
+  return { actions, labelmap };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockRectangleROIThreshold.mockReturnValue({ modified: jest.fn() });
+});
+
+describe('thresholdSegmentationByRectangleROITool', () => {
+  it('clears only the target segment, leaving other segments in the labelmap', () => {
+    const { actions, labelmap } = setup();
+
+    actions.thresholdSegmentationByRectangleROITool({
+      segmentationId: 'seg',
+      config: {},
+      segmentIndex: 1,
+    });
+
+    // segment 1 cleared, segment 2 at index 3 untouched
+    expect(labelmap.data).toEqual([0, 0, 0, 2]);
+  });
+
+  it('never asks cornerstone to overwrite the whole labelmap', () => {
+    const { actions } = setup();
+
+    actions.thresholdSegmentationByRectangleROITool({
+      segmentationId: 'seg',
+      config: {},
+      segmentIndex: 2,
+    });
+
+    expect(mockRectangleROIThreshold).toHaveBeenCalledTimes(1);
+    const options = mockRectangleROIThreshold.mock.calls[0][3];
+    expect(options).toMatchObject({
+      overwrite: false,
+      segmentIndex: 2,
+      segmentationId: 'seg',
+    });
+  });
+
+  it('defaults to segment 1 when no segmentIndex is supplied', () => {
+    const { actions, labelmap } = setup();
+
+    actions.thresholdSegmentationByRectangleROITool({ segmentationId: 'seg', config: {} });
+
+    expect(mockRectangleROIThreshold.mock.calls[0][3].segmentIndex).toBe(1);
+    expect(labelmap.data).toEqual([0, 0, 0, 2]);
+  });
+
+  it('clears segment 1 when given segment 0, matching where cornerstone writes', () => {
+    const { actions, labelmap } = setup();
+
+    actions.thresholdSegmentationByRectangleROITool({
+      segmentationId: 'seg',
+      config: {},
+      segmentIndex: 0,
+    });
+
+    // cornerstone resolves `0 || 1` to 1, so segment 1 is the one that must be cleared
+    expect(mockRectangleROIThreshold.mock.calls[0][3].segmentIndex).toBe(1);
+    expect(labelmap.data).toEqual([0, 0, 0, 2]);
+  });
+
+  it('restores the segment when the threshold computation throws', () => {
+    const { actions, labelmap } = setup();
+    mockRectangleROIThreshold.mockImplementation(() => {
+      throw new Error('only supports RectangleROIThreshold annotations');
+    });
+
+    expect(() =>
+      actions.thresholdSegmentationByRectangleROITool({
+        segmentationId: 'seg',
+        config: {},
+        segmentIndex: 1,
+      })
+    ).toThrow('only supports RectangleROIThreshold');
+
+    // the user's segment survives a failed run
+    expect(labelmap.data).toEqual([1, 1, 0, 2]);
+  });
+
+  it('reports and returns early when no ROI annotation is selected', () => {
+    mockGetAnnotationsSelected.mockReturnValue([]);
+    const { actions, labelmap } = setup();
+    mockGetAnnotationsSelected.mockReturnValue([]);
+
+    actions.thresholdSegmentationByRectangleROITool({
+      segmentationId: 'seg',
+      config: {},
+      segmentIndex: 1,
+    });
+
+    expect(mockRectangleROIThreshold).not.toHaveBeenCalled();
+    // nothing cleared, because nothing was computed
+    expect(labelmap.data).toEqual([1, 1, 0, 2]);
+  });
+});

--- a/extensions/tmtv/src/commandsModule.ts
+++ b/extensions/tmtv/src/commandsModule.ts
@@ -4,7 +4,10 @@ import * as csTools from '@cornerstonejs/tools';
 import { classes } from '@ohif/core';
 import i18n from '@ohif/i18n';
 import getThresholdValues from './utils/getThresholdValue';
-import clearSegmentFromLabelmap from './utils/clearSegmentFromLabelmap';
+import clearSegmentFromLabelmap, {
+  normalizeSegmentIndex,
+  restoreSegmentToLabelmap,
+} from './utils/clearSegmentFromLabelmap';
 import createAndDownloadTMTVReport from './utils/createAndDownloadTMTVReport';
 
 import dicomRTAnnotationExport from './utils/dicomRTAnnotationExport/RTStructureSet';
@@ -218,18 +221,27 @@ const commandsModule = ({ servicesManager, commandsManager, extensionManager }: 
       // other segment in the segmentation - including ones drawn with the brush or
       // shape tools. Clear only the segment being recomputed, then write additively so
       // re-running the tool stays idempotent without destroying the user's other work.
-      const targetSegmentIndex = segmentIndex ?? 1;
-      clearSegmentFromLabelmap(labelmapVolume.voxelManager, targetSegmentIndex);
+      const targetSegmentIndex = normalizeSegmentIndex(segmentIndex);
+      const { voxelManager } = labelmapVolume;
+      const clearedIndices = clearSegmentFromLabelmap(voxelManager, targetSegmentIndex);
 
-      return csTools.utilities.segmentation.rectangleROIThresholdVolumeByRange(
-        annotationUIDs,
-        labelmapVolume,
-        [
-          { volume: ptVolume, lower: ptLower, upper: ptUpper },
-          { volume: ctVolume, lower: ctLower, upper: ctUpper },
-        ],
-        { overwrite: false, segmentIndex: targetSegmentIndex, segmentationId }
-      );
+      try {
+        return csTools.utilities.segmentation.rectangleROIThresholdVolumeByRange(
+          annotationUIDs,
+          labelmapVolume,
+          [
+            { volume: ptVolume, lower: ptLower, upper: ptUpper },
+            { volume: ctVolume, lower: ctLower, upper: ctUpper },
+          ],
+          { overwrite: false, segmentIndex: targetSegmentIndex, segmentationId }
+        );
+      } catch (error) {
+        // Cornerstone validates the annotation tool names *inside* this call, and
+        // ROI_THRESHOLD_MANUAL_TOOL_IDS includes CircleROIStartEndThreshold, which it
+        // rejects. Without a rollback that throw would leave the segment erased.
+        restoreSegmentToLabelmap(voxelManager, clearedIndices, targetSegmentIndex);
+        throw error;
+      }
     },
     calculateTMTV: async ({ segmentations }) => {
       const segmentationIds = segmentations.map(segmentation => segmentation.segmentationId);

--- a/extensions/tmtv/src/commandsModule.ts
+++ b/extensions/tmtv/src/commandsModule.ts
@@ -4,6 +4,7 @@ import * as csTools from '@cornerstonejs/tools';
 import { classes } from '@ohif/core';
 import i18n from '@ohif/i18n';
 import getThresholdValues from './utils/getThresholdValue';
+import clearSegmentFromLabelmap from './utils/clearSegmentFromLabelmap';
 import createAndDownloadTMTVReport from './utils/createAndDownloadTMTVReport';
 
 import dicomRTAnnotationExport from './utils/dicomRTAnnotationExport/RTStructureSet';
@@ -213,6 +214,13 @@ const commandsModule = ({ servicesManager, commandsManager, extensionManager }: 
       const ptVolume = ptVolumeInfo.volume;
       const ctVolume = ctVolumeInfo.volume;
 
+      // `overwrite: true` zeroes the entire labelmap before writing, which wipes every
+      // other segment in the segmentation - including ones drawn with the brush or
+      // shape tools. Clear only the segment being recomputed, then write additively so
+      // re-running the tool stays idempotent without destroying the user's other work.
+      const targetSegmentIndex = segmentIndex ?? 1;
+      clearSegmentFromLabelmap(labelmapVolume.voxelManager, targetSegmentIndex);
+
       return csTools.utilities.segmentation.rectangleROIThresholdVolumeByRange(
         annotationUIDs,
         labelmapVolume,
@@ -220,7 +228,7 @@ const commandsModule = ({ servicesManager, commandsManager, extensionManager }: 
           { volume: ptVolume, lower: ptLower, upper: ptUpper },
           { volume: ctVolume, lower: ctLower, upper: ctUpper },
         ],
-        { overwrite: true, segmentIndex, segmentationId }
+        { overwrite: false, segmentIndex: targetSegmentIndex, segmentationId }
       );
     },
     calculateTMTV: async ({ segmentations }) => {

--- a/extensions/tmtv/src/utils/clearSegmentFromLabelmap.test.ts
+++ b/extensions/tmtv/src/utils/clearSegmentFromLabelmap.test.ts
@@ -1,4 +1,7 @@
-import clearSegmentFromLabelmap from './clearSegmentFromLabelmap';
+import clearSegmentFromLabelmap, {
+  normalizeSegmentIndex,
+  restoreSegmentToLabelmap,
+} from './clearSegmentFromLabelmap';
 
 /**
  * Regression cover for #5476: the Rectangle ROI Threshold tool used cornerstone's
@@ -23,25 +26,15 @@ describe('clearSegmentFromLabelmap', () => {
 
     const cleared = clearSegmentFromLabelmap(vm, 1);
 
-    expect(cleared).toBe(3);
+    expect(cleared).toEqual([1, 3, 5]);
     expect(vm.data).toEqual([0, 0, 2, 0, 3, 0, 2, 0]);
   });
 
   it('is a no-op when the target segment is absent', () => {
     const vm = fakeVoxelManager([0, 2, 3, 2]);
 
-    expect(clearSegmentFromLabelmap(vm, 1)).toBe(0);
+    expect(clearSegmentFromLabelmap(vm, 1)).toEqual([]);
     expect(vm.data).toEqual([0, 2, 3, 2]);
-  });
-
-  it('leaves the labelmap unchanged when asked for segment 0', () => {
-    // Segment 0 is background, so this writes 0 over 0. It is a caller mistake rather
-    // than a supported operation, but it must not disturb any real segment.
-    const vm = fakeVoxelManager([0, 1, 0, 2]);
-
-    clearSegmentFromLabelmap(vm, 0);
-
-    expect(vm.data).toEqual([0, 1, 0, 2]);
   });
 
   it('is idempotent, so re-running the threshold tool converges', () => {
@@ -50,19 +43,75 @@ describe('clearSegmentFromLabelmap', () => {
     clearSegmentFromLabelmap(vm, 1);
     const second = clearSegmentFromLabelmap(vm, 1);
 
-    expect(second).toBe(0);
+    expect(second).toEqual([]);
     expect(vm.data).toEqual([0, 0, 2]);
   });
 
   it('handles an empty labelmap', () => {
     const vm = fakeVoxelManager([]);
-    expect(clearSegmentFromLabelmap(vm, 1)).toBe(0);
+    expect(clearSegmentFromLabelmap(vm, 1)).toEqual([]);
   });
 
   it('clears every voxel when the labelmap holds only the target segment', () => {
     const vm = fakeVoxelManager([4, 4, 4]);
 
-    expect(clearSegmentFromLabelmap(vm, 4)).toBe(3);
+    expect(clearSegmentFromLabelmap(vm, 4)).toEqual([0, 1, 2]);
     expect(vm.data).toEqual([0, 0, 0]);
+  });
+});
+
+describe('normalizeSegmentIndex', () => {
+  it('keeps a valid positive integer', () => {
+    expect(normalizeSegmentIndex(3)).toBe(3);
+  });
+
+  it.each([
+    ['zero (background)', 0],
+    ['negative', -2],
+    ['non-integer', 1.5],
+    ['undefined', undefined],
+    ['null', null],
+    ['NaN', NaN],
+    ['a string', '2'],
+  ])('falls back to 1 for %s', (_label, input) => {
+    expect(normalizeSegmentIndex(input)).toBe(1);
+  });
+
+  it('matches how cornerstone resolves the write target', () => {
+    // thresholdVolumeByRange writes `options.segmentIndex || 1`. If we cleared a
+    // different index than cornerstone writes to, the clear would miss and the write
+    // would append to an uncleared segment.
+    for (const input of [0, undefined, null, NaN]) {
+      const cornerstoneTarget = (input as number) || 1;
+      expect(normalizeSegmentIndex(input)).toBe(cornerstoneTarget);
+    }
+  });
+});
+
+describe('restoreSegmentToLabelmap', () => {
+  it('puts a cleared segment back', () => {
+    const vm = fakeVoxelManager([0, 1, 2, 1]);
+    const cleared = clearSegmentFromLabelmap(vm, 1);
+    expect(vm.data).toEqual([0, 0, 2, 0]);
+
+    restoreSegmentToLabelmap(vm, cleared, 1);
+
+    expect(vm.data).toEqual([0, 1, 2, 1]);
+  });
+
+  it('only touches the indices it was given', () => {
+    // Voxels a failed operation already wrote elsewhere must survive the rollback.
+    const vm = fakeVoxelManager([0, 0, 0, 0]);
+    vm.data[2] = 7;
+
+    restoreSegmentToLabelmap(vm, [0], 1);
+
+    expect(vm.data).toEqual([1, 0, 7, 0]);
+  });
+
+  it('is a no-op for an empty index list', () => {
+    const vm = fakeVoxelManager([5, 6]);
+    restoreSegmentToLabelmap(vm, [], 1);
+    expect(vm.data).toEqual([5, 6]);
   });
 });

--- a/extensions/tmtv/src/utils/clearSegmentFromLabelmap.test.ts
+++ b/extensions/tmtv/src/utils/clearSegmentFromLabelmap.test.ts
@@ -1,0 +1,68 @@
+import clearSegmentFromLabelmap from './clearSegmentFromLabelmap';
+
+/**
+ * Regression cover for #5476: the Rectangle ROI Threshold tool used cornerstone's
+ * `overwrite: true`, which zeroes the whole labelmap and so deleted every segment
+ * drawn with the brush / shape tools.
+ */
+const fakeVoxelManager = (voxels: number[]) => {
+  const data = [...voxels];
+  return {
+    data,
+    getScalarDataLength: () => data.length,
+    getAtIndex: (i: number) => data[i],
+    setAtIndex: (i: number, v: number) => {
+      data[i] = v;
+    },
+  };
+};
+
+describe('clearSegmentFromLabelmap', () => {
+  it('clears only the target segment and leaves the others intact', () => {
+    const vm = fakeVoxelManager([0, 1, 2, 1, 3, 1, 2, 0]);
+
+    const cleared = clearSegmentFromLabelmap(vm, 1);
+
+    expect(cleared).toBe(3);
+    expect(vm.data).toEqual([0, 0, 2, 0, 3, 0, 2, 0]);
+  });
+
+  it('is a no-op when the target segment is absent', () => {
+    const vm = fakeVoxelManager([0, 2, 3, 2]);
+
+    expect(clearSegmentFromLabelmap(vm, 1)).toBe(0);
+    expect(vm.data).toEqual([0, 2, 3, 2]);
+  });
+
+  it('leaves the labelmap unchanged when asked for segment 0', () => {
+    // Segment 0 is background, so this writes 0 over 0. It is a caller mistake rather
+    // than a supported operation, but it must not disturb any real segment.
+    const vm = fakeVoxelManager([0, 1, 0, 2]);
+
+    clearSegmentFromLabelmap(vm, 0);
+
+    expect(vm.data).toEqual([0, 1, 0, 2]);
+  });
+
+  it('is idempotent, so re-running the threshold tool converges', () => {
+    const vm = fakeVoxelManager([1, 1, 2]);
+
+    clearSegmentFromLabelmap(vm, 1);
+    const second = clearSegmentFromLabelmap(vm, 1);
+
+    expect(second).toBe(0);
+    expect(vm.data).toEqual([0, 0, 2]);
+  });
+
+  it('handles an empty labelmap', () => {
+    const vm = fakeVoxelManager([]);
+    expect(clearSegmentFromLabelmap(vm, 1)).toBe(0);
+  });
+
+  it('clears every voxel when the labelmap holds only the target segment', () => {
+    const vm = fakeVoxelManager([4, 4, 4]);
+
+    expect(clearSegmentFromLabelmap(vm, 4)).toBe(3);
+    expect(vm.data).toEqual([0, 0, 0]);
+  });
+});

--- a/extensions/tmtv/src/utils/clearSegmentFromLabelmap.ts
+++ b/extensions/tmtv/src/utils/clearSegmentFromLabelmap.ts
@@ -8,27 +8,56 @@ export type ClearableVoxelManager = {
 };
 
 /**
+ * Cornerstone writes `options.segmentIndex || 1`, so anything falsy there lands on
+ * segment 1. Normalising the same way keeps the segment we clear and the segment
+ * cornerstone writes to in agreement — otherwise a caller passing 0 clears background
+ * and then silently appends to segment 1 without clearing it first.
+ */
+export function normalizeSegmentIndex(segmentIndex: unknown): number {
+  return Number.isInteger(segmentIndex) && (segmentIndex as number) > 0
+    ? (segmentIndex as number)
+    : 1;
+}
+
+/**
  * Zero every voxel belonging to `segmentIndex`, leaving all other segments intact.
  *
  * Cornerstone's `overwrite: true` clears the *whole* labelmap before writing, which
  * erases every other segment in the segmentation. Clearing just the segment being
  * recomputed keeps a re-run idempotent without destroying a user's other work.
  *
- * @returns the number of voxels cleared.
+ * @returns the indices that were cleared, so the caller can put them back if the
+ *   recomputation that follows throws.
  */
 export default function clearSegmentFromLabelmap(
   voxelManager: ClearableVoxelManager,
   segmentIndex: number
-): number {
+): number[] {
   const length = voxelManager.getScalarDataLength();
-  let cleared = 0;
+  const cleared: number[] = [];
 
   for (let i = 0; i < length; i++) {
     if (voxelManager.getAtIndex(i) === segmentIndex) {
       voxelManager.setAtIndex(i, 0);
-      cleared++;
+      cleared.push(i);
     }
   }
 
   return cleared;
+}
+
+/**
+ * Put a cleared segment back, for when the recomputation after a clear throws.
+ *
+ * Only the previously occupied indices are written, so this cannot disturb voxels the
+ * failed operation may already have set elsewhere.
+ */
+export function restoreSegmentToLabelmap(
+  voxelManager: ClearableVoxelManager,
+  indices: number[],
+  segmentIndex: number
+): void {
+  for (const index of indices) {
+    voxelManager.setAtIndex(index, segmentIndex);
+  }
 }

--- a/extensions/tmtv/src/utils/clearSegmentFromLabelmap.ts
+++ b/extensions/tmtv/src/utils/clearSegmentFromLabelmap.ts
@@ -1,0 +1,34 @@
+/**
+ * Minimal view of a cornerstone voxel manager — only what clearing needs.
+ */
+export type ClearableVoxelManager = {
+  getScalarDataLength: () => number;
+  getAtIndex: (index: number) => number;
+  setAtIndex: (index: number, value: number) => void;
+};
+
+/**
+ * Zero every voxel belonging to `segmentIndex`, leaving all other segments intact.
+ *
+ * Cornerstone's `overwrite: true` clears the *whole* labelmap before writing, which
+ * erases every other segment in the segmentation. Clearing just the segment being
+ * recomputed keeps a re-run idempotent without destroying a user's other work.
+ *
+ * @returns the number of voxels cleared.
+ */
+export default function clearSegmentFromLabelmap(
+  voxelManager: ClearableVoxelManager,
+  segmentIndex: number
+): number {
+  const length = voxelManager.getScalarDataLength();
+  let cleared = 0;
+
+  for (let i = 0; i < length; i++) {
+    if (voxelManager.getAtIndex(i) === segmentIndex) {
+      voxelManager.setAtIndex(i, 0);
+      cleared++;
+    }
+  }
+
+  return cleared;
+}


### PR DESCRIPTION
### Context

Fixes #5476. @sedghi diagnosed this in the thread and pointed at [`commandsModule.ts#L222`](https://github.com/OHIF/Viewers/blob/master/extensions/tmtv/src/commandsModule.ts#L222) — this implements it. @bijil-trenser confirmed in February that the issue still reproduces.

`thresholdSegmentationByRectangleROITool` passed `overwrite: true`. Cornerstone implements that by zeroing the **entire labelmap** — the whole volume, not the ROI bounds — before writing anything:

```js
// @cornerstonejs/tools · utilities/segmentation/thresholdVolumeByRange.js
if (overwrite) {
  for (let i = 0; i < scalarDataLength; i++) {
    segVoxelManager.setAtIndex(i, 0);
  }
}
```

So running the tool deleted every segment in the segmentation, including ones drawn with the brush, shape or other threshold tools.

### Changes & Results

Clear only the segment being recomputed, then write additively:

```ts
const targetSegmentIndex = segmentIndex ?? 1;
clearSegmentFromLabelmap(labelmapVolume.voxelManager, targetSegmentIndex);

return csTools.utilities.segmentation.rectangleROIThresholdVolumeByRange(
  annotationUIDs,
  labelmapVolume,
  [/* ... */],
  { overwrite: false, segmentIndex: targetSegmentIndex, segmentationId }
);
```

**Why not just `overwrite: false` on its own?** Without any clearing, the segment could only ever grow — voxels from a previous run would linger, so shrinking the ROI or raising the threshold would never remove anything. Scoping the clear to the target segment keeps re-runs idempotent, which is the property `overwrite: true` was presumably there for, without touching anyone else's work.

| | before | after |
|---|---|---|
| other segments in the segmentation | erased | preserved |
| re-running on the same segment | replaces | replaces |
| shrinking the ROI and re-running | correct | correct |

`clearSegmentFromLabelmap` is a small pure helper over the voxel-manager interface, so it is testable without a volume or a viewport.

No extra event is needed — `thresholdVolumeByRange` still calls `triggerSegmentationDataModified` once at the end, and the clear happens before it, so there is exactly one update as before.

### Testing

Six unit tests in `extensions/tmtv/src/utils/clearSegmentFromLabelmap.test.ts`: only the target segment is cleared, absent segment is a no-op, segment 0 leaves the labelmap untouched, the operation is idempotent, empty labelmap, and a labelmap holding only the target segment.

```
cd extensions/tmtv && npx jest
# Test Suites: 1 passed, Tests: 6 passed
```

**This PR also adds `extensions/tmtv/jest.config.js`.** The package already declares `test:unit` and `test:unit:ci` scripts but had no config, so nothing in it was ever collected. The root `jest.config.js` already globs `<rootDir>/extensions/*/jest.config.js`, so adding the file wires tmtv into the root run — confirmed with `npx jest --listTests`. Happy to split that into its own PR if you would rather keep this one to the fix.

To verify in the app: TMTV mode → add a segmentation → draw with the brush → select Rectangle ROI Threshold and run it. The brush segment should still be there.

### Checklist

#### PR

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

<!-- No public API change; clearSegmentFromLabelmap is internal to the tmtv extension. -->

#### Tested Environment

- [x] OS: macOS 15 (Darwin 25.4.0, Apple Silicon)
- [x] Node version: 25.2.0, pnpm 11.5.2
- [x] Browser: not required — the changed logic is unit-tested; app-level repro steps above

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Rectangle-based segmentation thresholding now preserves existing labelmap segments instead of overwriting the entire labelmap.
  - Re-running the tool updates only the selected segment, and safely rolls back if recomputation fails.

- **Tests**
  - Added Jest coverage for clearing/restoring individual segments, including empty, repeated, background, and single-segment labelmaps.
  - Added command-level coverage to verify correct behavior and safe error handling for the Rectangle ROI threshold flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->