### PR TITLE
fix(ToolbarService): stop toolbar option wrapping from leaking closures

### DIFF
--- a/platform/core/src/services/ToolBarService/ToolbarService.ts
+++ b/platform/core/src/services/ToolBarService/ToolbarService.ts
@@ -111,6 +111,12 @@ export default class ToolbarService extends PubSubService {
   _servicesManager: AppTypes.ServicesManager;
   _evaluateFunction: Record<string, EvaluateFunction> = {};
   _serviceSubscriptions = [];
+  /**
+   * Enhanced option -> the pristine option it was built from, so repeated
+   * refreshes re-wrap the original rather than the previous wrapper. Weak so
+   * discarded wrappers stay collectable.
+   */
+  private _pristineOptions = new WeakMap<ButtonOptions, ButtonOptions>();
 
   constructor(
     commandsManager: CommandsManager,
@@ -596,23 +602,37 @@ export default class ToolbarService extends PubSubService {
       const optionsToUse = Array.isArray(options) ? options : [options];
       const toolProps = this.getButtonProps(itemId);
 
-      return optionsToUse.map(option => {
-        if (typeof option.optionComponent === 'function') {
-          return option;
+      return optionsToUse.map(currentOption => {
+        if (typeof currentOption.optionComponent === 'function') {
+          return currentOption;
         }
 
-        return {
-          ...option,
+        // Enhanced options are written back onto the button props below, so a
+        // refresh sees the previous pass's output here. onChange must close over
+        // the option the button was defined with: closing over the wrapper would
+        // make each refresh's closure retain the previous one, and the button
+        // props keep the newest wrapper reachable — so the chain would grow by
+        // one closure per refresh and never become collectable.
+        const original = this._pristineOptions.get(currentOption) ?? currentOption;
+
+        // Spread the current option rather than the original, because evaluate
+        // functions run before this and write live tool state onto whatever is
+        // on the button props at that moment.
+        const enhancedOption = {
+          ...currentOption,
           onChange: value => {
             // Update the option's value for UI
-            option.value = value;
+            original.value = value;
+            enhancedOption.value = value;
 
-            const cmds = Array.isArray(option.commands) ? option.commands : [option.commands];
+            const cmds = Array.isArray(original.commands)
+              ? original.commands
+              : [original.commands];
 
             // Find the parent button and update its options
             if (toolProps && toolProps.options) {
               // Find the option in the button's options array and update its value
-              const optionIndex = toolProps.options.findIndex(opt => opt.id === option.id);
+              const optionIndex = toolProps.options.findIndex(opt => opt.id === original.id);
               if (optionIndex !== -1) {
                 toolProps.options[optionIndex].value = value;
               }
@@ -620,7 +640,7 @@ export default class ToolbarService extends PubSubService {
 
             cmds.forEach(command => {
               const commandOptions = {
-                ...option,
+                ...original,
                 value,
                 options: toolProps.options,
                 servicesManager: this._servicesManager,
@@ -637,6 +657,10 @@ export default class ToolbarService extends PubSubService {
             });
           },
         };
+
+        this._pristineOptions.set(enhancedOption, original);
+
+        return enhancedOption;
       });
     };
 

--- a/platform/core/src/services/ToolBarService/__tests__/ToolbarService.test.ts
+++ b/platform/core/src/services/ToolBarService/__tests__/ToolbarService.test.ts
@@ -1,0 +1,156 @@
+import ToolbarService from '../ToolbarService';
+
+const BUTTON_UI_TYPE = 'ohif.radioGroup';
+
+function createService() {
+  const commandsManager = { run: jest.fn() };
+  const extensionManager = {
+    modules: {
+      toolbarModule: [
+        { module: [{ name: BUTTON_UI_TYPE, defaultComponent: () => null }] },
+      ],
+    },
+  };
+  const servicesManager = { services: {} };
+
+  return {
+    commandsManager,
+    service: new ToolbarService(
+      commandsManager as never,
+      extensionManager as never,
+      servicesManager as never
+    ),
+  };
+}
+
+/** A single-button section whose one option the service will wrap. */
+function addButtonWithOption(service, option) {
+  service.register([
+    {
+      id: 'brush',
+      uiType: BUTTON_UI_TYPE,
+      props: { id: 'brush', options: [option] },
+    },
+  ]);
+  service.updateSection('primary', ['brush']);
+}
+
+function currentOption(service) {
+  return service.getButtonSection('primary')[0].componentProps.options[0];
+}
+
+/**
+ * A nested button whose child carries the option. The child id is deliberately
+ * not registered as a top-level button, which is how the segmentation toolbox
+ * is built — `getButtonProps(item.id)` finds nothing for it.
+ */
+function addNestedButtonWithOption(service, option) {
+  service.register([
+    {
+      id: 'toolbox',
+      uiType: BUTTON_UI_TYPE,
+      props: {
+        id: 'toolbox',
+        items: [{ id: 'brush', options: [option] }],
+      },
+    },
+  ]);
+  service.updateSection('primary', ['toolbox']);
+}
+
+function currentNestedOption(service) {
+  return service.getButtonSection('primary')[0].componentProps.items[0].options[0];
+}
+
+describe('ToolbarService option enhancement', () => {
+  it('keeps the button definition as the source of truth across repeated refreshes', () => {
+    const { service } = createService();
+    const option = { id: 'radius', value: 5, commands: [] };
+    addButtonWithOption(service, option);
+
+    // Every refresh re-wraps the button's options. If a refresh wrapped the
+    // previous wrapper instead of the original, onChange would write to that
+    // intermediate object and the button's own option would go stale.
+    currentOption(service);
+    currentOption(service);
+    currentOption(service).onChange(42);
+
+    expect(option.value).toBe(42);
+  });
+
+  it('returns a fresh wrapper over the same option on each refresh', () => {
+    const { service } = createService();
+    const option = { id: 'radius', value: 5, commands: [] };
+    addButtonWithOption(service, option);
+
+    const first = currentOption(service);
+    const second = currentOption(service);
+
+    // Each refresh yields a fresh wrapper over the same original, so the
+    // wrapper never nests: its own enumerable shape stays that of the original.
+    expect(Object.keys(second).sort()).toEqual(Object.keys(first).sort());
+    expect(second).not.toBe(first);
+    expect(second.id).toBe('radius');
+  });
+
+  it('anchors every wrapper to the definition, never to the previous wrapper', () => {
+    const { service } = createService();
+    const option = { id: 'radius', value: 5, commands: [] };
+    addButtonWithOption(service, option);
+
+    const wrappers = [currentOption(service), currentOption(service), currentOption(service)];
+
+    const { _pristineOptions } = service as unknown as {
+      _pristineOptions: WeakMap<object, object>;
+    };
+
+    // This is what keeps the closure chain from forming: onChange closes over
+    // whatever this resolves to, so it must be the definition every time. If a
+    // refresh anchored to the previous wrapper, each closure would retain the
+    // one before it and the chain would grow by one per refresh.
+    for (const wrapper of wrappers) {
+      expect(_pristineOptions.get(wrapper)).toBe(option);
+    }
+  });
+
+  it('keeps live values an evaluate function wrote onto the button props', () => {
+    const { service } = createService();
+    addButtonWithOption(service, { id: 'radius', value: 25, commands: [] });
+
+    currentOption(service);
+    // Evaluate functions run before the options are wrapped and write live tool
+    // state onto whatever option object is on the button props at that moment
+    // (see evaluate.cornerstone.segmentation.synchronizeDrawingRadius). The next
+    // wrap has to carry that value through, not reset it to the definition's.
+    service.getButtonProps('brush').options[0].value = 19;
+
+    expect(currentOption(service).value).toBe(19);
+  });
+
+  it('keeps live values on nested buttons too', () => {
+    const { service } = createService();
+    addNestedButtonWithOption(service, { id: 'radius', value: 25, commands: [] });
+
+    currentNestedOption(service);
+    service.getButtonProps('toolbox').items[0].options[0].value = 19;
+
+    expect(currentNestedOption(service).value).toBe(19);
+  });
+
+  it('still runs the option commands and broadcasts the state change', () => {
+    const { service, commandsManager } = createService();
+    const option = { id: 'radius', value: 5, commands: ['setBrushSize'] };
+    addButtonWithOption(service, option);
+
+    const onStateModified = jest.fn();
+    service.subscribe(service.EVENTS.TOOL_BAR_STATE_MODIFIED, onStateModified);
+
+    currentOption(service).onChange(9);
+
+    expect(commandsManager.run).toHaveBeenCalledWith(
+      'setBrushSize',
+      expect.objectContaining({ value: 9, id: 'radius' })
+    );
+    expect(onStateModified).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
### Problem

`_mapButtonToDisplay` writes enhanced options back onto the button's props (`item.options = createEnhancedOptions(...)`). Consumers such as `useActiveToolOptions` read options from there, so the write-back has to stay — but it means the next refresh wraps the *previous wrapper*. Each new `onChange` closes over the old one, and the newest wrapper stays reachable from `state.buttons`, so the chain is pinned and grows by one closure layer per refresh.

`refreshToolbarState` runs on every `SEGMENTATION_MODIFIED`, so brush painting grows it continuously — the toolbar leaks in proportion to how much the user paints.

### Fix

Resolve each option back to the one the button was defined with (`WeakMap` wrapper → original), so a refresh always yields exactly one closure layer. Write-back unchanged.

### Measured

120 brush strokes on a 1315-slice labelmap segmentation with 2 segmentations, heap sampled after a forced GC:

| | before | after |
|---|---|---|
| retained after loading the next volume | 490 MB | **75 MB** |
| heap objects | 2.34M → 23.24M (**9.9×**) | 2.32M → 5.61M (**2.4×**) |
| retained `onChange` closures | 2,830,072 | **0** |
| JS heap | 493 → 1474 MB | 492 → **562 MB** |

`_mapButtonToDisplay` went from 375 MB of 470 MB sampled allocation (80%) to off the list. Same voxels painted before and after — no behaviour change.

### Tests

6 unit tests in `platform/core/src/services/ToolBarService/__tests__/`, each verified to fail against the code it guards.

An earlier revision of this PR rebuilt the wrapper from the original option, which discarded whatever an evaluate function had written onto the button props in the meantime — `synchronizeDrawingRadius` sets the live brush size there, and `handleEvaluate` runs before the options are wrapped, so the radius input reverted to its default. That showed up as 3 `SEGDrawingToolsResizing` failures on the first CI run; it is covered by two of the tests above.

### Not addressed

Nothing unsubscribes `ToolbarService._serviceSubscriptions`, and `extensions/cornerstone` registers `SEGMENTATION_MODIFIED` from both `init.tsx` and `index.tsx`. I tried deduplicating that and reverted it — `SegmentationService` is a singleton whose `onModeExit` → `destroy()` → `reset()` clears its listeners, so suppressing the re-registration on the next mode enter silently stops the toolbar updating. Duplicate listeners still cost CPU per event, but with the chain fixed they no longer leak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed toolbar refresh behavior to prevent repeated updates from accumulating redundant actions.
  * Ensured toolbar controls consistently reflect current values after refreshes, including nested controls.
  * Preserved command execution and toolbar state notifications when options change.

* **Tests**
  * Added coverage for repeated refreshes, independent toolbar options, live values, command execution, and state updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->