### PR TITLE
fix(segmentation): drop a removed representation from the panel

### DIFF
--- a/extensions/cornerstone/src/hooks/useViewportSegmentations.ts
+++ b/extensions/cornerstone/src/hooks/useViewportSegmentations.ts
@@ -198,6 +198,17 @@ export function useViewportSegmentations({
         segmentationService.EVENTS.SEGMENTATION_REPRESENTATION_MODIFIED,
         debouncedUpdate
       ),
+      // What this hook reads is `getSegmentationRepresentations(viewportId)`, so a
+      // representation leaving the viewport changes its answer and has to re-run it.
+      // Without this, "Remove from Viewport" cleared the overlay from the image but
+      // left the segmentation listed in the panel: the data was already correct, the
+      // panel simply never asked again. Nothing else covers it — a hydrated
+      // segmentation is not a display set in the viewport, so removing it moves no
+      // grid state and fires no grid event either.
+      segmentationService.subscribe(
+        segmentationService.EVENTS.SEGMENTATION_REPRESENTATION_REMOVED,
+        debouncedUpdate
+      ),
       viewportGridService.subscribe(
         viewportGridService.EVENTS.ACTIVE_VIEWPORT_ID_CHANGED,
         debouncedUpdate

--- a/tests/ContourSegmentationCrudInteractions.spec.ts
+++ b/tests/ContourSegmentationCrudInteractions.spec.ts
@@ -222,13 +222,10 @@ test.describe('Contour Segmentation interactions on RTSTRUCT panel', () => {
     await expectSegmentationLabels(segmentationSelect, ['Contours on PET']);
   });
 
-  // KNOWN BUG: the last remaining segmentation cannot be removed from the viewport
-  // ("Remove from Viewport" is a silent no-op once it is the only one left), so the
-  // panel keeps its segment row instead of clearing. Skipped until the bug is fixed.
-  // Tracked in https://github.com/OHIF/Viewers/issues/6090
-  test.skip('should remove every segmentation from the viewport', async ({
-    rightPanelPageObject,
-  }) => {
+  // Regression coverage for https://github.com/OHIF/Viewers/issues/6090: removing the
+  // last remaining segmentation looked like a silent no-op, because the panel never
+  // re-read the viewport's representations once nothing was left to become active.
+  test('should remove every segmentation from the viewport', async ({ rightPanelPageObject }) => {
     const { panel, addSegmentationButton } = rightPanelPageObject.contourSegmentationPanel;
 
     // Start with the hydrated RTSTRUCT plus two created segmentations.


### PR DESCRIPTION
Fixes #6090

## What's broken

"Remove from Viewport" on the last remaining segmentation looks like a silent no-op: the overlay disappears from the image, but the panel keeps listing the segmentation and its segment rows.

## Why

`useViewportSegmentations` renders from `segmentationService.getSegmentationRepresentations(viewportId)`, but it never subscribed to `SEGMENTATION_REPRESENTATION_REMOVED`. The state was already correct by the time the event fired — the panel simply never asked again.

Nothing else covered that transition. A hydrated segmentation is not a display set in the viewport, so removing it moves no grid state and fires no grid event; the segmentation itself is untouched, so no segmentation event fires either.

This is also why the bug looked intermittent. `removeSegmentationRepresentations` fires `REPRESENTATION_MODIFIED` for whichever representation becomes active next, so with two or more segmentations loaded the panel refreshed by accident. Only the last one was visibly broken — exactly the split between the two E2E cases added in #6091, where `should remove a segmentation from the viewport and drop it from the selector` passes and `should remove every segmentation from the viewport` was skipped.

## The change

One subscription in `useViewportSegmentations`, plus un-skipping the E2E test that was written for this bug and left skipped pointing at #6090.

No new crash path: `removeSegmentationRepresentations` updates state before triggering the event, so the hook's re-read is never stale, and `removeSegmentation` strips representations from all viewports before deleting the segmentation, so `_toOHIFSegmentationRepresentation`'s "Segmentation not found" throw is not newly reachable. `SegmentationTable` already handled empty `data`.

## Testing

- `tests/ContourSegmentationCrudInteractions.spec.ts` → `should remove every segmentation from the viewport` is un-skipped and is the regression coverage for this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated segmentation panels automatically when a segmentation representation is removed from the viewport.
  * Removing all contour segmentations now correctly clears the panel and restores the “Add segmentation” option.

* **Tests**
  * Enabled regression coverage for removing all contour segmentations from the viewport.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->