### PR TITLE
fix(hotkeys): hand keystrokes back to the browser inside modal dialogs

### DIFF
--- a/platform/core/src/utils/hotkeys/allowNativeKeysPlugin.js
+++ b/platform/core/src/utils/hotkeys/allowNativeKeysPlugin.js
@@ -1,0 +1,72 @@
+/**
+ * Hands a keystroke back to the browser — instead of firing a bound OHIF hotkey
+ * — whenever it lands inside a modal dialog, or inside an element explicitly
+ * marked as a native-keyboard region.
+ *
+ * `HotkeysManager` always `preventDefault`s a matched hotkey before running its
+ * command (`_bindHotkeys` in `platform/core/src/classes/HotkeysManager.ts`), so a
+ * bound keystroke is claimed **app-wide** — including while a modal dialog is
+ * open. Two things follow from that:
+ *
+ *   - Single-key hotkeys (rotate, scroll, layout, …) still fire on the viewport
+ *     behind an open modal, even though the modal has focus.
+ *   - A mode that binds a combo the browser already owns — `ctrl+c`, `ctrl+a`,
+ *     `ctrl+v` — takes select-all, copy and paste away from every dialog too, so
+ *     text shown in a modal selects but never copies.
+ *
+ * Mousetrap's default `stopCallback` already opts keystrokes out of the hotkey
+ * system when the target is an `input`, `select`, `textarea` or `contenteditable`
+ * element, letting their native action through. This plugin extends that same
+ * rule from "the target is editable" to "the target is somewhere the browser's
+ * own keyboard behaviour should win".
+ *
+ * The test is on *where the keystroke landed*, not on what happens to be
+ * selected, and not on which combo was pressed. That keeps it predictable: every
+ * hotkey is live everywhere except in the regions below, rather than flickering
+ * off whenever a stale selection exists somewhere in the document.
+ */
+
+/**
+ * `[role="dialog"]` covers every modal in the app with no markup changes at all.
+ * A `DialogContent` renders that role, carries `tabindex="-1"` and focuses itself
+ * on open, so a keydown's target is inside it from the moment the dialog appears.
+ * Blocking hotkeys under an open modal is the right default in its own right.
+ *
+ * `.ohif-text-select` is the opt-in for selectable text that is **not** inside a
+ * dialog — a value in a side panel, say. Nothing in this repo uses it yet; add it
+ * when such a case turns up. Two things are needed, not one:
+ *
+ *   1. The class must sit on the element that receives focus, or on an ancestor
+ *      of it. A keydown's target *is* `document.activeElement`, so marking a
+ *      descendant of the focused element does nothing.
+ *   2. That element must be focusable — `tabIndex={-1}` for click-focusable but
+ *      out of the tab order, `tabIndex={0}` to make it keyboard-reachable too.
+ *      A plain `<div>`/`<span>` never becomes `document.activeElement`; clicking
+ *      one leaves focus on `body` or the nearest focusable ancestor, and the
+ *      class would never be seen.
+ *
+ * Give it a visible focus style as well (`focus:ring-*`), so the user can tell
+ * that their keystrokes are going to the browser rather than to the viewer — all
+ * hotkeys are off while focus sits there, not just the clipboard ones.
+ *
+ * Note that `tabIndex` alone cannot stand in for the class: it already marks
+ * "clickable widget" in several places (measurement rows, study items, the cine
+ * player, …), and keying off it would suppress hotkeys on those clicked widgets.
+ */
+const NATIVE_KEYS_SELECTOR = '[role="dialog"], .ohif-text-select';
+
+function isNativeKeysRegion(element) {
+  return typeof element?.closest === 'function' && !!element.closest(NATIVE_KEYS_SELECTOR);
+}
+
+export default function allowNativeKeysPlugin(Mousetrap) {
+  const _originalStopCallback = Mousetrap.prototype.stopCallback;
+
+  Mousetrap.prototype.stopCallback = function (e, element, combo, sequence) {
+    if (isNativeKeysRegion(element)) {
+      return true;
+    }
+
+    return _originalStopCallback.call(this, e, element, combo, sequence);
+  };
+}

--- a/platform/core/src/utils/hotkeys/allowNativeKeysPlugin.test.js
+++ b/platform/core/src/utils/hotkeys/allowNativeKeysPlugin.test.js
@@ -1,0 +1,95 @@
+import allowNativeKeysPlugin from './allowNativeKeysPlugin';
+
+/** Minimal Mousetrap stand-in exposing the prototype the plugin wraps. */
+function makeMousetrap(originalReturn = false) {
+  const original = jest.fn(() => originalReturn);
+  function Mousetrap() {}
+  Mousetrap.prototype.stopCallback = original;
+  return { Mousetrap, original };
+}
+
+/** Builds `<parent><child/></parent>` in the document and returns both. */
+function mount(parentAttributes = {}) {
+  const parent = document.createElement('div');
+  Object.entries(parentAttributes).forEach(([name, value]) => parent.setAttribute(name, value));
+
+  const child = document.createElement('span');
+  parent.appendChild(child);
+  document.body.appendChild(parent);
+
+  return { parent, child };
+}
+
+describe('allowNativeKeysPlugin', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('stops a hotkey that lands inside a modal dialog', () => {
+    // A modal renders role="dialog" and focuses its content on open, so the
+    // keydown target is the dialog or something inside it.
+    const { child } = mount({ role: 'dialog' });
+    const { Mousetrap } = makeMousetrap();
+    allowNativeKeysPlugin(Mousetrap);
+
+    expect(Mousetrap.prototype.stopCallback.call({}, {}, child, 'ctrl+c')).toBe(true);
+  });
+
+  it('stops every combo there, not just the clipboard ones', () => {
+    // ctrl+a is the case a selection test could never reach: its native meaning
+    // is select-all, so nothing is selected at the moment it is pressed.
+    const { parent } = mount({ role: 'dialog' });
+    const { Mousetrap } = makeMousetrap();
+    allowNativeKeysPlugin(Mousetrap);
+
+    ['ctrl+a', 'ctrl+v', 'ctrl+x', 'ctrl+shift+c', 'r'].forEach(combo => {
+      expect(Mousetrap.prototype.stopCallback.call({}, {}, parent, combo)).toBe(true);
+    });
+  });
+
+  it('stops a hotkey inside an element marked .ohif-text-select', () => {
+    const { child } = mount({ class: 'ohif-text-select', tabindex: '-1' });
+    const { Mousetrap } = makeMousetrap();
+    allowNativeKeysPlugin(Mousetrap);
+
+    expect(Mousetrap.prototype.stopCallback.call({}, {}, child, 'ctrl+c')).toBe(true);
+  });
+
+  it('lets a hotkey through everywhere else, so bound commands still fire', () => {
+    // A viewport carries neither marker, and a text selection sitting elsewhere
+    // in the document is no longer consulted, so its hotkeys are unaffected.
+    const { child } = mount({ class: 'viewport-element' });
+    const { Mousetrap, original } = makeMousetrap(false);
+    allowNativeKeysPlugin(Mousetrap);
+
+    expect(Mousetrap.prototype.stopCallback.call({}, {}, child, 'ctrl+c')).toBe(false);
+    expect(original).toHaveBeenCalled();
+  });
+
+  it('forwards every argument Mousetrap passes, including the sequence', () => {
+    const { Mousetrap, original } = makeMousetrap(false);
+    allowNativeKeysPlugin(Mousetrap);
+
+    const event = {};
+    Mousetrap.prototype.stopCallback.call({}, event, document.body, 'ctrl+k', 'ctrl+k p');
+
+    expect(original).toHaveBeenCalledWith(event, document.body, 'ctrl+k', 'ctrl+k p');
+  });
+
+  it('keeps the wrapped stopCallback in charge outside those regions', () => {
+    // The pause plugin's stopCallback sits underneath this one: while paused it
+    // returns true for every combo, and that must still win.
+    const { Mousetrap } = makeMousetrap(true);
+    allowNativeKeysPlugin(Mousetrap);
+
+    expect(Mousetrap.prototype.stopCallback.call({}, {}, document.body, 'ctrl+c')).toBe(true);
+  });
+
+  it('tolerates a target with no closest(), such as document', () => {
+    const { Mousetrap, original } = makeMousetrap(false);
+    allowNativeKeysPlugin(Mousetrap);
+
+    expect(Mousetrap.prototype.stopCallback.call({}, {}, document, 'ctrl+c')).toBe(false);
+    expect(original).toHaveBeenCalled();
+  });
+});

--- a/platform/core/src/utils/hotkeys/index.js
+++ b/platform/core/src/utils/hotkeys/index.js
@@ -1,8 +1,14 @@
 import Mousetrap from 'mousetrap';
 import pausePlugin from './pausePlugin';
 import recordPlugin from './recordPlugin';
+import allowNativeKeysPlugin from './allowNativeKeysPlugin';
 
 recordPlugin(Mousetrap);
 pausePlugin(Mousetrap);
+// Registered after pausePlugin so its stopCallback wraps the pause check: while
+// paused, still stop; otherwise stop only for keystrokes landing in a modal
+// dialog or an `.ohif-text-select` region, where the browser's own keyboard
+// behaviour should win.
+allowNativeKeysPlugin(Mousetrap);
 
 export default Mousetrap;


### PR DESCRIPTION
### Context

OHIF hotkeys stay live while a modal dialog is open. `HotkeysManager._bindHotkeys` (`platform/core/src/classes/HotkeysManager.ts`) binds every hotkey through Mousetrap and **always** `preventDefault`s before running the command:

```js
mouseTrapAPI.bind(combinedKeys, evt => {
  evt.preventDefault();
  ...
```

Mousetrap's default `stopCallback` opts a keystroke out only when the target is an `input`, `select`, `textarea` or `contenteditable` element. A focused modal dialog is none of those, so two things happen while a modal is open:

- Single-key viewport hotkeys (rotate, scroll, layout, …) still fire behind the modal, even though the modal has focus.
- A mode that binds a combo the browser already owns — `ctrl+c`, `ctrl+a`, `ctrl+v` — takes select-all, copy and paste away from every dialog too. Text shown inside a modal selects but never copies, because the keystroke was claimed and its default action cancelled.

### Changes & Results

A Mousetrap `stopCallback` plugin (`allowNativeKeysPlugin`), registered next to the existing `pausePlugin` and `recordPlugin`. `stopCallback` is Mousetrap's supported way to opt a keystroke out of the hotkey system and let its default action through — the same hook it already uses to ignore shortcuts typed into inputs and textareas.

The test is on **where the keystroke landed**, not on what is selected and not on which combo was pressed. No OHIF hotkey fires when the event target is inside:

- **`[role="dialog"]`** — every modal, with no markup changes. A `DialogContent` renders that role, carries `tabindex="-1"` and focuses itself on open, so a keydown's target is inside it from the moment the dialog appears. Blocking hotkeys under an open modal is correct on its own terms.
- **`.ohif-text-select`** — an opt-in marker for selectable text that is *not* in a dialog (a value in a side panel, say). Nothing uses it yet; it is there so the next such case is a class plus a `tabIndex` rather than another plugin. The plugin's doc comment spells out the two requirements (the class must sit on the focused element or an ancestor, and that element must be focusable).

It sits in `platform/core` beside the other Mousetrap plugins, and after `pausePlugin`, so the pause check still wins while paused.

Before: `ctrl+c` over selectable text in a modal fires the bound annotation command and copies nothing; `r`, arrows, etc. drive the viewport behind an open modal.
After: inside a dialog (or a marked region) the browser keeps `ctrl+a`/`ctrl+c`/`ctrl+x`/`ctrl+v` and OHIF hotkeys stay silent; everywhere else every hotkey is unchanged.

### Testing

Unit: `platform/core/src/utils/hotkeys/allowNativeKeysPlugin.test.js` — 7 tests over real DOM nodes (target inside a dialog, target *being* the dialog, target inside `.ohif-text-select`, target in neither, every argument forwarded incl. the `sequence`, the wrapped `stopCallback` still deciding the rest, a target with no `closest()`).

Manual, in a build that binds a clipboard combo to a command:
- Open a modal with selectable text, drag-select it, press `ctrl+c` → the text is copied and no bound command fires; check `defaultPrevented` is `false` on the `ctrl+c` keydown.
- With a modal open, press a single-key viewport hotkey (e.g. rotate) → nothing happens on the viewport behind it.
- Over a viewport, every hotkey behaves exactly as before.

### Notes

Contributed by University of Calgary. Thanks to @wayfarer3130 for directing the fix toward `platform/core` and asking for it upstream.

### Checklist

#### PR

- [x] My Pull Request title is descriptive, accurate and follows the semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments, etc.)

#### Public Documentation Updates

- [x] The documentation page has been updated as necessary for any public API additions or removals.

#### Tested Environment

- [x] OS: macOS 15
- [x] Node version: 24.3.0
- [x] Browser: Chrome


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Native browser keyboard behavior is now preserved when typing or selecting text in dialogs and designated text-selection areas.
  * Application hotkeys continue to work normally outside these regions.
* **Tests**
  * Added coverage for dialog handling, text-selection areas, pass-through behavior, and compatibility with different event targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->