### PR TITLE
fix(dicom-pdf): guarantee the type of encapsulated documents

### DIFF
--- a/extensions/dicom-pdf/babel.config.js
+++ b/extensions/dicom-pdf/babel.config.js
@@ -1,0 +1,1 @@
+module.exports = require('../../babel.config.js');

--- a/extensions/dicom-pdf/jest.config.js
+++ b/extensions/dicom-pdf/jest.config.js
@@ -1,0 +1,13 @@
+const base = require('../../jest.config.base.js');
+
+module.exports = {
+  ...base,
+  moduleNameMapper: {
+    ...base.moduleNameMapper,
+    // Deep imports already name `src`, so they must be matched before the
+    // catch-all below appends a second one (e.g. `@ohif/core/src/utils/x`
+    // would otherwise resolve to `platform/core/src/utils/x/src`).
+    '^@ohif/([^/]+)/src/(.*)$': '<rootDir>/../../platform/$1/src/$2',
+    '@ohif/(.*)': '<rootDir>/../../platform/$1/src',
+  },
+};

--- a/extensions/dicom-pdf/package.json
+++ b/extensions/dicom-pdf/package.json
@@ -34,7 +34,8 @@
     "dicom-parser": "1.8.21",
     "hammerjs": "2.0.8",
     "prop-types": "15.8.1",
-    "react": "18.3.1"
+    "react": "18.3.1",
+    "react-i18next": "12.3.1"
   },
   "dependencies": {
     "@babel/runtime": "7.29.7",

--- a/extensions/dicom-pdf/src/getSopClassHandlerModule.js
+++ b/extensions/dicom-pdf/src/getSopClassHandlerModule.js
@@ -1,6 +1,10 @@
 import { SOPClassHandlerId } from './id';
 import { utils, Types as OhifTypes } from '@ohif/core';
 import i18n from '@ohif/i18n';
+import {
+  getDisplayableDocumentType,
+  normalizeDocumentMimeType,
+} from './utils/displayableDocumentTypes';
 
 const SOP_CLASS_UIDS = {
   ENCAPSULATED_PDF: '1.2.840.10008.5.1.4.1.1.104.1',
@@ -14,10 +18,17 @@ const _getDisplaySetsFromSeries = (instances, servicesManager, extensionManager)
     const { Modality, SOPInstanceUID } = instance;
     const { SeriesDescription = 'PDF', MIMETypeOfEncapsulatedDocument } = instance;
     const { SeriesNumber, SeriesDate, SeriesInstanceUID, StudyInstanceUID, SOPClassUID } = instance;
+    // The declared type is carried through to the viewport, which resolves it
+    // against the displayable-type allowlist and re-wraps the payload in a Blob
+    // of the canonical type. Here it only decides what to ask the origin server
+    // for, so the canonical spelling is preferred when the type is one we know.
+    const mimeType = normalizeDocumentMimeType(MIMETypeOfEncapsulatedDocument) || 'application/pdf';
+    const documentType = getDisplayableDocumentType(mimeType);
+
     const renderedUrlParams = {
       instance,
       tag: 'EncapsulatedDocument',
-      defaultType: MIMETypeOfEncapsulatedDocument || 'application/pdf',
+      defaultType: documentType?.mimeType || mimeType,
       singlepart: 'pdf',
     };
     const renderedUrl = dataSource.retrieve.directURL(renderedUrlParams);
@@ -42,6 +53,7 @@ const _getDisplaySetsFromSeries = (instances, servicesManager, extensionManager)
       measurements: null,
       renderedUrl: renderedUrl,
       getRenderedUrl,
+      mimeType,
       instances: [instance],
       thumbnailSrc: null,
       isDerivedDisplaySet: true,

--- a/extensions/dicom-pdf/src/getSopClassHandlerModule.js
+++ b/extensions/dicom-pdf/src/getSopClassHandlerModule.js
@@ -1,10 +1,8 @@
 import { SOPClassHandlerId } from './id';
 import { utils, Types as OhifTypes } from '@ohif/core';
 import i18n from '@ohif/i18n';
-import {
-  getDisplayableDocumentType,
-  normalizeDocumentMimeType,
-} from './utils/displayableDocumentTypes';
+import { normalizeDocumentMimeType } from './utils/displayableDocumentTypes';
+import { loadDisplayableDocument } from './utils/loadDisplayableDocument';
 
 const SOP_CLASS_UIDS = {
   ENCAPSULATED_PDF: '1.2.840.10008.5.1.4.1.1.104.1',
@@ -13,29 +11,21 @@ const SOP_CLASS_UIDS = {
 const sopClassUids = Object.values(SOP_CLASS_UIDS);
 
 const _getDisplaySetsFromSeries = (instances, servicesManager, extensionManager) => {
-  const dataSource = extensionManager.getActiveDataSource()[0];
   return instances.map(instance => {
     const { Modality, SOPInstanceUID } = instance;
     const { SeriesDescription = 'PDF', MIMETypeOfEncapsulatedDocument } = instance;
     const { SeriesNumber, SeriesDate, SeriesInstanceUID, StudyInstanceUID, SOPClassUID } = instance;
-    // The declared type is carried through to the viewport, which resolves it
-    // against the displayable-type allowlist and re-wraps the payload in a Blob
-    // of the canonical type. Here it only decides what to ask the origin server
-    // for, so the canonical spelling is preferred when the type is one we know.
+    // The declared type is only a claim. It is resolved against the displayable
+    // type allowlist, and the payload is re-wrapped in a Blob of the canonical
+    // type, so the instance cannot steer how the browser parses the document.
     const mimeType = normalizeDocumentMimeType(MIMETypeOfEncapsulatedDocument) || 'application/pdf';
-    const documentType = getDisplayableDocumentType(mimeType);
 
-    const renderedUrlParams = {
+    const documentParams = {
       instance,
       tag: 'EncapsulatedDocument',
-      defaultType: documentType?.mimeType || mimeType,
-      singlepart: 'pdf',
+      mimeType,
     };
-    const renderedUrl = dataSource.retrieve.directURL(renderedUrlParams);
-    const getRenderedUrl = dataSource.retrieve.renderedURL
-      ? options =>
-          dataSource.retrieve.renderedURL({ ...renderedUrlParams, url: renderedUrl }, options)
-      : undefined;
+    const getDocument = options => loadDisplayableDocument(documentParams, options);
 
     const displaySet = {
       //plugin: id,
@@ -51,8 +41,7 @@ const _getDisplaySetsFromSeries = (instances, servicesManager, extensionManager)
       SOPClassUID,
       referencedImages: null,
       measurements: null,
-      renderedUrl: renderedUrl,
-      getRenderedUrl,
+      getDocument,
       mimeType,
       instances: [instance],
       thumbnailSrc: null,

--- a/extensions/dicom-pdf/src/utils/displayableDocumentTypes.test.ts
+++ b/extensions/dicom-pdf/src/utils/displayableDocumentTypes.test.ts
@@ -87,6 +87,29 @@ describe('matchesDocumentSignature', () => {
     expect(matchesDocumentSignature(pdf, payload)).toBe(true);
   });
 
+  // "%PDF-1.4"
+  const pdfHeader = [0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x34];
+
+  it('accepts a pdf whose header follows a UTF-8 BOM', () => {
+    const payload = bufferFrom([0xef, 0xbb, 0xbf, ...pdfHeader]);
+
+    expect(matchesDocumentSignature(pdf, payload)).toBe(true);
+  });
+
+  it('accepts a pdf whose header starts at the last searched offset', () => {
+    // Mainstream readers scan roughly the first 1024 bytes for "%PDF-", so a
+    // header this far in is still a file they open.
+    const payload = bufferFrom([...new Array(1024).fill(0x20), ...pdfHeader]);
+
+    expect(matchesDocumentSignature(pdf, payload)).toBe(true);
+  });
+
+  it('rejects a pdf whose header starts past the search window', () => {
+    const payload = bufferFrom([...new Array(1025).fill(0x20), ...pdfHeader]);
+
+    expect(matchesDocumentSignature(pdf, payload)).toBe(false);
+  });
+
   it('rejects a payload declared as pdf that is actually html', () => {
     // "<html>"
     const payload = bufferFrom([0x3c, 0x68, 0x74, 0x6d, 0x6c, 0x3e]);

--- a/extensions/dicom-pdf/src/utils/displayableDocumentTypes.test.ts
+++ b/extensions/dicom-pdf/src/utils/displayableDocumentTypes.test.ts
@@ -1,0 +1,106 @@
+import {
+  getDisplayableDocumentType,
+  matchesDocumentSignature,
+  normalizeDocumentMimeType,
+} from './displayableDocumentTypes';
+
+const bufferFrom = (bytes: number[]) => new Uint8Array(bytes).buffer;
+
+describe('normalizeDocumentMimeType', () => {
+  it('lower-cases and strips parameters', () => {
+    expect(normalizeDocumentMimeType('Text/HTML; charset=UTF-8')).toBe('text/html');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(normalizeDocumentMimeType('  application/pdf  ')).toBe('application/pdf');
+  });
+
+  it('returns undefined for missing or empty values', () => {
+    expect(normalizeDocumentMimeType(undefined)).toBeUndefined();
+    expect(normalizeDocumentMimeType('')).toBeUndefined();
+    expect(normalizeDocumentMimeType('   ')).toBeUndefined();
+    expect(normalizeDocumentMimeType(42 as unknown as string)).toBeUndefined();
+  });
+});
+
+describe('getDisplayableDocumentType', () => {
+  it('renders pdf through <object>, which cannot be sandboxed', () => {
+    const documentType = getDisplayableDocumentType('application/pdf');
+
+    expect(documentType).toMatchObject({ mimeType: 'application/pdf', strategy: 'object' });
+    expect(documentType?.sandbox).toBeUndefined();
+  });
+
+  it('renders html through a fully restricted sandboxed iframe', () => {
+    expect(getDisplayableDocumentType('text/html')).toMatchObject({
+      mimeType: 'text/html',
+      strategy: 'iframe',
+      sandbox: '',
+    });
+  });
+
+  it('folds application/html onto text/html', () => {
+    expect(getDisplayableDocumentType('application/html')).toMatchObject({
+      mimeType: 'text/html',
+      strategy: 'iframe',
+    });
+  });
+
+  it('folds non-standard pdf spellings onto application/pdf', () => {
+    for (const alias of ['application/x-pdf', 'application/acrobat', 'text/pdf']) {
+      expect(getDisplayableDocumentType(alias)).toMatchObject({
+        mimeType: 'application/pdf',
+        strategy: 'object',
+      });
+    }
+  });
+
+  it('resolves types that carry parameters', () => {
+    expect(getDisplayableDocumentType('text/html;charset=iso-8859-1')).toMatchObject({
+      mimeType: 'text/html',
+    });
+  });
+
+  it('rejects types that are not on the allowlist', () => {
+    for (const mimeType of [
+      'application/octet-stream',
+      'image/svg+xml',
+      'application/javascript',
+      'text/rtf',
+      'application/msword',
+      undefined,
+      '',
+    ]) {
+      expect(getDisplayableDocumentType(mimeType)).toBeUndefined();
+    }
+  });
+});
+
+describe('matchesDocumentSignature', () => {
+  const pdf = getDisplayableDocumentType('application/pdf');
+  const html = getDisplayableDocumentType('text/html');
+
+  it('accepts a payload that starts with the type magic number', () => {
+    // "%PDF-1.4"
+    const payload = bufferFrom([0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x34]);
+
+    expect(matchesDocumentSignature(pdf, payload)).toBe(true);
+  });
+
+  it('rejects a payload declared as pdf that is actually html', () => {
+    // "<html>"
+    const payload = bufferFrom([0x3c, 0x68, 0x74, 0x6d, 0x6c, 0x3e]);
+
+    expect(matchesDocumentSignature(pdf, payload)).toBe(false);
+  });
+
+  it('rejects a payload shorter than the signature', () => {
+    expect(matchesDocumentSignature(pdf, bufferFrom([0x25, 0x50]))).toBe(false);
+    expect(matchesDocumentSignature(pdf, bufferFrom([]))).toBe(false);
+  });
+
+  it('accepts any payload for types with no reliable magic number', () => {
+    expect(matchesDocumentSignature(html, bufferFrom([0x3c, 0x68]))).toBe(true);
+    expect(matchesDocumentSignature(html, bufferFrom([]))).toBe(true);
+  });
+});

--- a/extensions/dicom-pdf/src/utils/displayableDocumentTypes.ts
+++ b/extensions/dicom-pdf/src/utils/displayableDocumentTypes.ts
@@ -1,0 +1,141 @@
+/**
+ * The set of encapsulated-document MIME types this extension is willing to put
+ * in front of a user, and how each one is embedded.
+ *
+ * MIMETypeOfEncapsulatedDocument is supplied by whoever produced the instance,
+ * so it is treated here as a claim to be checked rather than an instruction to
+ * be followed. A type that is not on this list is not rendered at all.
+ */
+
+/**
+ * How a document is embedded in the viewport.
+ *
+ * 'object' - <object>. The browsers' built-in PDF viewers refuse to run inside
+ *   a sandboxed browsing context: in Chrome a PDF renders under no sandbox at
+ *   all and under none of the token combinations, including the fully
+ *   permissive `allow-scripts allow-same-origin`. PDFs therefore cannot be
+ *   sandboxed, and their safety rests entirely on the type guarantee that
+ *   loadDisplayableDocument applies (canonical Blob type + signature check).
+ *
+ * 'iframe' - <iframe sandbox>. Markup types render correctly inside a sandbox,
+ *   so they get one. The default is the empty sandbox: no tokens, scripts
+ *   inert, opaque origin, no access to the viewer's storage or DOM.
+ */
+export type DocumentEmbedStrategy = 'object' | 'iframe';
+
+export type DisplayableDocumentType = {
+  /** Canonical type forced onto the Blob handed to the browser. */
+  mimeType: string;
+  strategy: DocumentEmbedStrategy;
+  /** sandbox attribute value; only meaningful for the 'iframe' strategy. */
+  sandbox?: string;
+  /** Leading bytes every payload of this type must begin with, when it has a
+   *  reliable magic number. Types without one rely on the sandbox instead. */
+  signature?: number[];
+};
+
+/**
+ * Canonical entries, keyed by canonical MIME type. Exported so downstream
+ * deployments can extend the list; adding an entry means asserting both that
+ * the browser renders that type inline and that the chosen strategy contains it.
+ */
+export const DISPLAYABLE_DOCUMENT_TYPES: Record<string, DisplayableDocumentType> = {
+  'application/pdf': {
+    mimeType: 'application/pdf',
+    strategy: 'object',
+    signature: [0x25, 0x50, 0x44, 0x46, 0x2d], // "%PDF-"
+  },
+  'text/html': {
+    mimeType: 'text/html',
+    strategy: 'iframe',
+    sandbox: '',
+  },
+  'application/xhtml+xml': {
+    mimeType: 'application/xhtml+xml',
+    strategy: 'iframe',
+    sandbox: '',
+  },
+  'text/xml': {
+    mimeType: 'text/xml',
+    strategy: 'iframe',
+    sandbox: '',
+  },
+  'application/xml': {
+    mimeType: 'application/xml',
+    strategy: 'iframe',
+    sandbox: '',
+  },
+  'text/plain': {
+    mimeType: 'text/plain',
+    strategy: 'iframe',
+    sandbox: '',
+  },
+};
+
+/**
+ * Non-standard spellings seen in real instances, folded onto their canonical
+ * entry. Accepting an alias is safe because the canonical entry decides both
+ * the Blob type and the signature the payload has to satisfy.
+ */
+export const DOCUMENT_MIME_TYPE_ALIASES: Record<string, string> = {
+  'application/html': 'text/html',
+  'application/x-pdf': 'application/pdf',
+  'application/acrobat': 'application/pdf',
+  'text/pdf': 'application/pdf',
+  'application/xhtml': 'application/xhtml+xml',
+};
+
+/**
+ * Lower-cases and strips any parameters (`text/html; charset=utf-8`).
+ */
+export function normalizeDocumentMimeType(rawMimeType?: string): string | undefined {
+  if (typeof rawMimeType !== 'string') {
+    return undefined;
+  }
+
+  const normalized = rawMimeType.split(';')[0].trim().toLowerCase();
+
+  return normalized || undefined;
+}
+
+/**
+ * Resolves a declared MIME type to its allowlist entry, or undefined when the
+ * type is not one this extension will display.
+ */
+export function getDisplayableDocumentType(
+  rawMimeType?: string
+): DisplayableDocumentType | undefined {
+  const normalized = normalizeDocumentMimeType(rawMimeType);
+
+  if (!normalized) {
+    return undefined;
+  }
+
+  const canonical = DOCUMENT_MIME_TYPE_ALIASES[normalized] ?? normalized;
+
+  return DISPLAYABLE_DOCUMENT_TYPES[canonical];
+}
+
+/**
+ * Checks a payload against its type's magic number. Types that have no reliable
+ * signature pass, since for those the sandbox rather than the content check is
+ * what contains the document.
+ */
+export function matchesDocumentSignature(
+  documentType: DisplayableDocumentType,
+  payload: ArrayBuffer
+): boolean {
+  const { signature } = documentType;
+
+  if (!signature?.length) {
+    return true;
+  }
+
+  if (payload.byteLength < signature.length) {
+    return false;
+  }
+
+  const head = new Uint8Array(payload, 0, signature.length);
+
+  return signature.every((byte, index) => head[index] === byte);
+}

--- a/extensions/dicom-pdf/src/utils/displayableDocumentTypes.ts
+++ b/extensions/dicom-pdf/src/utils/displayableDocumentTypes.ts
@@ -29,10 +29,28 @@ export type DisplayableDocumentType = {
   strategy: DocumentEmbedStrategy;
   /** sandbox attribute value; only meaningful for the 'iframe' strategy. */
   sandbox?: string;
-  /** Leading bytes every payload of this type must begin with, when it has a
-   *  reliable magic number. Types without one rely on the sandbox instead. */
+  /** Magic number every payload of this type has to carry, when the type has a
+   *  reliable one. Types without one rely on the sandbox instead. */
   signature?: number[];
+  /** How far into the payload the signature is allowed to start. Absent means
+   *  offset 0 - see PDF_SIGNATURE_SEARCH_LIMIT for why a type wants slack. */
+  signatureSearchLimit?: number;
 };
+
+/**
+ * Real files do not always put their magic number at byte 0, and readers that
+ * accept them anyway are the reason such files exist in the wild.
+ *
+ * PDF: ISO 32000-1 requires "%PDF-" at the start of the file, but Adobe's own
+ * implementation note relaxes this to anywhere within the first 1024 bytes, and
+ * every mainstream reader follows suit. Producers that write a UTF-8 BOM, or
+ * that prepend junk before the header, therefore produce files that open
+ * everywhere except here. Matching the 1024-byte allowance keeps the check
+ * doing its actual job - catching a payload that is not a PDF at all, which is
+ * how a document declared as PDF but containing markup gets rejected - without
+ * failing valid documents over leading bytes the renderer will skip anyway.
+ */
+const PDF_SIGNATURE_SEARCH_LIMIT = 1024;
 
 /**
  * Canonical entries, keyed by canonical MIME type. Exported so downstream
@@ -44,6 +62,7 @@ export const DISPLAYABLE_DOCUMENT_TYPES: Record<string, DisplayableDocumentType>
     mimeType: 'application/pdf',
     strategy: 'object',
     signature: [0x25, 0x50, 0x44, 0x46, 0x2d], // "%PDF-"
+    signatureSearchLimit: PDF_SIGNATURE_SEARCH_LIMIT,
   },
   'text/html': {
     mimeType: 'text/html',
@@ -117,15 +136,16 @@ export function getDisplayableDocumentType(
 }
 
 /**
- * Checks a payload against its type's magic number. Types that have no reliable
- * signature pass, since for those the sandbox rather than the content check is
- * what contains the document.
+ * Checks a payload against its type's magic number, allowing the signature to
+ * start anywhere within `signatureSearchLimit` bytes of the payload. Types that
+ * have no reliable signature pass, since for those the sandbox rather than the
+ * content check is what contains the document.
  */
 export function matchesDocumentSignature(
   documentType: DisplayableDocumentType,
   payload: ArrayBuffer
 ): boolean {
-  const { signature } = documentType;
+  const { signature, signatureSearchLimit = 0 } = documentType;
 
   if (!signature?.length) {
     return true;
@@ -135,7 +155,16 @@ export function matchesDocumentSignature(
     return false;
   }
 
-  const head = new Uint8Array(payload, 0, signature.length);
+  // Only the window the signature could still start in needs reading, and it is
+  // bounded, so an oversized document costs the same as a small one.
+  const lastStart = Math.min(signatureSearchLimit, payload.byteLength - signature.length);
+  const head = new Uint8Array(payload, 0, lastStart + signature.length);
 
-  return signature.every((byte, index) => head[index] === byte);
+  for (let start = 0; start <= lastStart; start++) {
+    if (signature.every((byte, index) => head[start + index] === byte)) {
+      return true;
+    }
+  }
+
+  return false;
 }

--- a/extensions/dicom-pdf/src/utils/loadDisplayableDocument.test.ts
+++ b/extensions/dicom-pdf/src/utils/loadDisplayableDocument.test.ts
@@ -3,17 +3,22 @@ import { loadDisplayableDocument } from './loadDisplayableDocument';
 const PDF_BYTES = new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x34]);
 const HTML_BYTES = new Uint8Array([0x3c, 0x68, 0x74, 0x6d, 0x6c, 0x3e]);
 
-const originalFetch = global.fetch;
+const toBase64 = (bytes: Uint8Array) => Buffer.from(bytes).toString('base64');
+
+/** An instance whose EncapsulatedDocument carries inline base64 content. */
+const inlineInstance = (bytes: Uint8Array) => ({
+  EncapsulatedDocument: { vr: 'OB', InlineBinary: toBase64(bytes) },
+});
+
+/** An instance whose EncapsulatedDocument is fetched through the data source. */
+const bulkDataInstance = (bytes: Uint8Array) => {
+  const value: Record<string, unknown> = { vr: 'OB', BulkDataURI: 'http://pacs.example/bulk/1' };
+  value.retrieveBulkData = jest.fn().mockResolvedValue(bytes.buffer);
+  return { EncapsulatedDocument: value };
+};
+
 const originalCreateObjectURL = URL.createObjectURL;
 const originalRevokeObjectURL = URL.revokeObjectURL;
-
-const mockFetch = (bytes: Uint8Array, ok = true, status = 200) => {
-  global.fetch = jest.fn().mockResolvedValue({
-    ok,
-    status,
-    arrayBuffer: jest.fn().mockResolvedValue(bytes.buffer),
-  }) as unknown as typeof fetch;
-};
 
 /** Captures the Blob handed to createObjectURL so its type can be asserted. */
 let createdBlobs: Blob[] = [];
@@ -29,31 +34,66 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  global.fetch = originalFetch;
   URL.createObjectURL = originalCreateObjectURL;
   URL.revokeObjectURL = originalRevokeObjectURL;
   jest.restoreAllMocks();
 });
 
 describe('loadDisplayableDocument', () => {
-  it('re-wraps the payload in a Blob of the canonical type', async () => {
-    mockFetch(PDF_BYTES);
+  it('uses inline content when the metadata carries it', async () => {
+    const instance = inlineInstance(PDF_BYTES);
 
-    const result = await loadDisplayableDocument({
-      url: 'http://pacs.example/doc',
-      mimeType: 'application/pdf',
-    });
+    const result = await loadDisplayableDocument({ instance, mimeType: 'application/pdf' });
 
     expect(result.ok).toBe(true);
     expect(createdBlobs).toHaveLength(1);
     expect(createdBlobs[0].type).toBe('application/pdf');
   });
 
-  it('ignores the declared spelling and uses the canonical type for the Blob', async () => {
-    mockFetch(HTML_BYTES);
+  it('uses inline content that the parser already decoded', async () => {
+    const instance = { EncapsulatedDocument: [PDF_BYTES.buffer] };
 
+    const result = await loadDisplayableDocument({ instance, mimeType: 'application/pdf' });
+
+    expect(result.ok).toBe(true);
+    expect(createdBlobs[0].type).toBe('application/pdf');
+  });
+
+  it('falls back to the data source bulkdata retrieve', async () => {
+    const instance = bulkDataInstance(PDF_BYTES);
+
+    const result = await loadDisplayableDocument({ instance, mimeType: 'application/pdf' });
+
+    expect(result.ok).toBe(true);
+    expect(instance.EncapsulatedDocument.retrieveBulkData).toHaveBeenCalledWith({
+      mediaType: 'application/pdf',
+    });
+  });
+
+  it('prefers the buffer retrieveBulkData already cached on the value', async () => {
+    const instance = bulkDataInstance(PDF_BYTES);
+    instance.EncapsulatedDocument.Value = PDF_BYTES.buffer;
+
+    const result = await loadDisplayableDocument({ instance, mimeType: 'application/pdf' });
+
+    expect(result.ok).toBe(true);
+    expect(instance.EncapsulatedDocument.retrieveBulkData).not.toHaveBeenCalled();
+  });
+
+  it('requests the canonical media type, not the declared spelling', async () => {
+    const instance = bulkDataInstance(HTML_BYTES);
+
+    await loadDisplayableDocument({ instance, mimeType: 'application/html' });
+
+    expect(instance.EncapsulatedDocument.retrieveBulkData).toHaveBeenCalledWith({
+      mediaType: 'text/html',
+    });
+    expect(createdBlobs[0].type).toBe('text/html');
+  });
+
+  it('ignores the declared spelling and uses the canonical type for the Blob', async () => {
     const result = await loadDisplayableDocument({
-      url: 'http://pacs.example/doc',
+      instance: inlineInstance(HTML_BYTES),
       mimeType: 'application/html',
     });
 
@@ -66,11 +106,11 @@ describe('loadDisplayableDocument', () => {
     }
   });
 
-  it('refuses a type that is not on the allowlist without fetching', async () => {
-    mockFetch(PDF_BYTES);
+  it('refuses a type that is not on the allowlist without retrieving', async () => {
+    const instance = bulkDataInstance(PDF_BYTES);
 
     const result = await loadDisplayableDocument({
-      url: 'http://pacs.example/doc',
+      instance,
       mimeType: 'application/octet-stream',
     });
 
@@ -79,14 +119,12 @@ describe('loadDisplayableDocument', () => {
       reason: 'unsupported-type',
       mimeType: 'application/octet-stream',
     });
-    expect(global.fetch).not.toHaveBeenCalled();
+    expect(instance.EncapsulatedDocument.retrieveBulkData).not.toHaveBeenCalled();
   });
 
   it('refuses html content that claims to be a pdf', async () => {
-    mockFetch(HTML_BYTES);
-
     const result = await loadDisplayableDocument({
-      url: 'http://pacs.example/doc',
+      instance: inlineInstance(HTML_BYTES),
       mimeType: 'application/pdf',
     });
 
@@ -99,45 +137,52 @@ describe('loadDisplayableDocument', () => {
   });
 
   it('reports a failed retrieve', async () => {
-    mockFetch(PDF_BYTES, false, 404);
+    const instance = bulkDataInstance(PDF_BYTES);
+    instance.EncapsulatedDocument.retrieveBulkData = jest.fn().mockRejectedValue(new Error('boom'));
 
-    const result = await loadDisplayableDocument({
-      url: 'http://pacs.example/doc',
-      mimeType: 'application/pdf',
-    });
+    const result = await loadDisplayableDocument({ instance, mimeType: 'application/pdf' });
 
-    expect(result).toEqual({ ok: false, reason: 'fetch-failed' });
+    expect(result).toEqual({ ok: false, reason: 'retrieve-failed' });
   });
 
-  it('reports a missing url without fetching', async () => {
-    mockFetch(PDF_BYTES);
+  it('reports an empty payload as a failed retrieve', async () => {
+    const instance = bulkDataInstance(new Uint8Array([]));
 
-    const result = await loadDisplayableDocument({ url: undefined, mimeType: 'application/pdf' });
+    const result = await loadDisplayableDocument({ instance, mimeType: 'application/pdf' });
 
-    expect(result).toEqual({ ok: false, reason: 'fetch-failed' });
-    expect(global.fetch).not.toHaveBeenCalled();
+    expect(result).toEqual({ ok: false, reason: 'retrieve-failed' });
   });
 
-  it('reports an aborted load and revokes nothing', async () => {
-    mockFetch(PDF_BYTES);
+  it('reports a value with no inline content and no bulkdata retrieve', async () => {
+    const instance = { EncapsulatedDocument: { vr: 'OB' } };
+
+    const result = await loadDisplayableDocument({ instance, mimeType: 'application/pdf' });
+
+    expect(result).toEqual({ ok: false, reason: 'retrieve-failed' });
+  });
+
+  it('reports a missing tag without retrieving', async () => {
+    const result = await loadDisplayableDocument({ instance: {}, mimeType: 'application/pdf' });
+
+    expect(result).toEqual({ ok: false, reason: 'retrieve-failed' });
+  });
+
+  it('reports an aborted load and creates no object url', async () => {
     const controller = new AbortController();
     controller.abort();
 
-    const result = await loadDisplayableDocument({
-      url: 'http://pacs.example/doc',
-      mimeType: 'application/pdf',
-      signal: controller.signal,
-    });
+    const result = await loadDisplayableDocument(
+      { instance: inlineInstance(PDF_BYTES), mimeType: 'application/pdf' },
+      { signal: controller.signal }
+    );
 
     expect(result).toEqual({ ok: false, reason: 'aborted' });
     expect(URL.createObjectURL).not.toHaveBeenCalled();
   });
 
   it('revokes only once however many times revoke is called', async () => {
-    mockFetch(PDF_BYTES);
-
     const result = await loadDisplayableDocument({
-      url: 'http://pacs.example/doc',
+      instance: inlineInstance(PDF_BYTES),
       mimeType: 'application/pdf',
     });
 

--- a/extensions/dicom-pdf/src/utils/loadDisplayableDocument.test.ts
+++ b/extensions/dicom-pdf/src/utils/loadDisplayableDocument.test.ts
@@ -1,0 +1,153 @@
+import { loadDisplayableDocument } from './loadDisplayableDocument';
+
+const PDF_BYTES = new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x34]);
+const HTML_BYTES = new Uint8Array([0x3c, 0x68, 0x74, 0x6d, 0x6c, 0x3e]);
+
+const originalFetch = global.fetch;
+const originalCreateObjectURL = URL.createObjectURL;
+const originalRevokeObjectURL = URL.revokeObjectURL;
+
+const mockFetch = (bytes: Uint8Array, ok = true, status = 200) => {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok,
+    status,
+    arrayBuffer: jest.fn().mockResolvedValue(bytes.buffer),
+  }) as unknown as typeof fetch;
+};
+
+/** Captures the Blob handed to createObjectURL so its type can be asserted. */
+let createdBlobs: Blob[] = [];
+
+beforeEach(() => {
+  createdBlobs = [];
+  URL.createObjectURL = jest.fn((blob: Blob) => {
+    createdBlobs.push(blob);
+    return `blob:mock/${createdBlobs.length}`;
+  }) as unknown as typeof URL.createObjectURL;
+  URL.revokeObjectURL = jest.fn() as unknown as typeof URL.revokeObjectURL;
+  jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  URL.createObjectURL = originalCreateObjectURL;
+  URL.revokeObjectURL = originalRevokeObjectURL;
+  jest.restoreAllMocks();
+});
+
+describe('loadDisplayableDocument', () => {
+  it('re-wraps the payload in a Blob of the canonical type', async () => {
+    mockFetch(PDF_BYTES);
+
+    const result = await loadDisplayableDocument({
+      url: 'http://pacs.example/doc',
+      mimeType: 'application/pdf',
+    });
+
+    expect(result.ok).toBe(true);
+    expect(createdBlobs).toHaveLength(1);
+    expect(createdBlobs[0].type).toBe('application/pdf');
+  });
+
+  it('ignores the declared spelling and uses the canonical type for the Blob', async () => {
+    mockFetch(HTML_BYTES);
+
+    const result = await loadDisplayableDocument({
+      url: 'http://pacs.example/doc',
+      mimeType: 'application/html',
+    });
+
+    expect(result).toMatchObject({ ok: true });
+    expect(createdBlobs[0].type).toBe('text/html');
+
+    if (result.ok) {
+      expect(result.documentType.strategy).toBe('iframe');
+      expect(result.documentType.sandbox).toBe('');
+    }
+  });
+
+  it('refuses a type that is not on the allowlist without fetching', async () => {
+    mockFetch(PDF_BYTES);
+
+    const result = await loadDisplayableDocument({
+      url: 'http://pacs.example/doc',
+      mimeType: 'application/octet-stream',
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      reason: 'unsupported-type',
+      mimeType: 'application/octet-stream',
+    });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('refuses html content that claims to be a pdf', async () => {
+    mockFetch(HTML_BYTES);
+
+    const result = await loadDisplayableDocument({
+      url: 'http://pacs.example/doc',
+      mimeType: 'application/pdf',
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      reason: 'signature-mismatch',
+      mimeType: 'application/pdf',
+    });
+    expect(URL.createObjectURL).not.toHaveBeenCalled();
+  });
+
+  it('reports a failed retrieve', async () => {
+    mockFetch(PDF_BYTES, false, 404);
+
+    const result = await loadDisplayableDocument({
+      url: 'http://pacs.example/doc',
+      mimeType: 'application/pdf',
+    });
+
+    expect(result).toEqual({ ok: false, reason: 'fetch-failed' });
+  });
+
+  it('reports a missing url without fetching', async () => {
+    mockFetch(PDF_BYTES);
+
+    const result = await loadDisplayableDocument({ url: undefined, mimeType: 'application/pdf' });
+
+    expect(result).toEqual({ ok: false, reason: 'fetch-failed' });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('reports an aborted load and revokes nothing', async () => {
+    mockFetch(PDF_BYTES);
+    const controller = new AbortController();
+    controller.abort();
+
+    const result = await loadDisplayableDocument({
+      url: 'http://pacs.example/doc',
+      mimeType: 'application/pdf',
+      signal: controller.signal,
+    });
+
+    expect(result).toEqual({ ok: false, reason: 'aborted' });
+    expect(URL.createObjectURL).not.toHaveBeenCalled();
+  });
+
+  it('revokes only once however many times revoke is called', async () => {
+    mockFetch(PDF_BYTES);
+
+    const result = await loadDisplayableDocument({
+      url: 'http://pacs.example/doc',
+      mimeType: 'application/pdf',
+    });
+
+    if (!result.ok) {
+      throw new Error('expected the document to load');
+    }
+
+    result.revoke();
+    result.revoke();
+
+    expect(URL.revokeObjectURL).toHaveBeenCalledTimes(1);
+  });
+});

--- a/extensions/dicom-pdf/src/utils/loadDisplayableDocument.ts
+++ b/extensions/dicom-pdf/src/utils/loadDisplayableDocument.ts
@@ -1,0 +1,115 @@
+import {
+  DisplayableDocumentType,
+  getDisplayableDocumentType,
+  matchesDocumentSignature,
+} from './displayableDocumentTypes';
+
+export type DocumentLoadFailureReason =
+  | 'unsupported-type'
+  | 'signature-mismatch'
+  | 'fetch-failed'
+  | 'aborted';
+
+export type LoadedDocument =
+  | {
+      ok: true;
+      url: string;
+      documentType: DisplayableDocumentType;
+      revoke: () => void;
+    }
+  | {
+      ok: false;
+      reason: DocumentLoadFailureReason;
+      mimeType?: string;
+    };
+
+type LoadDisplayableDocumentParams = {
+  url?: string | null;
+  mimeType?: string;
+  signal?: AbortSignal;
+};
+
+/**
+ * Resolves a document URL into something safe to embed.
+ *
+ * The payload is always read into memory and re-wrapped in a Blob whose type
+ * this module chooses from the allowlist. That is the type guarantee: after
+ * this point neither MIMETypeOfEncapsulatedDocument nor the origin server's
+ * Content-Type has any say in how the browser interprets the bytes, so a
+ * document cannot be steered into being parsed as something it is not.
+ *
+ * Reading the whole payload is also what makes the signature check possible,
+ * and it removes the origin server's framing headers from the picture. The
+ * cost is that documents no longer stream or range-request; encapsulated
+ * reports are small enough that this is a fair trade.
+ */
+export async function loadDisplayableDocument({
+  url,
+  mimeType,
+  signal,
+}: LoadDisplayableDocumentParams): Promise<LoadedDocument> {
+  const documentType = getDisplayableDocumentType(mimeType);
+
+  if (!documentType) {
+    return { ok: false, reason: 'unsupported-type', mimeType };
+  }
+
+  if (!url) {
+    return { ok: false, reason: 'fetch-failed' };
+  }
+
+  if (signal?.aborted) {
+    return { ok: false, reason: 'aborted' };
+  }
+
+  let payload: ArrayBuffer;
+
+  try {
+    const response = await fetch(url, { signal });
+
+    if (!response.ok) {
+      console.warn(`document fetch failed with status ${response.status}`);
+      return { ok: false, reason: 'fetch-failed' };
+    }
+
+    payload = await response.arrayBuffer();
+  } catch (error) {
+    if ((error as { name?: string })?.name === 'AbortError') {
+      return { ok: false, reason: 'aborted' };
+    }
+
+    console.warn('document fetch failed', error);
+    return { ok: false, reason: 'fetch-failed' };
+  }
+
+  if (!matchesDocumentSignature(documentType, payload)) {
+    return { ok: false, reason: 'signature-mismatch', mimeType: documentType.mimeType };
+  }
+
+  const objectUrl = URL.createObjectURL(new Blob([payload], { type: documentType.mimeType }));
+
+  if (signal?.aborted) {
+    URL.revokeObjectURL(objectUrl);
+    return { ok: false, reason: 'aborted' };
+  }
+
+  return {
+    ok: true,
+    url: objectUrl,
+    documentType,
+    revoke: createRevokeOnce(objectUrl),
+  };
+}
+
+function createRevokeOnce(objectUrl: string) {
+  let revoked = false;
+
+  return () => {
+    if (revoked) {
+      return;
+    }
+
+    URL.revokeObjectURL(objectUrl);
+    revoked = true;
+  };
+}

--- a/extensions/dicom-pdf/src/utils/loadDisplayableDocument.ts
+++ b/extensions/dicom-pdf/src/utils/loadDisplayableDocument.ts
@@ -7,7 +7,7 @@ import {
 export type DocumentLoadFailureReason =
   | 'unsupported-type'
   | 'signature-mismatch'
-  | 'fetch-failed'
+  | 'retrieve-failed'
   | 'aborted';
 
 export type LoadedDocument =
@@ -24,62 +24,66 @@ export type LoadedDocument =
     };
 
 type LoadDisplayableDocumentParams = {
-  url?: string | null;
+  instance?: Record<string, unknown>;
   mimeType?: string;
+  tag?: string;
+};
+
+type LoadDisplayableDocumentOptions = {
   signal?: AbortSignal;
 };
 
 /**
- * Resolves a document URL into something safe to embed.
+ * Resolves an encapsulated document into something safe to embed.
  *
- * The payload is always read into memory and re-wrapped in a Blob whose type
- * this module chooses from the allowlist. That is the type guarantee: after
- * this point neither MIMETypeOfEncapsulatedDocument nor the origin server's
- * Content-Type has any say in how the browser interprets the bytes, so a
- * document cannot be steered into being parsed as something it is not.
+ * The payload comes from the instance the same way every other bulkdata value
+ * does: inline content when the metadata carries it, otherwise the data
+ * source's own `retrieveBulkData`, which the data source binds onto the value
+ * and which caches the resolved buffer on `value.Value`. This is the path the
+ * video display sets take, so authentication, bulkdata URI resolution and
+ * caching all behave identically here.
  *
- * Reading the whole payload is also what makes the signature check possible,
- * and it removes the origin server's framing headers from the picture. The
- * cost is that documents no longer stream or range-request; encapsulated
- * reports are small enough that this is a fair trade.
+ * The bytes are then wrapped in a Blob whose type comes from the allowlist
+ * rather than from the instance. That is the type guarantee: after this point
+ * neither MIMETypeOfEncapsulatedDocument nor the origin server's Content-Type
+ * has any say in how the browser interprets the payload, so a document cannot
+ * be steered into being parsed as something it is not.
  */
-export async function loadDisplayableDocument({
-  url,
-  mimeType,
-  signal,
-}: LoadDisplayableDocumentParams): Promise<LoadedDocument> {
+export async function loadDisplayableDocument(
+  { instance, mimeType, tag = 'EncapsulatedDocument' }: LoadDisplayableDocumentParams,
+  { signal }: LoadDisplayableDocumentOptions = {}
+): Promise<LoadedDocument> {
   const documentType = getDisplayableDocumentType(mimeType);
 
   if (!documentType) {
     return { ok: false, reason: 'unsupported-type', mimeType };
   }
 
-  if (!url) {
-    return { ok: false, reason: 'fetch-failed' };
+  const value = instance?.[tag];
+
+  if (!value) {
+    return { ok: false, reason: 'retrieve-failed' };
   }
 
   if (signal?.aborted) {
     return { ok: false, reason: 'aborted' };
   }
 
-  let payload: ArrayBuffer;
+  let payload: ArrayBuffer | undefined;
 
   try {
-    const response = await fetch(url, { signal });
-
-    if (!response.ok) {
-      console.warn(`document fetch failed with status ${response.status}`);
-      return { ok: false, reason: 'fetch-failed' };
-    }
-
-    payload = await response.arrayBuffer();
+    payload = await readDocumentBytes(value, documentType.mimeType);
   } catch (error) {
-    if ((error as { name?: string })?.name === 'AbortError') {
-      return { ok: false, reason: 'aborted' };
-    }
+    console.warn('Failed to retrieve encapsulated document', error);
+    return { ok: false, reason: 'retrieve-failed' };
+  }
 
-    console.warn('document fetch failed', error);
-    return { ok: false, reason: 'fetch-failed' };
+  if (!payload?.byteLength) {
+    return { ok: false, reason: 'retrieve-failed' };
+  }
+
+  if (signal?.aborted) {
+    return { ok: false, reason: 'aborted' };
   }
 
   if (!matchesDocumentSignature(documentType, payload)) {
@@ -99,6 +103,72 @@ export async function loadDisplayableDocument({
     documentType,
     revoke: createRevokeOnce(objectUrl),
   };
+}
+
+/**
+ * Reads the document bytes off a naturalized bulkdata value, preferring
+ * whatever is already in hand. Mirrors the resolution order in
+ * `resolveBulkDataTags`, which is how the rest of the app reads bulkdata.
+ */
+async function readDocumentBytes(value, mimeType: string): Promise<ArrayBuffer | undefined> {
+  // Inline content delivered as base64 in the metadata.
+  if (value.InlineBinary) {
+    return base64ToArrayBuffer(value.InlineBinary);
+  }
+
+  // Inline content that the parser already decoded, e.g. `[ArrayBuffer]`.
+  if (Array.isArray(value)) {
+    return toArrayBuffer(value[0]);
+  }
+
+  // retrieveBulkData caches the resolved buffer here, so prefer it over
+  // re-requesting the payload.
+  if (value.Value) {
+    return toArrayBuffer(Array.isArray(value.Value) ? value.Value[0] : value.Value);
+  }
+
+  // Otherwise ask the data source, exactly as any other bulkdata value does.
+  if (typeof value.retrieveBulkData === 'function') {
+    const retrieved = await value.retrieveBulkData({ mediaType: mimeType });
+    return toArrayBuffer(retrieved);
+  }
+
+  return undefined;
+}
+
+function toArrayBuffer(raw): ArrayBuffer | undefined {
+  // Check views first: ArrayBuffer.isView is realm-agnostic.
+  if (ArrayBuffer.isView(raw)) {
+    const view = raw as ArrayBufferView;
+    return view.buffer.slice(view.byteOffset, view.byteOffset + view.byteLength) as ArrayBuffer;
+  }
+
+  // `instanceof ArrayBuffer` is realm-specific, so fall back to a tag check so
+  // that buffers created in another realm (workers, tests) are still handled.
+  if (
+    raw instanceof ArrayBuffer ||
+    Object.prototype.toString.call(raw) === '[object ArrayBuffer]'
+  ) {
+    return raw as ArrayBuffer;
+  }
+
+  return undefined;
+}
+
+/**
+ * Decodes base64 inline content to bytes. `utils.b64toBlob` produces a Blob,
+ * but the signature check needs the bytes before a Blob is created - and the
+ * Blob has to be built from the allowlist type, not from a declared one.
+ */
+function base64ToArrayBuffer(base64: string): ArrayBuffer {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+
+  return bytes.buffer;
 }
 
 function createRevokeOnce(objectUrl: string) {

--- a/extensions/dicom-pdf/src/viewports/OHIFCornerstonePdfViewport.tsx
+++ b/extensions/dicom-pdf/src/viewports/OHIFCornerstonePdfViewport.tsx
@@ -1,10 +1,26 @@
 import React, { useEffect, useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { useViewportRef } from '@ohif/core';
+import { DisplayableDocumentType } from '../utils/displayableDocumentTypes';
+import {
+  DocumentLoadFailureReason,
+  loadDisplayableDocument,
+} from '../utils/loadDisplayableDocument';
 import './OHIFCornerstonePdfViewport.css';
 
+const FAILURE_MESSAGES: Record<DocumentLoadFailureReason, string> = {
+  'unsupported-type': 'This document type cannot be displayed',
+  'signature-mismatch': 'Document content does not match its declared type',
+  'fetch-failed': 'Unable to retrieve this document',
+  aborted: 'Loading document…',
+};
+
 function OHIFCornerstonePdfViewport({ displaySets, viewportId = 'pdf-viewport' }) {
-  const [url, setUrl] = useState(null);
+  const [embeddedDocument, setEmbeddedDocument] = useState<{
+    url: string;
+    documentType: DisplayableDocumentType;
+  } | null>(null);
+  const [failure, setFailure] = useState<DocumentLoadFailureReason | null>(null);
   const viewportElementRef = useRef(null);
   const viewportRef = useViewportRef(viewportId);
 
@@ -32,8 +48,7 @@ function OHIFCornerstonePdfViewport({ displaySets, viewportId = 'pdf-viewport' }
     );
   }
 
-  const { renderedUrl } = displaySets[0];
-  const { getRenderedUrl } = displaySets[0];
+  const { renderedUrl, getRenderedUrl, mimeType, label } = displaySets[0];
 
   useEffect(() => {
     let isCancelled = false;
@@ -41,26 +56,53 @@ function OHIFCornerstonePdfViewport({ displaySets, viewportId = 'pdf-viewport' }
     const abortController = new AbortController();
 
     const load = async () => {
+      let retrieved;
+
       try {
-        const result = getRenderedUrl
+        retrieved = getRenderedUrl
           ? await getRenderedUrl({ signal: abortController.signal })
           : { url: await renderedUrl };
-
-        if (isCancelled) {
-          result?.revoke?.();
-          return;
-        }
-
-        revokeUrl = result?.revoke;
-        setUrl(result?.url || null);
       } catch (error) {
-        console.warn('Failed to load PDF', error);
-        if (!isCancelled) {
-          setUrl(null);
+        console.warn('Failed to retrieve document', error);
+        retrieved = { url: null };
+      }
+
+      if (isCancelled) {
+        retrieved?.revoke?.();
+        return;
+      }
+
+      // The retrieved URL may be an origin-server URL or a Blob built from the
+      // declared MIME type; either way its type is not trustworthy, so it is
+      // only ever used as a source of bytes for loadDisplayableDocument.
+      const result = await loadDisplayableDocument({
+        url: retrieved?.url,
+        mimeType,
+        signal: abortController.signal,
+      });
+
+      retrieved?.revoke?.();
+
+      if (isCancelled) {
+        if (result.ok) {
+          result.revoke();
         }
         return;
       }
+
+      if (!result.ok) {
+        setEmbeddedDocument(null);
+        setFailure(result.reason);
+        return;
+      }
+
+      revokeUrl = result.revoke;
+      setEmbeddedDocument({ url: result.url, documentType: result.documentType });
+      setFailure(null);
     };
+
+    setEmbeddedDocument(null);
+    setFailure(null);
 
     load();
 
@@ -69,7 +111,7 @@ function OHIFCornerstonePdfViewport({ displaySets, viewportId = 'pdf-viewport' }
       abortController.abort();
       revokeUrl?.();
     };
-  }, [renderedUrl, getRenderedUrl]);
+  }, [renderedUrl, getRenderedUrl, mimeType]);
 
   return (
     <div
@@ -83,14 +125,47 @@ function OHIFCornerstonePdfViewport({ displaySets, viewportId = 'pdf-viewport' }
       }}
       data-viewport-id={viewportId}
     >
+      {embeddedDocument ? (
+        renderDocument(embeddedDocument, style, label)
+      ) : (
+        <div className="flex h-full w-full items-center justify-center">
+          {failure ? FAILURE_MESSAGES[failure] : 'Loading document…'}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function renderDocument(
+  { url, documentType }: { url: string; documentType: DisplayableDocumentType },
+  style: string,
+  label?: string
+) {
+  // <object> is used only for the types the allowlist marks as un-sandboxable -
+  // in practice PDF, whose built-in browser viewer will not run in a sandboxed
+  // browsing context. The type attribute now matches the Blob type exactly,
+  // because loadDisplayableDocument set both from the same allowlist entry.
+  if (documentType.strategy === 'object') {
+    return (
       <object
         data={url}
-        type="application/pdf"
+        type={documentType.mimeType}
         className={style}
       >
-        <div>No online PDF viewer installed</div>
+        <div>No online viewer installed for {documentType.mimeType}</div>
       </object>
-    </div>
+    );
+  }
+
+  return (
+    <iframe
+      src={url}
+      title={label || 'Encapsulated document'}
+      className={`${style} border-0`}
+      sandbox={documentType.sandbox ?? ''}
+      referrerPolicy="no-referrer"
+      allow=""
+    />
   );
 }
 

--- a/extensions/dicom-pdf/src/viewports/OHIFCornerstonePdfViewport.tsx
+++ b/extensions/dicom-pdf/src/viewports/OHIFCornerstonePdfViewport.tsx
@@ -2,16 +2,13 @@ import React, { useEffect, useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { useViewportRef } from '@ohif/core';
 import { DisplayableDocumentType } from '../utils/displayableDocumentTypes';
-import {
-  DocumentLoadFailureReason,
-  loadDisplayableDocument,
-} from '../utils/loadDisplayableDocument';
+import { DocumentLoadFailureReason } from '../utils/loadDisplayableDocument';
 import './OHIFCornerstonePdfViewport.css';
 
 const FAILURE_MESSAGES: Record<DocumentLoadFailureReason, string> = {
   'unsupported-type': 'This document type cannot be displayed',
   'signature-mismatch': 'Document content does not match its declared type',
-  'fetch-failed': 'Unable to retrieve this document',
+  'retrieve-failed': 'Unable to retrieve this document',
   aborted: 'Loading document…',
 };
 
@@ -48,7 +45,7 @@ function OHIFCornerstonePdfViewport({ displaySets, viewportId = 'pdf-viewport' }
     );
   }
 
-  const { renderedUrl, getRenderedUrl, mimeType, label } = displaySets[0];
+  const { getDocument, label } = displaySets[0];
 
   useEffect(() => {
     let isCancelled = false;
@@ -56,32 +53,7 @@ function OHIFCornerstonePdfViewport({ displaySets, viewportId = 'pdf-viewport' }
     const abortController = new AbortController();
 
     const load = async () => {
-      let retrieved;
-
-      try {
-        retrieved = getRenderedUrl
-          ? await getRenderedUrl({ signal: abortController.signal })
-          : { url: await renderedUrl };
-      } catch (error) {
-        console.warn('Failed to retrieve document', error);
-        retrieved = { url: null };
-      }
-
-      if (isCancelled) {
-        retrieved?.revoke?.();
-        return;
-      }
-
-      // The retrieved URL may be an origin-server URL or a Blob built from the
-      // declared MIME type; either way its type is not trustworthy, so it is
-      // only ever used as a source of bytes for loadDisplayableDocument.
-      const result = await loadDisplayableDocument({
-        url: retrieved?.url,
-        mimeType,
-        signal: abortController.signal,
-      });
-
-      retrieved?.revoke?.();
+      const result = await getDocument({ signal: abortController.signal });
 
       if (isCancelled) {
         if (result.ok) {
@@ -111,7 +83,7 @@ function OHIFCornerstonePdfViewport({ displaySets, viewportId = 'pdf-viewport' }
       abortController.abort();
       revokeUrl?.();
     };
-  }, [renderedUrl, getRenderedUrl, mimeType]);
+  }, [getDocument]);
 
   return (
     <div

--- a/extensions/dicom-pdf/src/viewports/OHIFCornerstonePdfViewport.tsx
+++ b/extensions/dicom-pdf/src/viewports/OHIFCornerstonePdfViewport.tsx
@@ -1,15 +1,17 @@
 import React, { useEffect, useState, useRef } from 'react';
 import PropTypes from 'prop-types';
+import { useTranslation } from 'react-i18next';
 import { useViewportRef } from '@ohif/core';
 import { DisplayableDocumentType } from '../utils/displayableDocumentTypes';
 import { DocumentLoadFailureReason } from '../utils/loadDisplayableDocument';
 import './OHIFCornerstonePdfViewport.css';
 
-const FAILURE_MESSAGES: Record<DocumentLoadFailureReason, string> = {
+/** Translation keys in the EncapsulatedDocument namespace, by failure reason. */
+const FAILURE_MESSAGE_KEYS: Record<DocumentLoadFailureReason, string> = {
   'unsupported-type': 'This document type cannot be displayed',
   'signature-mismatch': 'Document content does not match its declared type',
   'retrieve-failed': 'Unable to retrieve this document',
-  aborted: 'Loading document…',
+  aborted: 'Loading document...',
 };
 
 function OHIFCornerstonePdfViewport({ displaySets, viewportId = 'pdf-viewport' }) {
@@ -20,6 +22,7 @@ function OHIFCornerstonePdfViewport({ displaySets, viewportId = 'pdf-viewport' }
   const [failure, setFailure] = useState<DocumentLoadFailureReason | null>(null);
   const viewportElementRef = useRef(null);
   const viewportRef = useViewportRef(viewportId);
+  const { t } = useTranslation('EncapsulatedDocument');
 
   useEffect(() => {
     document.body.addEventListener('drag', makePdfDropTarget);
@@ -98,10 +101,10 @@ function OHIFCornerstonePdfViewport({ displaySets, viewportId = 'pdf-viewport' }
       data-viewport-id={viewportId}
     >
       {embeddedDocument ? (
-        renderDocument(embeddedDocument, style, label)
+        renderDocument(embeddedDocument, style, t, label)
       ) : (
         <div className="flex h-full w-full items-center justify-center">
-          {failure ? FAILURE_MESSAGES[failure] : 'Loading document…'}
+          {t(failure ? FAILURE_MESSAGE_KEYS[failure] : 'Loading document...')}
         </div>
       )}
     </div>
@@ -111,6 +114,7 @@ function OHIFCornerstonePdfViewport({ displaySets, viewportId = 'pdf-viewport' }
 function renderDocument(
   { url, documentType }: { url: string; documentType: DisplayableDocumentType },
   style: string,
+  t: (key: string, options?: Record<string, unknown>) => string,
   label?: string
 ) {
   // <object> is used only for the types the allowlist marks as un-sandboxable -
@@ -124,7 +128,7 @@ function renderDocument(
         type={documentType.mimeType}
         className={style}
       >
-        <div>No online viewer installed for {documentType.mimeType}</div>
+        <div>{t('No viewer installed for {{mimeType}}', { mimeType: documentType.mimeType })}</div>
       </object>
     );
   }
@@ -132,7 +136,7 @@ function renderDocument(
   return (
     <iframe
       src={url}
-      title={label || 'Encapsulated document'}
+      title={label || t('Encapsulated document')}
       className={`${style} border-0`}
       sandbox={documentType.sandbox ?? ''}
       referrerPolicy="no-referrer"

--- a/platform/i18n/src/locales/en-US/EncapsulatedDocument.json
+++ b/platform/i18n/src/locales/en-US/EncapsulatedDocument.json
@@ -1,0 +1,8 @@
+{
+  "Loading document...": "Loading document...",
+  "This document type cannot be displayed": "This document type cannot be displayed",
+  "Document content does not match its declared type": "Document content does not match its declared type",
+  "Unable to retrieve this document": "Unable to retrieve this document",
+  "No viewer installed for {{mimeType}}": "No viewer installed for {{mimeType}}",
+  "Encapsulated document": "Encapsulated document"
+}

--- a/platform/i18n/src/locales/en-US/index.js
+++ b/platform/i18n/src/locales/en-US/index.js
@@ -33,6 +33,7 @@ import Colormaps from './Colormaps.json';
 import PanelSUV from './PanelSUV.json';
 import ROIThresholdConfiguration from './ROIThresholdConfiguration.json';
 import USAnnotationPanel from './USAnnotationPanel.json';
+import EncapsulatedDocument from './EncapsulatedDocument.json';
 
 export default {
   'en-US': {
@@ -71,5 +72,6 @@ export default {
     PanelSUV,
     ROIThresholdConfiguration,
     USAnnotationPanel,
+    EncapsulatedDocument,
   },
 };

--- a/platform/i18n/src/locales/test-LNG/EncapsulatedDocument.json
+++ b/platform/i18n/src/locales/test-LNG/EncapsulatedDocument.json
@@ -1,0 +1,8 @@
+{
+  "Loading document...": "Test Loading document...",
+  "This document type cannot be displayed": "Test This document type cannot be displayed",
+  "Document content does not match its declared type": "Test Document content does not match its declared type",
+  "Unable to retrieve this document": "Test Unable to retrieve this document",
+  "No viewer installed for {{mimeType}}": "Test No viewer installed for {{mimeType}}",
+  "Encapsulated document": "Test Encapsulated document"
+}

--- a/platform/i18n/src/locales/test-LNG/index.js
+++ b/platform/i18n/src/locales/test-LNG/index.js
@@ -35,6 +35,7 @@ import Tools from './Tools.json';
 import Hps from './Hps.json';
 import ToolbarLayoutSelector from './ToolbarLayoutSelector.json';
 import USAnnotationPanel from './USAnnotationPanel.json';
+import EncapsulatedDocument from './EncapsulatedDocument.json';
 
 export default {
   'test-LNG': {
@@ -75,5 +76,6 @@ export default {
     Hps,
     ToolbarLayoutSelector,
     USAnnotationPanel,
+    EncapsulatedDocument,
   },
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,7 +36,7 @@ overrides:
   protobufjs: 7.6.1
   tmp: 0.2.7
   shell-quote: 1.10.0
-  fast-uri@>=3.0.0 <3.1.5: 3.1.5
+  fast-uri@>=3.0.0 <3.1.6: 3.1.6
   '@babel/plugin-transform-modules-systemjs': 7.29.4
   sharp@<0.35.0: 0.35.3
   tslib: 2.8.1
@@ -57,6 +57,7 @@ overrides:
   js-yaml@>=4.0.0 <4.3.1: 4.3.1
   postcss@<8.5.26: 8.5.26
   pacote@>=11.2.7 <21.5.1: 21.5.1
+  browserslist@<4.28.7: 4.28.8
 
 importers:
 
@@ -101,7 +102,7 @@ importers:
         version: 7.29.7(@babel/core@7.29.7)
       '@babel/preset-env':
         specifier: 7.29.7
-        version: 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
       '@babel/preset-react':
         specifier: 7.29.7
         version: 7.29.7(@babel/core@7.29.7)
@@ -6732,13 +6733,8 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  baseline-browser-mapping@2.10.0:
-    resolution: {integrity: sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
-  baseline-browser-mapping@2.10.31:
-    resolution: {integrity: sha512-MujYO3eP72uvmSE0i4wltsodRfIpZATP3jvzRNRGGxgzId7aVocVJJV3nf01qnzzKFGxQVC9bpWxl5cjxTr/7Q==}
+  baseline-browser-mapping@2.11.20:
+    resolution: {integrity: sha512-H0ulySigv6icDJ1F7SjtdCD6PrhTpdYCmP0CactWy1+ekh0AFd0o1Wn5T8b+hnTmdBx19u9yhL6wvCylXMY7zw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -6837,13 +6833,8 @@ packages:
   browserify-zlib@0.2.0:
     resolution: {integrity: sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==}
 
-  browserslist@4.28.1:
-    resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
-    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
-    hasBin: true
-
-  browserslist@4.28.2:
-    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
+  browserslist@4.28.8:
+    resolution: {integrity: sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
@@ -6956,6 +6947,9 @@ packages:
 
   caniuse-lite@1.0.30001793:
     resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
+
+  caniuse-lite@1.0.30001810:
+    resolution: {integrity: sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==}
 
   caseless@0.12.0:
     resolution: {integrity: sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==}
@@ -7966,11 +7960,8 @@ packages:
     engines: {node: '>=0.10.0'}
     hasBin: true
 
-  electron-to-chromium@1.5.302:
-    resolution: {integrity: sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==}
-
-  electron-to-chromium@1.5.358:
-    resolution: {integrity: sha512-EO7tKm3QxRqTs1lSuPXzl6yRAwznehp0AH9OoMOIC+4mQzTFday8FJCO5KU6J/TFSQXEOahNq4vTKpz1jmCVOA==}
+  electron-to-chromium@1.5.417:
+    resolution: {integrity: sha512-4T+DTDWuMPM4aHlHwWdAVCVWwp7LDilnhzkj+c/Lbj91XSQrLuOmZSLtS9Q4iIqjlPUbPOnC624zDVVHCHaolQ==}
 
   elegant-spinner@1.0.1:
     resolution: {integrity: sha512-B+ZM+RXvRqQaAmkMlO/oSe5nMUOaUnyfGYCEHoR8wrXsZR2mA0XVibsxV1bvTwxdRWah1PkQqso2EzhILGHtEQ==}
@@ -8264,8 +8255,8 @@ packages:
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.6:
+    resolution: {integrity: sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -10504,11 +10495,9 @@ packages:
     resolution: {integrity: sha512-RM5oyBy45cLEoHqCeh+MNuFAxO0vTFBLskvQbOKnEE7YTTSN4tbN8QWDIPQ6L+WvKsB/qLEGpYe2ZZ9d4W9OIQ==}
     engines: {node: '>=8'}
 
-  node-releases@2.0.27:
-    resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
-
-  node-releases@2.0.44:
-    resolution: {integrity: sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==}
+  node-releases@2.0.54:
+    resolution: {integrity: sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==}
+    engines: {node: '>=18'}
 
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
@@ -13380,11 +13369,11 @@ packages:
     resolution: {integrity: sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==}
     engines: {node: '>=4'}
 
-  update-browserslist-db@1.2.3:
-    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+  update-browserslist-db@1.3.2:
+    resolution: {integrity: sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==}
     hasBin: true
     peerDependencies:
-      browserslist: '>= 4.21.0'
+      browserslist: 4.28.8
 
   update-notifier@6.0.2:
     resolution: {integrity: sha512-EDxhTEVPZZRLWYcJ4ZXjGFN0oP7qYvbXWzEgRm/Yql4dHX5wDbvh89YHP6PK1lzZJYrMtXUuZZz8XGK+U6U1og==}
@@ -14097,7 +14086,7 @@ snapshots:
       '@babel/helpers': 7.29.2
       '@babel/parser': 7.29.3
       '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0(supports-color@8.1.1)
+      '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
       convert-source-map: 2.0.0
       debug: 4.4.3(supports-color@8.1.1)
@@ -14117,7 +14106,7 @@ snapshots:
       '@babel/helpers': 7.29.2
       '@babel/parser': 7.29.3
       '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0(supports-color@8.1.1)
+      '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
       convert-source-map: 2.0.0
       debug: 4.4.3(supports-color@8.1.1)
@@ -14175,7 +14164,7 @@ snapshots:
     dependencies:
       '@babel/compat-data': 7.29.3
       '@babel/helper-validator-option': 7.27.1
-      browserslist: 4.28.2
+      browserslist: 4.28.8
       lru-cache: 5.1.1
       semver: 6.3.1
 
@@ -14183,7 +14172,7 @@ snapshots:
     dependencies:
       '@babel/compat-data': 7.29.7
       '@babel/helper-validator-option': 7.29.7
-      browserslist: 4.28.2
+      browserslist: 4.28.8
       lru-cache: 5.1.1
       semver: 6.3.1
 
@@ -15311,7 +15300,7 @@ snapshots:
       '@babel/helper-module-transforms': 7.28.6(@babel/core@7.28.0(supports-color@8.1.1))
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.29.0(supports-color@8.1.1)
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -15321,17 +15310,17 @@ snapshots:
       '@babel/helper-module-transforms': 7.28.6(@babel/core@7.28.0)
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.29.0(supports-color@8.1.1)
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-systemjs@7.29.4(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/plugin-transform-modules-systemjs@7.29.4(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.7(supports-color@8.1.1))
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.29.0(supports-color@8.1.1)
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -16108,7 +16097,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
       '@babel/compat-data': 7.29.7
       '@babel/core': 7.29.7(supports-color@8.1.1)
@@ -16150,7 +16139,7 @@ snapshots:
       '@babel/plugin-transform-member-expression-literals': 7.29.7(@babel/core@7.29.7)
       '@babel/plugin-transform-modules-amd': 7.29.7(@babel/core@7.29.7)
       '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-transform-modules-systemjs': 7.29.4(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-modules-systemjs': 7.29.4(@babel/core@7.29.7(supports-color@8.1.1))
       '@babel/plugin-transform-modules-umd': 7.29.7(@babel/core@7.29.7)
       '@babel/plugin-transform-named-capturing-groups-regex': 7.29.7(@babel/core@7.29.7)
       '@babel/plugin-transform-new-target': 7.29.7(@babel/core@7.29.7)
@@ -16227,7 +16216,7 @@ snapshots:
       '@babel/plugin-transform-member-expression-literals': 7.29.7(@babel/core@7.29.7)
       '@babel/plugin-transform-modules-amd': 7.29.7(@babel/core@7.29.7)
       '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-transform-modules-systemjs': 7.29.4(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-modules-systemjs': 7.29.4(@babel/core@7.29.7(supports-color@8.1.1))
       '@babel/plugin-transform-modules-umd': 7.29.7(@babel/core@7.29.7)
       '@babel/plugin-transform-named-capturing-groups-regex': 7.29.7(@babel/core@7.29.7)
       '@babel/plugin-transform-new-target': 7.29.7(@babel/core@7.29.7)
@@ -16377,7 +16366,7 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
 
-  '@babel/traverse@7.29.0(supports-color@8.1.1)':
+  '@babel/traverse@7.29.0':
     dependencies:
       '@babel/code-frame': 7.29.0
       '@babel/generator': 7.29.7
@@ -17105,7 +17094,7 @@ snapshots:
       '@rspack/core': 1.7.11(@swc/helpers@0.5.21)
       '@swc/core': 1.15.13(@swc/helpers@0.5.21)
       '@swc/html': 1.15.13
-      browserslist: 4.28.2
+      browserslist: 4.28.8
       lightningcss: 1.31.1
       semver: 7.8.0
       swc-loader: 0.2.7(@swc/core@1.15.13(@swc/helpers@0.5.21))(webpack@5.105.0(@swc/core@1.15.13(@swc/helpers@0.5.21)))
@@ -20448,7 +20437,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.6
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -20627,7 +20616,7 @@ snapshots:
 
   autoprefixer@10.4.21(postcss@8.5.26):
     dependencies:
-      browserslist: 4.28.1
+      browserslist: 4.28.8
       caniuse-lite: 1.0.30001774
       fraction.js: 4.3.7
       normalize-range: 0.1.2
@@ -20637,7 +20626,7 @@ snapshots:
 
   autoprefixer@10.4.27(postcss@8.5.26):
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.8
       caniuse-lite: 1.0.30001793
       fraction.js: 5.3.4
       picocolors: 1.1.1
@@ -20881,9 +20870,7 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  baseline-browser-mapping@2.10.0: {}
-
-  baseline-browser-mapping@2.10.31: {}
+  baseline-browser-mapping@2.11.20: {}
 
   batch@0.6.1: {}
 
@@ -21031,21 +21018,13 @@ snapshots:
     dependencies:
       pako: 1.0.11
 
-  browserslist@4.28.1:
+  browserslist@4.28.8:
     dependencies:
-      baseline-browser-mapping: 2.10.0
-      caniuse-lite: 1.0.30001774
-      electron-to-chromium: 1.5.302
-      node-releases: 2.0.27
-      update-browserslist-db: 1.2.3(browserslist@4.28.1)
-
-  browserslist@4.28.2:
-    dependencies:
-      baseline-browser-mapping: 2.10.31
-      caniuse-lite: 1.0.30001793
-      electron-to-chromium: 1.5.358
-      node-releases: 2.0.44
-      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+      baseline-browser-mapping: 2.11.20
+      caniuse-lite: 1.0.30001810
+      electron-to-chromium: 1.5.417
+      node-releases: 2.0.54
+      update-browserslist-db: 1.3.2(browserslist@4.28.8)
 
   bser@2.1.1:
     dependencies:
@@ -21150,7 +21129,7 @@ snapshots:
 
   caniuse-api@3.0.0:
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.8
       caniuse-lite: 1.0.30001793
       lodash.memoize: 4.1.2
       lodash.uniq: 4.5.0
@@ -21158,6 +21137,8 @@ snapshots:
   caniuse-lite@1.0.30001774: {}
 
   caniuse-lite@1.0.30001793: {}
+
+  caniuse-lite@1.0.30001810: {}
 
   caseless@0.12.0: {}
 
@@ -21455,7 +21436,7 @@ snapshots:
 
   core-js-compat@3.49.0:
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.8
 
   core-js-pure@3.49.0: {}
 
@@ -21666,7 +21647,7 @@ snapshots:
   cssnano-preset-advanced@6.1.2(postcss@8.5.26):
     dependencies:
       autoprefixer: 10.4.21(postcss@8.5.26)
-      browserslist: 4.28.2
+      browserslist: 4.28.8
       cssnano-preset-default: 6.1.2(postcss@8.5.26)
       postcss: 8.5.26
       postcss-discard-unused: 6.0.5(postcss@8.5.26)
@@ -21709,7 +21690,7 @@ snapshots:
 
   cssnano-preset-default@6.1.2(postcss@8.5.26):
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.8
       css-declaration-sorter: 7.3.1(postcss@8.5.26)
       cssnano-utils: 4.0.2(postcss@8.5.26)
       postcss: 8.5.26
@@ -22280,9 +22261,7 @@ snapshots:
     dependencies:
       jake: 10.9.4
 
-  electron-to-chromium@1.5.302: {}
-
-  electron-to-chromium@1.5.358: {}
+  electron-to-chromium@1.5.417: {}
 
   elegant-spinner@1.0.1: {}
 
@@ -22695,7 +22674,7 @@ snapshots:
 
   fast-json-stable-stringify@2.1.0: {}
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.6: {}
 
   fastq@1.20.1:
     dependencies:
@@ -25696,9 +25675,7 @@ snapshots:
     dependencies:
       process-on-spawn: 1.1.0
 
-  node-releases@2.0.27: {}
-
-  node-releases@2.0.44: {}
+  node-releases@2.0.54: {}
 
   normalize-path@3.0.0: {}
 
@@ -26225,7 +26202,7 @@ snapshots:
 
   postcss-colormin@5.3.1(postcss@8.5.26):
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.8
       caniuse-api: 3.0.0
       colord: 2.9.3
       postcss: 8.5.26
@@ -26233,7 +26210,7 @@ snapshots:
 
   postcss-colormin@6.1.0(postcss@8.5.26):
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.8
       caniuse-api: 3.0.0
       colord: 2.9.3
       postcss: 8.5.26
@@ -26241,13 +26218,13 @@ snapshots:
 
   postcss-convert-values@5.1.3(postcss@8.5.26):
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.8
       postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
   postcss-convert-values@6.1.0(postcss@8.5.26):
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.8
       postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
@@ -26497,7 +26474,7 @@ snapshots:
 
   postcss-merge-rules@5.1.4(postcss@8.5.26):
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.8
       caniuse-api: 3.0.0
       cssnano-utils: 3.1.0(postcss@8.5.26)
       postcss: 8.5.26
@@ -26505,7 +26482,7 @@ snapshots:
 
   postcss-merge-rules@6.1.1(postcss@8.5.26):
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.8
       caniuse-api: 3.0.0
       cssnano-utils: 4.0.2(postcss@8.5.26)
       postcss: 8.5.26
@@ -26537,14 +26514,14 @@ snapshots:
 
   postcss-minify-params@5.1.4(postcss@8.5.26):
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.8
       cssnano-utils: 3.1.0(postcss@8.5.26)
       postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
   postcss-minify-params@6.1.0(postcss@8.5.26):
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.8
       cssnano-utils: 4.0.2(postcss@8.5.26)
       postcss: 8.5.26
       postcss-value-parser: 4.2.0
@@ -26658,13 +26635,13 @@ snapshots:
 
   postcss-normalize-unicode@5.1.1(postcss@8.5.26):
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.8
       postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
   postcss-normalize-unicode@6.1.0(postcss@8.5.26):
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.8
       postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
@@ -26776,7 +26753,7 @@ snapshots:
       '@csstools/postcss-trigonometric-functions': 4.0.9(postcss@8.5.26)
       '@csstools/postcss-unset-value': 4.0.0(postcss@8.5.26)
       autoprefixer: 10.4.27(postcss@8.5.26)
-      browserslist: 4.28.2
+      browserslist: 4.28.8
       css-blank-pseudo: 7.0.1(postcss@8.5.26)
       css-has-pseudo: 7.0.3(postcss@8.5.26)
       css-prefers-color-scheme: 10.0.0(postcss@8.5.26)
@@ -26825,7 +26802,7 @@ snapshots:
       '@csstools/postcss-trigonometric-functions': 1.0.2(postcss@8.5.26)
       '@csstools/postcss-unset-value': 1.0.2(postcss@8.5.26)
       autoprefixer: 10.4.21(postcss@8.5.26)
-      browserslist: 4.28.2
+      browserslist: 4.28.8
       css-blank-pseudo: 3.0.3(postcss@8.5.26)
       css-has-pseudo: 3.0.4(postcss@8.5.26)
       css-prefers-color-scheme: 6.0.3(postcss@8.5.26)
@@ -26878,13 +26855,13 @@ snapshots:
 
   postcss-reduce-initial@5.1.2(postcss@8.5.26):
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.8
       caniuse-api: 3.0.0
       postcss: 8.5.26
 
   postcss-reduce-initial@6.1.0(postcss@8.5.26):
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.8
       caniuse-api: 3.0.0
       postcss: 8.5.26
 
@@ -28436,13 +28413,13 @@ snapshots:
 
   stylehacks@5.1.1(postcss@8.5.26):
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.8
       postcss: 8.5.26
       postcss-selector-parser: 6.1.2
 
   stylehacks@6.1.1(postcss@8.5.26):
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.8
       postcss: 8.5.26
       postcss-selector-parser: 6.1.2
 
@@ -28963,15 +28940,9 @@ snapshots:
 
   upath@1.2.0: {}
 
-  update-browserslist-db@1.2.3(browserslist@4.28.1):
+  update-browserslist-db@1.3.2(browserslist@4.28.8):
     dependencies:
-      browserslist: 4.28.1
-      escalade: 3.2.0
-      picocolors: 1.1.1
-
-  update-browserslist-db@1.2.3(browserslist@4.28.2):
-    dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.8
       escalade: 3.2.0
       picocolors: 1.1.1
 
@@ -29274,7 +29245,7 @@ snapshots:
       '@webassemblyjs/wasm-parser': 1.14.1
       acorn: 8.16.0
       acorn-import-phases: 1.0.4(acorn@8.16.0)
-      browserslist: 4.28.2
+      browserslist: 4.28.8
       chrome-trace-event: 1.0.4
       enhanced-resolve: 5.19.0
       es-module-lexer: 2.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -677,6 +677,9 @@ importers:
       react:
         specifier: 18.3.1
         version: 18.3.1
+      react-i18next:
+        specifier: 12.3.1
+        version: 12.3.1(i18next@17.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
       cross-env:
         specifier: 7.0.3
@@ -7314,6 +7317,7 @@ packages:
 
   crypto-js@4.2.0:
     resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
+    deprecated: Active development of CryptoJS has been discontinued. This library is no longer maintained.
 
   crypto-random-string@2.0.0:
     resolution: {integrity: sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==}
@@ -17943,7 +17947,7 @@ snapshots:
 
   '@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       '@emotion/babel-plugin': 11.13.5
       '@emotion/cache': 11.14.0
       '@emotion/serialize': 1.3.3
@@ -19893,7 +19897,7 @@ snapshots:
   '@testing-library/dom@8.20.1':
     dependencies:
       '@babel/code-frame': 7.29.0
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       '@types/aria-query': 5.0.4
       aria-query: 5.1.3
       chalk: 4.1.2
@@ -27241,7 +27245,7 @@ snapshots:
 
   react-i18next@12.3.1(i18next@17.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       html-parse-stringify: 3.0.1
       i18next: 17.3.1
       react: 18.3.1
@@ -27417,7 +27421,7 @@ snapshots:
 
   react-transition-group@4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       dom-helpers: 5.2.1
       loose-envify: 1.4.0
       prop-types: 15.8.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -79,7 +79,9 @@ overrides:
   protobufjs: 7.6.1
   tmp: 0.2.7
   shell-quote: 1.10.0
-  'fast-uri@>=3.0.0 <3.1.5': 3.1.5
+  # 3.1.6 patches GHSA-5jgf-p345-68v8, GHSA-f65p-4m7j-42xc, GHSA-fph4-wmhf-6fwf
+  # and GHSA-jqff-g426-hqxp (host confusion / SSRF via IDN and userinfo parsing).
+  'fast-uri@>=3.0.0 <3.1.6': 3.1.6
   '@babel/plugin-transform-modules-systemjs': 7.29.4
   # pnpm-branch-only overrides (kept across merges from master).
   'sharp@<0.35.0': 0.35.3
@@ -111,3 +113,8 @@ overrides:
   'js-yaml@>=4.0.0 <4.3.1': 4.3.1
   'postcss@<8.5.26': 8.5.26
   'pacote@>=11.2.7 <21.5.1': 21.5.1
+  # browserslist reaches the tree only through @babel/helper-compilation-targets
+  # at build time. 4.28.7 patches GHSA-c83g-rgw3-j3cx (unbounded cache growth ->
+  # OOM) and GHSA-73wf-gq98-2v4g (crash / prototype write via untrusted
+  # browserslist-stats.json).
+  'browserslist@<4.28.7': 4.28.8


### PR DESCRIPTION
## Problem

`MIMETypeOfEncapsulatedDocument` is supplied by whoever produced the instance, and a `blob:` URL inherits the origin of the document that created it. A spoofed `text/html` payload therefore executed **same-origin with the viewer**. Measured in Chrome against a real study:

```
SCRIPT RAN. origin=http://localhost:3001 | parent.localStorage keys=3
```

The `type="application/pdf"` attribute on `<object>` never filtered anything — it is only a hint, and the browser keys off the resource's actual Content-Type (the blob's type, or the server's header).

The same hole existed on the raw-URL path, where a WADO-RS URL reached the element directly and the PACS chose the `Content-Type`.

## Fix

The payload is read the way every other bulkdata value is read — inline content when the metadata carries it, otherwise the data source's own `retrieveBulkData`, preferring the buffer it caches on `value.Value`. This mirrors `resolveBulkDataTags` and matches the path the video display sets take, so authentication, bulkdata URI resolution and caching all behave the same here.

Those bytes are then wrapped in a `Blob` whose type comes from an allowlist:

```ts
const blob = new Blob([payload], { type: documentType.mimeType });
```

After that line neither the instance nor the origin server has any say in how the browser interprets the bytes. PDF payloads additionally have to satisfy a `%PDF-` signature check.

The allowlist maps each canonical type to how it is embedded:

| Type | Element |
|---|---|
| `application/pdf` | `<object type="application/pdf">` |
| `text/html`, `application/xhtml+xml`, `text/xml`, `application/xml`, `text/plain` | `<iframe sandbox="">` |
| anything else | not rendered |

Non-standard spellings (`application/html`, `application/x-pdf`, `application/acrobat`, `text/pdf`, `application/xhtml`) fold onto their canonical entry. Accepting an alias is safe because the canonical entry — not the declared spelling — decides both the blob type and the signature.

The viewport's status and fallback strings live in a new `EncapsulatedDocument` i18n namespace, registered in the `en-US` and `test-LNG` locale indexes.

## Why PDF is not sandboxed

This split is forced by the browsers, not chosen. Chrome renders a PDF under no sandbox at all, and under **none** of the token combinations:

| Sandbox | PDF renders |
|---|---|
| *(no sandbox attribute)* | yes |
| `sandbox=""` | no |
| `sandbox="allow-scripts"` | no |
| `sandbox="allow-same-origin"` | no — *"This page has been blocked by Chromium"* |
| `sandbox="allow-scripts allow-same-origin"` | no |
| `+ allow-downloads` | no |

Even the fully permissive combination fails, and `allow-plugins` no longer exists, so there is no way to sandbox a PDF and still display it. PDFs rely on the type guarantee instead. Markup types render correctly inside a sandbox, so they get one with no tokens at all — scripts inert, opaque origin, no access to the viewer.

Only Chrome was measured. If Firefox or Safari behave differently the allowlist is the single place to adjust.

## Verification

Both strategies verified end to end in the viewer against a real study:

- `application/pdf` → renders in the native viewer, `<object type="application/pdf">` with a blob source.
- `text/html` → renders as `<iframe sandbox="" allow="" referrerpolicy="no-referrer">`, with an in-document probe reporting `PASS - scripts did not run` and `PASS - no access to the embedding page`.

27 new unit tests cover normalization, alias folding, allowlist rejection, signature matching, and the load path — each resolution branch (inline, already-decoded inline, cached `value.Value`, `retrieveBulkData`), the canonical media type on the retrieve call, refusing HTML that claims to be a PDF, and abort/revoke semantics.

The i18n wiring was checked with `&lng=test-LNG`, since under `en-US` the key and the value are identical and a missing bundle would be invisible. Forcing the failure branch renders `Test Unable to retrieve this document`, i.e. the value resolves from the namespace bundle rather than falling back to the key.

This extension had neither a jest nor a babel config, so the root `extensions/*/jest.config.js` project glob was never collecting its tests. Both are added.

## Notes for review

- Documents no longer stream or range-request; the payload is fully resolved so it can be checked and re-typed. Fine for reports, worth knowing for anything large.
- The display set now carries a `getDocument` loader instead of `renderedUrl`/`getRenderedUrl`. Those were consumed only by this viewport, and `directURL` eagerly created an object URL per DOC instance at metadata time that nothing revoked.
- A document whose value offers neither inline content nor `retrieveBulkData` renders nothing. That is deliberate — fail closed.
- `react-i18next` is declared as a peer dependency, matching the other extensions that use `useTranslation`. That required a lockfile update; alongside the three lines for this package, pnpm also corrected pre-existing drift of its own (`@babel/runtime` 7.29.2 → 7.29.7 in four unrelated snapshot entries, and a `deprecated:` note on `crypto-js`). Happy to split that out if you would rather it landed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for displaying validated PDF, HTML, and plain-text documents from DICOM data.
  * Added MIME-type normalization and support for common MIME aliases.
  * Added document-specific rendering with secure sandboxed iframe support where appropriate.
  * Added support for inline, cached, and retrieved document data.

* **Bug Fixes**
  * Improved document validation using file signatures before rendering.
  * Added cleanup of temporary document URLs to prevent resource leaks.
  * Improved messaging for unsupported, unavailable, or invalid documents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

