### PR TITLE
fix(Calendar): backport readable date filter dropdown colors

### DIFF
--- a/platform/ui-next/src/components/Calendar/Calendar.tsx
+++ b/platform/ui-next/src/components/Calendar/Calendar.tsx
@@ -114,7 +114,10 @@ function Calendar({
           'relative rounded-md border border-input',
           defaultClassNames.dropdown_root
         ),
-        dropdown: cn('absolute inset-0 opacity-0', defaultClassNames.dropdown),
+        dropdown: cn(
+          'bg-popover text-popover-foreground absolute inset-0 opacity-0',
+          defaultClassNames.dropdown
+        ),
         caption_label: cn(
           'select-none font-medium',
           captionLayout === 'label'


### PR DESCRIPTION
### Context

Fixes #6218.

This backports the calendar dropdown color fix from `450cd3aefb` to `release/3.13`.

The study-list date filter uses `captionLayout="dropdown"`, which renders native month/year `<select>` elements beneath the styled caption. Browser option popups use the select element's own foreground and background colors, so the options can become unreadable unless those colors are set directly.

Note: #6164 is still open on master, so this isolated change is for the 3.13 release line.

### Changes & Results

- Set `bg-popover text-popover-foreground` on the calendar dropdown select.
- Keep the change scoped to `Calendar.tsx`.

### Testing

- `git diff --check`
- Compared the class change with commit `450cd3aefb`
- Confirmed only `platform/ui-next/src/components/Calendar/Calendar.tsx` changes