### PR TITLE
test(contour): add fill, outline and opacity contour display coverage

### DIFF
--- a/tests/ContourCombineOperations.spec.ts
+++ b/tests/ContourCombineOperations.spec.ts
@@ -38,7 +38,7 @@ test.describe('Intersect operation', () => {
     const activeViewport = await viewportPageObject.active;
     await activeViewport.pane.dblclick();
 
-    await contourSegmentationPanel.config.toggle.click();
+    await contourSegmentationPanel.config.open();
 
     await contourSegmentationPanel.config.display.fillAndOutline.click();
 
@@ -83,7 +83,7 @@ test.describe('Subtract operation', () => {
     const activeViewport = await viewportPageObject.active;
     await activeViewport.pane.dblclick();
 
-    await contourSegmentationPanel.config.toggle.click();
+    await contourSegmentationPanel.config.open();
 
     await contourSegmentationPanel.config.display.fillAndOutline.click();
 

--- a/tests/ContourCombineOperations.spec.ts
+++ b/tests/ContourCombineOperations.spec.ts
@@ -40,7 +40,7 @@ test.describe('Intersect operation', () => {
 
     await contourSegmentationPanel.config.toggle.click();
 
-    await contourSegmentationPanel.config.display.fillAndOutline();
+    await contourSegmentationPanel.config.display.fillAndOutline.click();
 
     await contourSegmentationPanel.panel.segmentByText(segments.bigSphere).click();
 
@@ -85,7 +85,7 @@ test.describe('Subtract operation', () => {
 
     await contourSegmentationPanel.config.toggle.click();
 
-    await contourSegmentationPanel.config.display.fillAndOutline();
+    await contourSegmentationPanel.config.display.fillAndOutline.click();
 
     await contourSegmentationPanel.panel.segmentByText(segments.bigSphere).click();
 

--- a/tests/ContourSegmentationFillOutlineOpacity.spec.ts
+++ b/tests/ContourSegmentationFillOutlineOpacity.spec.ts
@@ -63,8 +63,9 @@ test.beforeEach(async ({ page, rightPanelPageObject }) => {
   await expect(contourPanel.panel.rows, 'Expected the default segment row').toHaveCount(1);
   await waitForViewportsRendered(page);
 
-  // Expand the appearance config section holding the display tabs and sliders.
-  await contourPanel.config.toggle.click();
+  // Expand the appearance config section holding the display tabs and sliders, so the tests
+  // that only assert on its controls find them. The config actions expand it on their own.
+  await contourPanel.config.open();
 });
 
 test('should render a panel-created contour with both fill and outline by default', async ({

--- a/tests/ContourSegmentationFillOutlineOpacity.spec.ts
+++ b/tests/ContourSegmentationFillOutlineOpacity.spec.ts
@@ -1,13 +1,19 @@
-import { expect, test, visitStudy, waitForViewportsRendered } from './utils';
+import { drawFreehandContour, expect, test, visitStudy, waitForViewportsRendered } from './utils';
+import type { RightPanelPageObject } from './pages';
+import type { IViewportPageObject } from './pages/ViewportPageObject';
 
 const studyInstanceUID = '1.3.12.2.1107.5.2.32.35162.30000015050317233592200000046';
 const mode = 'segmentation';
 
-// Default contour style for segmentations created from the panel: the fill is
-// enabled on creation and inherits the type-level fill alpha, the outline uses
-// the default outline width (see segmentationPanelCustomization / contourConfig).
+// Default contour style for segmentations created from the panel: the fill is enabled on
+// creation (segmentationPanelCustomization) and inherits the Contour type-level fill alpha
+// declared in the cornerstone extension init, while the outline uses the default width.
 const defaultFillOpacity = '0.5';
 const defaultOutlineWidth = '1';
+
+// First entry of the cornerstone color LUT, which a panel-created segmentation gets for its
+// first segment (SegmentationService seeds the LUT with the background color only).
+const defaultSegmentColor = 'rgb(221, 84, 84)';
 
 const dragShape = [
   { x: 0.4, y: 0.4 },
@@ -24,6 +30,29 @@ const secondDragShape = [
   { x: 0.65, y: 0.35 },
   { x: 0.65, y: 0.15 },
 ];
+
+/**
+ * Draws the first freehand contour of a test into the active segment and returns its SVG path,
+ * asserting the viewport starts empty and ends up rendering the drawn contour.
+ */
+async function drawFirstContour({
+  contourPanel,
+  viewport,
+}: {
+  contourPanel: RightPanelPageObject['contourSegmentationPanel'];
+  viewport: IViewportPageObject;
+}) {
+  const paths = viewport.svg('path');
+
+  await expect(paths, 'Expected the starting number of paths to be 0').toHaveCount(0);
+  await drawFreehandContour({ segmentationPanel: contourPanel, viewport, path: dragShape });
+  await expect(paths, 'Expected the freehand contour to be added').toHaveCount(1);
+
+  const contour = paths.nth(0);
+  await expect(contour, 'Expected the drawn contour to be visible').toBeVisible();
+
+  return contour;
+}
 
 test.beforeEach(async ({ page, rightPanelPageObject }) => {
   await visitStudy(page, studyInstanceUID, mode, 2000);
@@ -43,15 +72,14 @@ test('should render a panel-created contour with both fill and outline by defaul
   viewportPageObject,
 }) => {
   const contourPanel = rightPanelPageObject.contourSegmentationPanel;
+  const { display } = contourPanel.config;
   const activeViewport = await viewportPageObject.active;
-  const paths = activeViewport.svg('path');
+  const contour = await drawFirstContour({ contourPanel, viewport: activeViewport });
 
-  await expect(paths, 'Expected the starting number of paths to be 0').toHaveCount(0);
-  await contourPanel.tools.freehandContour.click();
-  await activeViewport.normalizedPathDragAt({ path: dragShape });
-  await expect(paths, 'Expected the freehand contour to be added').toHaveCount(1);
-
-  const contour = paths.nth(0);
+  await expect(
+    display.fillAndOutline.button,
+    'Expected the panel to start in fill & outline mode'
+  ).toHaveAttribute('data-state', 'active');
   await expect(contour, 'Expected the fill at the default alpha').toHaveAttribute(
     'fill-opacity',
     defaultFillOpacity
@@ -62,7 +90,7 @@ test('should render a panel-created contour with both fill and outline by defaul
   );
   await expect(contour, 'Expected the fill to use the segment color').toHaveAttribute(
     'fill',
-    /^rgb\(/
+    defaultSegmentColor
   );
 });
 
@@ -71,16 +99,15 @@ test('should toggle fill and outline rendering when switching display modes', as
   viewportPageObject,
 }) => {
   const contourPanel = rightPanelPageObject.contourSegmentationPanel;
+  const { display } = contourPanel.config;
   const activeViewport = await viewportPageObject.active;
-  const paths = activeViewport.svg('path');
+  const contour = await drawFirstContour({ contourPanel, viewport: activeViewport });
 
-  await expect(paths, 'Expected the starting number of paths to be 0').toHaveCount(0);
-  await contourPanel.tools.freehandContour.click();
-  await activeViewport.normalizedPathDragAt({ path: dragShape });
-  await expect(paths, 'Expected the freehand contour to be added').toHaveCount(1);
-  const contour = paths.nth(0);
-
-  await contourPanel.config.display.outline();
+  await display.outline.click();
+  await expect(display.outline.button, 'Expected the panel to be in outline mode').toHaveAttribute(
+    'data-state',
+    'active'
+  );
   await expect(contour, 'Expected outline mode to hide the fill').toHaveAttribute(
     'fill-opacity',
     '0'
@@ -90,7 +117,11 @@ test('should toggle fill and outline rendering when switching display modes', as
     defaultOutlineWidth
   );
 
-  await contourPanel.config.display.fill();
+  await display.fill.click();
+  await expect(display.fill.button, 'Expected the panel to be in fill mode').toHaveAttribute(
+    'data-state',
+    'active'
+  );
   await expect(contour, 'Expected fill mode to restore the fill').toHaveAttribute(
     'fill-opacity',
     defaultFillOpacity
@@ -100,7 +131,11 @@ test('should toggle fill and outline rendering when switching display modes', as
     '0'
   );
 
-  await contourPanel.config.display.fillAndOutline();
+  await display.fillAndOutline.click();
+  await expect(
+    display.fillAndOutline.button,
+    'Expected the panel to be in fill & outline mode'
+  ).toHaveAttribute('data-state', 'active');
   await expect(contour, 'Expected fill & outline mode to render the fill').toHaveAttribute(
     'fill-opacity',
     defaultFillOpacity
@@ -111,12 +146,13 @@ test('should toggle fill and outline rendering when switching display modes', as
   );
 });
 
-test('should apply the selected display mode to contours drawn afterwards in any segment', async ({
+test('should apply a display mode to contours drawn afterwards and re-render existing ones', async ({
   page,
   rightPanelPageObject,
   viewportPageObject,
 }) => {
   const contourPanel = rightPanelPageObject.contourSegmentationPanel;
+  const { display } = contourPanel.config;
   const panel = contourPanel.panel;
   const activeViewport = await viewportPageObject.active;
   const paths = activeViewport.svg('path');
@@ -124,19 +160,36 @@ test('should apply the selected display mode to contours drawn afterwards in any
   await expect(paths, 'Expected the starting number of paths to be 0').toHaveCount(0);
 
   // Select outline-only before anything is drawn.
-  await contourPanel.config.display.outline();
+  await display.outline.click();
+  await expect(display.outline.button, 'Expected the panel to be in outline mode').toHaveAttribute(
+    'data-state',
+    'active'
+  );
 
-  await contourPanel.tools.freehandContour.click();
-  await activeViewport.normalizedPathDragAt({ path: dragShape });
+  await drawFreehandContour({
+    segmentationPanel: contourPanel,
+    viewport: activeViewport,
+    path: dragShape,
+  });
   await expect(paths, 'Expected the first freehand contour to be added').toHaveCount(1);
 
   await contourPanel.addSegmentButton.click();
   await expect(panel.rows, 'Expected a second segment row to be added').toHaveCount(2);
   await panel.nthSegment(1).click();
+  // The second contour must land in the second segment, so wait for the selection to render
+  // before drawing it.
   await waitForViewportsRendered(page);
 
-  await activeViewport.normalizedPathDragAt({ path: secondDragShape });
+  // The freehand tool is still armed from the first contour.
+  await drawFreehandContour({
+    segmentationPanel: contourPanel,
+    viewport: activeViewport,
+    path: secondDragShape,
+    activateTool: false,
+  });
   await expect(paths, 'Expected the second freehand contour to be added').toHaveCount(2);
+  await expect(paths.nth(0), 'Expected the first contour to be visible').toBeVisible();
+  await expect(paths.nth(1), 'Expected the second contour to be visible').toBeVisible();
 
   await expect(paths.nth(0), 'Expected the first contour without fill').toHaveAttribute(
     'fill-opacity',
@@ -148,7 +201,7 @@ test('should apply the selected display mode to contours drawn afterwards in any
   );
 
   // Switching back must re-render both existing contours with a fill.
-  await contourPanel.config.display.fillAndOutline();
+  await display.fillAndOutline.click();
   await expect(paths.nth(0), 'Expected the first contour to regain its fill').toHaveAttribute(
     'fill-opacity',
     defaultFillOpacity
@@ -159,20 +212,14 @@ test('should apply the selected display mode to contours drawn afterwards in any
   );
 });
 
-test('should change the contour fill opacity when the opacity slider value changes', async ({
+test('should change the contour fill opacity when the opacity value is typed in', async ({
   rightPanelPageObject,
   viewportPageObject,
 }) => {
   const contourPanel = rightPanelPageObject.contourSegmentationPanel;
-  const { opacity } = contourPanel.config;
+  const { opacity, display } = contourPanel.config;
   const activeViewport = await viewportPageObject.active;
-  const paths = activeViewport.svg('path');
-
-  await expect(paths, 'Expected the starting number of paths to be 0').toHaveCount(0);
-  await contourPanel.tools.freehandContour.click();
-  await activeViewport.normalizedPathDragAt({ path: dragShape });
-  await expect(paths, 'Expected the freehand contour to be added').toHaveCount(1);
-  const contour = paths.nth(0);
+  const contour = await drawFirstContour({ contourPanel, viewport: activeViewport });
 
   await expect(opacity.input, 'Expected the default opacity value').toHaveValue(defaultFillOpacity);
 
@@ -194,26 +241,25 @@ test('should change the contour fill opacity when the opacity slider value chang
     'fill-opacity',
     '0'
   );
+  // A zero alpha is the opacity value hiding the fill, not the fill display being turned off.
+  await expect(
+    display.fillAndOutline.button,
+    'Expected the panel to stay in fill & outline mode'
+  ).toHaveAttribute('data-state', 'active');
   await expect(contour, 'Expected the outline to be unaffected by opacity').toHaveAttribute(
     'stroke-width',
     defaultOutlineWidth
   );
 });
 
-test('should change the contour outline width when the border slider value changes', async ({
+test('should change the contour outline width when the border value is typed in', async ({
   rightPanelPageObject,
   viewportPageObject,
 }) => {
   const contourPanel = rightPanelPageObject.contourSegmentationPanel;
   const { border } = contourPanel.config;
   const activeViewport = await viewportPageObject.active;
-  const paths = activeViewport.svg('path');
-
-  await expect(paths, 'Expected the starting number of paths to be 0').toHaveCount(0);
-  await contourPanel.tools.freehandContour.click();
-  await activeViewport.normalizedPathDragAt({ path: dragShape });
-  await expect(paths, 'Expected the freehand contour to be added').toHaveCount(1);
-  const contour = paths.nth(0);
+  const contour = await drawFirstContour({ contourPanel, viewport: activeViewport });
 
   await expect(border.input, 'Expected the default border value').toHaveValue(defaultOutlineWidth);
 
@@ -240,17 +286,15 @@ test('should keep the fill hidden in outline mode until fill display is re-enabl
   viewportPageObject,
 }) => {
   const contourPanel = rightPanelPageObject.contourSegmentationPanel;
-  const { opacity } = contourPanel.config;
+  const { opacity, display } = contourPanel.config;
   const activeViewport = await viewportPageObject.active;
-  const paths = activeViewport.svg('path');
+  const contour = await drawFirstContour({ contourPanel, viewport: activeViewport });
 
-  await expect(paths, 'Expected the starting number of paths to be 0').toHaveCount(0);
-  await contourPanel.tools.freehandContour.click();
-  await activeViewport.normalizedPathDragAt({ path: dragShape });
-  await expect(paths, 'Expected the freehand contour to be added').toHaveCount(1);
-  const contour = paths.nth(0);
-
-  await contourPanel.config.display.outline();
+  await display.outline.click();
+  await expect(display.outline.button, 'Expected the panel to be in outline mode').toHaveAttribute(
+    'data-state',
+    'active'
+  );
   await expect(contour, 'Expected outline mode to hide the fill').toHaveAttribute(
     'fill-opacity',
     '0'
@@ -269,7 +313,7 @@ test('should keep the fill hidden in outline mode until fill display is re-enabl
   );
 
   // Re-enabling the fill applies the opacity chosen while it was hidden.
-  await contourPanel.config.display.fillAndOutline();
+  await display.fillAndOutline.click();
   await expect(contour, 'Expected the fill to return at the new alpha').toHaveAttribute(
     'fill-opacity',
     '0.8'

--- a/tests/ContourSegmentationFillOutlineOpacity.spec.ts
+++ b/tests/ContourSegmentationFillOutlineOpacity.spec.ts
@@ -1,0 +1,277 @@
+import { expect, test, visitStudy, waitForViewportsRendered } from './utils';
+
+const studyInstanceUID = '1.3.12.2.1107.5.2.32.35162.30000015050317233592200000046';
+const mode = 'segmentation';
+
+// Default contour style for segmentations created from the panel: the fill is
+// enabled on creation and inherits the type-level fill alpha, the outline uses
+// the default outline width (see segmentationPanelCustomization / contourConfig).
+const defaultFillOpacity = '0.5';
+const defaultOutlineWidth = '1';
+
+const dragShape = [
+  { x: 0.4, y: 0.4 },
+  { x: 0.6, y: 0.4 },
+  { x: 0.6, y: 0.6 },
+  { x: 0.4, y: 0.6 },
+  { x: 0.4, y: 0.4 },
+];
+
+const secondDragShape = [
+  { x: 0.65, y: 0.15 },
+  { x: 0.85, y: 0.15 },
+  { x: 0.85, y: 0.35 },
+  { x: 0.65, y: 0.35 },
+  { x: 0.65, y: 0.15 },
+];
+
+test.beforeEach(async ({ page, rightPanelPageObject }) => {
+  await visitStudy(page, studyInstanceUID, mode, 2000);
+  await waitForViewportsRendered(page);
+
+  const contourPanel = rightPanelPageObject.contourSegmentationPanel;
+  await contourPanel.addSegmentation();
+  await expect(contourPanel.panel.rows, 'Expected the default segment row').toHaveCount(1);
+  await waitForViewportsRendered(page);
+
+  // Expand the appearance config section holding the display tabs and sliders.
+  await contourPanel.config.toggle.click();
+});
+
+test('should render a panel-created contour with both fill and outline by default', async ({
+  rightPanelPageObject,
+  viewportPageObject,
+}) => {
+  const contourPanel = rightPanelPageObject.contourSegmentationPanel;
+  const activeViewport = await viewportPageObject.active;
+  const paths = activeViewport.svg('path');
+
+  await expect(paths, 'Expected the starting number of paths to be 0').toHaveCount(0);
+  await contourPanel.tools.freehandContour.click();
+  await activeViewport.normalizedPathDragAt({ path: dragShape });
+  await expect(paths, 'Expected the freehand contour to be added').toHaveCount(1);
+
+  const contour = paths.nth(0);
+  await expect(contour, 'Expected the fill at the default alpha').toHaveAttribute(
+    'fill-opacity',
+    defaultFillOpacity
+  );
+  await expect(contour, 'Expected the outline at the default width').toHaveAttribute(
+    'stroke-width',
+    defaultOutlineWidth
+  );
+  await expect(contour, 'Expected the fill to use the segment color').toHaveAttribute(
+    'fill',
+    /^rgb\(/
+  );
+});
+
+test('should toggle fill and outline rendering when switching display modes', async ({
+  rightPanelPageObject,
+  viewportPageObject,
+}) => {
+  const contourPanel = rightPanelPageObject.contourSegmentationPanel;
+  const activeViewport = await viewportPageObject.active;
+  const paths = activeViewport.svg('path');
+
+  await expect(paths, 'Expected the starting number of paths to be 0').toHaveCount(0);
+  await contourPanel.tools.freehandContour.click();
+  await activeViewport.normalizedPathDragAt({ path: dragShape });
+  await expect(paths, 'Expected the freehand contour to be added').toHaveCount(1);
+  const contour = paths.nth(0);
+
+  await contourPanel.config.display.outline();
+  await expect(contour, 'Expected outline mode to hide the fill').toHaveAttribute(
+    'fill-opacity',
+    '0'
+  );
+  await expect(contour, 'Expected outline mode to keep the outline').toHaveAttribute(
+    'stroke-width',
+    defaultOutlineWidth
+  );
+
+  await contourPanel.config.display.fill();
+  await expect(contour, 'Expected fill mode to restore the fill').toHaveAttribute(
+    'fill-opacity',
+    defaultFillOpacity
+  );
+  await expect(contour, 'Expected fill mode to hide the outline').toHaveAttribute(
+    'stroke-width',
+    '0'
+  );
+
+  await contourPanel.config.display.fillAndOutline();
+  await expect(contour, 'Expected fill & outline mode to render the fill').toHaveAttribute(
+    'fill-opacity',
+    defaultFillOpacity
+  );
+  await expect(contour, 'Expected fill & outline mode to render the outline').toHaveAttribute(
+    'stroke-width',
+    defaultOutlineWidth
+  );
+});
+
+test('should apply the selected display mode to contours drawn afterwards in any segment', async ({
+  page,
+  rightPanelPageObject,
+  viewportPageObject,
+}) => {
+  const contourPanel = rightPanelPageObject.contourSegmentationPanel;
+  const panel = contourPanel.panel;
+  const activeViewport = await viewportPageObject.active;
+  const paths = activeViewport.svg('path');
+
+  await expect(paths, 'Expected the starting number of paths to be 0').toHaveCount(0);
+
+  // Select outline-only before anything is drawn.
+  await contourPanel.config.display.outline();
+
+  await contourPanel.tools.freehandContour.click();
+  await activeViewport.normalizedPathDragAt({ path: dragShape });
+  await expect(paths, 'Expected the first freehand contour to be added').toHaveCount(1);
+
+  await contourPanel.addSegmentButton.click();
+  await expect(panel.rows, 'Expected a second segment row to be added').toHaveCount(2);
+  await panel.nthSegment(1).click();
+  await waitForViewportsRendered(page);
+
+  await activeViewport.normalizedPathDragAt({ path: secondDragShape });
+  await expect(paths, 'Expected the second freehand contour to be added').toHaveCount(2);
+
+  await expect(paths.nth(0), 'Expected the first contour without fill').toHaveAttribute(
+    'fill-opacity',
+    '0'
+  );
+  await expect(paths.nth(1), 'Expected the second contour without fill').toHaveAttribute(
+    'fill-opacity',
+    '0'
+  );
+
+  // Switching back must re-render both existing contours with a fill.
+  await contourPanel.config.display.fillAndOutline();
+  await expect(paths.nth(0), 'Expected the first contour to regain its fill').toHaveAttribute(
+    'fill-opacity',
+    defaultFillOpacity
+  );
+  await expect(paths.nth(1), 'Expected the second contour to regain its fill').toHaveAttribute(
+    'fill-opacity',
+    defaultFillOpacity
+  );
+});
+
+test('should change the contour fill opacity when the opacity slider value changes', async ({
+  rightPanelPageObject,
+  viewportPageObject,
+}) => {
+  const contourPanel = rightPanelPageObject.contourSegmentationPanel;
+  const { opacity } = contourPanel.config;
+  const activeViewport = await viewportPageObject.active;
+  const paths = activeViewport.svg('path');
+
+  await expect(paths, 'Expected the starting number of paths to be 0').toHaveCount(0);
+  await contourPanel.tools.freehandContour.click();
+  await activeViewport.normalizedPathDragAt({ path: dragShape });
+  await expect(paths, 'Expected the freehand contour to be added').toHaveCount(1);
+  const contour = paths.nth(0);
+
+  await expect(opacity.input, 'Expected the default opacity value').toHaveValue(defaultFillOpacity);
+
+  await opacity.fill('0.3');
+  await expect(opacity.input, 'Expected the opacity input to accept 0.3').toHaveValue('0.3');
+  await expect(contour, 'Expected the fill to render at 0.3 alpha').toHaveAttribute(
+    'fill-opacity',
+    '0.3'
+  );
+
+  await opacity.fill('1');
+  await expect(contour, 'Expected the fill to render fully opaque').toHaveAttribute(
+    'fill-opacity',
+    '1'
+  );
+
+  await opacity.fill('0');
+  await expect(contour, 'Expected the fill to render fully transparent').toHaveAttribute(
+    'fill-opacity',
+    '0'
+  );
+  await expect(contour, 'Expected the outline to be unaffected by opacity').toHaveAttribute(
+    'stroke-width',
+    defaultOutlineWidth
+  );
+});
+
+test('should change the contour outline width when the border slider value changes', async ({
+  rightPanelPageObject,
+  viewportPageObject,
+}) => {
+  const contourPanel = rightPanelPageObject.contourSegmentationPanel;
+  const { border } = contourPanel.config;
+  const activeViewport = await viewportPageObject.active;
+  const paths = activeViewport.svg('path');
+
+  await expect(paths, 'Expected the starting number of paths to be 0').toHaveCount(0);
+  await contourPanel.tools.freehandContour.click();
+  await activeViewport.normalizedPathDragAt({ path: dragShape });
+  await expect(paths, 'Expected the freehand contour to be added').toHaveCount(1);
+  const contour = paths.nth(0);
+
+  await expect(border.input, 'Expected the default border value').toHaveValue(defaultOutlineWidth);
+
+  await border.fill('5');
+  await expect(border.input, 'Expected the border input to accept 5').toHaveValue('5');
+  await expect(contour, 'Expected the outline to render 5px wide').toHaveAttribute(
+    'stroke-width',
+    '5'
+  );
+  await expect(contour, 'Expected the fill to be unaffected by border').toHaveAttribute(
+    'fill-opacity',
+    defaultFillOpacity
+  );
+
+  await border.fill('0');
+  await expect(contour, 'Expected a zero border to hide the outline').toHaveAttribute(
+    'stroke-width',
+    '0'
+  );
+});
+
+test('should keep the fill hidden in outline mode until fill display is re-enabled', async ({
+  rightPanelPageObject,
+  viewportPageObject,
+}) => {
+  const contourPanel = rightPanelPageObject.contourSegmentationPanel;
+  const { opacity } = contourPanel.config;
+  const activeViewport = await viewportPageObject.active;
+  const paths = activeViewport.svg('path');
+
+  await expect(paths, 'Expected the starting number of paths to be 0').toHaveCount(0);
+  await contourPanel.tools.freehandContour.click();
+  await activeViewport.normalizedPathDragAt({ path: dragShape });
+  await expect(paths, 'Expected the freehand contour to be added').toHaveCount(1);
+  const contour = paths.nth(0);
+
+  await contourPanel.config.display.outline();
+  await expect(contour, 'Expected outline mode to hide the fill').toHaveAttribute(
+    'fill-opacity',
+    '0'
+  );
+
+  // Changing the opacity while the fill is hidden must not reveal it.
+  await opacity.fill('0.8');
+  await expect(opacity.input, 'Expected the opacity input to accept 0.8').toHaveValue('0.8');
+  await expect(contour, 'Expected the fill to stay hidden in outline mode').toHaveAttribute(
+    'fill-opacity',
+    '0'
+  );
+  await expect(contour, 'Expected the outline to keep rendering').toHaveAttribute(
+    'stroke-width',
+    defaultOutlineWidth
+  );
+
+  // Re-enabling the fill applies the opacity chosen while it was hidden.
+  await contourPanel.config.display.fillAndOutline();
+  await expect(contour, 'Expected the fill to return at the new alpha').toHaveAttribute(
+    'fill-opacity',
+    '0.8'
+  );
+});

--- a/tests/SegmentationPanel.spec.ts
+++ b/tests/SegmentationPanel.spec.ts
@@ -88,7 +88,7 @@ test.describe('Segmentation panel config input validation for labelmap', () => {
   test.beforeEach(async ({ rightPanelPageObject }) => {
     await rightPanelPageObject.labelMapSegmentationPanel.addSegmentationButton.click();
 
-    await rightPanelPageObject.labelMapSegmentationPanel.config.toggle.click();
+    await rightPanelPageObject.labelMapSegmentationPanel.config.open();
   });
 
   test.describe('opacity', () => {

--- a/tests/pages/RightPanelPageObject.ts
+++ b/tests/pages/RightPanelPageObject.ts
@@ -421,6 +421,28 @@ export class RightPanelPageObject {
               await page.getByTestId(`segmentation-config-display-fill-Contour`).click();
             },
           },
+
+          get opacity() {
+            const container = page.getByTestId('segmentation-config-opacity-Contour');
+            return {
+              input: container.locator('input'),
+              slider: container.getByRole('slider'),
+              fill: async (value: string) => {
+                await container.locator('input').fill(value);
+              },
+            };
+          },
+
+          get border() {
+            const container = page.getByTestId('segmentation-config-border-Contour');
+            return {
+              input: container.locator('input'),
+              slider: container.getByRole('slider'),
+              fill: async (value: string) => {
+                await container.locator('input').fill(value);
+              },
+            };
+          },
         };
       },
       get combineContours() {

--- a/tests/pages/RightPanelPageObject.ts
+++ b/tests/pages/RightPanelPageObject.ts
@@ -21,6 +21,58 @@ export class RightPanelPageObject {
     this.DOMOverlayPageObject = new DOMOverlayPageObject(page);
   }
 
+  /**
+   * Returns the accessors for one of the numeric (slider plus number input) controls of the
+   * segmentation appearance config section, e.g. its Opacity or Border control. The value is
+   * driven through the number input; the slider itself is not exercised yet.
+   */
+  private getNumericConfig(dataCy: string) {
+    const input = this.page.getByTestId(dataCy).locator('input[type="number"]');
+
+    return {
+      input,
+      fill: async (value: string) => {
+        await input.fill(value);
+      },
+    };
+  }
+
+  /**
+   * Returns the appearance config accessors shared by the segmentation panels: the section
+   * toggle, the display mode tabs and the opacity/border controls. The display tab buttons
+   * carry a data-state attribute reflecting which mode is currently selected.
+   */
+  private getSegmentationConfig(typeSuffix: string) {
+    const page = this.page;
+    const configToggle = page.getByTestId(`segmentation-config-toggle-${typeSuffix}`);
+    const displayMode = (mode: 'fill-and-outline' | 'outline' | 'fill') => {
+      const button = page.getByTestId(`segmentation-config-display-${mode}-${typeSuffix}`);
+      return {
+        button,
+        click: async () => {
+          await button.click();
+        },
+      };
+    };
+
+    return {
+      toggle: {
+        locator: configToggle,
+        click: async () => {
+          await configToggle.click();
+        },
+      },
+      display: {
+        fillAndOutline: displayMode('fill-and-outline'),
+        outline: displayMode('outline'),
+        fill: displayMode('fill'),
+      },
+      opacity: this.getNumericConfig(`segmentation-config-opacity-${typeSuffix}`),
+      border: this.getNumericConfig(`segmentation-config-border-${typeSuffix}`),
+      opacityInactive: this.getNumericConfig(`segmentation-config-opacity-inactive-${typeSuffix}`),
+    };
+  }
+
   private getCollapsedMoreMenu(typeSuffix?: string) {
     const page = this.page;
     const testId = typeSuffix
@@ -399,52 +451,7 @@ export class RightPanelPageObject {
           };
         },
       },
-      get config() {
-        const configToggle = page.getByTestId('segmentation-config-toggle-Contour');
-        return {
-          toggle: {
-            locator: configToggle,
-            click: async () => {
-              await configToggle.click();
-            },
-          },
-          display: {
-            fillAndOutline: async () => {
-              await page
-                .getByTestId(`segmentation-config-display-fill-and-outline-Contour`)
-                .click();
-            },
-            outline: async () => {
-              await page.getByTestId(`segmentation-config-display-outline-Contour`).click();
-            },
-            fill: async () => {
-              await page.getByTestId(`segmentation-config-display-fill-Contour`).click();
-            },
-          },
-
-          get opacity() {
-            const container = page.getByTestId('segmentation-config-opacity-Contour');
-            return {
-              input: container.locator('input'),
-              slider: container.getByRole('slider'),
-              fill: async (value: string) => {
-                await container.locator('input').fill(value);
-              },
-            };
-          },
-
-          get border() {
-            const container = page.getByTestId('segmentation-config-border-Contour');
-            return {
-              input: container.locator('input'),
-              slider: container.getByRole('slider'),
-              fill: async (value: string) => {
-                await container.locator('input').fill(value);
-              },
-            };
-          },
-        };
-      },
+      config: this.getSegmentationConfig('Contour'),
       get combineContours() {
         return {
           open: async () => {
@@ -535,50 +542,7 @@ export class RightPanelPageObject {
         },
       },
 
-      get config() {
-        const configToggle = page.getByTestId('segmentation-config-toggle-Labelmap');
-        return {
-          toggle: {
-            locator: configToggle,
-            click: async () => {
-              await configToggle.click();
-            },
-          },
-
-          get opacity() {
-            const container = page.getByTestId('segmentation-config-opacity-Labelmap');
-            return {
-              input: container.locator('input'),
-              slider: container.getByRole('slider'),
-              fill: async (value: string) => {
-                await container.locator('input').fill(value);
-              },
-            };
-          },
-
-          get border() {
-            const container = page.getByTestId('segmentation-config-border-Labelmap');
-            return {
-              input: container.locator('input'),
-              slider: container.getByRole('slider'),
-              fill: async (value: string) => {
-                await container.locator('input').fill(value);
-              },
-            };
-          },
-
-          get opacityInactive() {
-            const container = page.getByTestId('segmentation-config-opacity-inactive-Labelmap');
-            return {
-              input: container.locator('input'),
-              slider: container.getByRole('slider'),
-              fill: async (value: string) => {
-                await container.locator('input').fill(value);
-              },
-            };
-          },
-        };
-      },
+      config: this.getSegmentationConfig('Labelmap'),
 
       get segmentBidirectional() {
         const button = page.getByTestId('SegmentBidirectional');

--- a/tests/pages/RightPanelPageObject.ts
+++ b/tests/pages/RightPanelPageObject.ts
@@ -22,40 +22,56 @@ export class RightPanelPageObject {
   }
 
   /**
-   * Returns the accessors for one of the numeric (slider plus number input) controls of the
-   * segmentation appearance config section, e.g. its Opacity or Border control. The value is
-   * driven through the number input; the slider itself is not exercised yet.
+   * Expands the segmentation appearance config section unless it already is.
    */
-  private getNumericConfig(dataCy: string) {
-    const input = this.page.getByTestId(dataCy).locator('input[type="number"]');
+  private async openSegmentationConfig(typeSuffix: string) {
+    const opacityControl = this.page.getByTestId(`segmentation-config-opacity-${typeSuffix}`);
+
+    if (await opacityControl.isVisible()) {
+      return;
+    }
+    await this.page.getByTestId(`segmentation-config-toggle-${typeSuffix}`).click();
+    await opacityControl.waitFor({ state: 'visible' });
+  }
+
+  /**
+   * A numeric (slider plus number input) config control, e.g. Opacity or Border. The value is
+   * driven through the number input.
+   */
+  private getNumericConfig(control: 'opacity' | 'border' | 'opacity-inactive', typeSuffix: string) {
+    const input = this.page
+      .getByTestId(`segmentation-config-${control}-${typeSuffix}`)
+      .locator('input[type="number"]');
 
     return {
       input,
       fill: async (value: string) => {
+        await this.openSegmentationConfig(typeSuffix);
         await input.fill(value);
       },
     };
   }
 
   /**
-   * Returns the appearance config accessors shared by the segmentation panels: the section
-   * toggle, the display mode tabs and the opacity/border controls. The display tab buttons
-   * carry a data-state attribute reflecting which mode is currently selected.
+   * The appearance config shared by the segmentation panels.
    */
   private getSegmentationConfig(typeSuffix: string) {
     const page = this.page;
     const configToggle = page.getByTestId(`segmentation-config-toggle-${typeSuffix}`);
+    const open = () => this.openSegmentationConfig(typeSuffix);
     const displayMode = (mode: 'fill-and-outline' | 'outline' | 'fill') => {
       const button = page.getByTestId(`segmentation-config-display-${mode}-${typeSuffix}`);
       return {
         button,
         click: async () => {
+          await open();
           await button.click();
         },
       };
     };
 
     return {
+      open,
       toggle: {
         locator: configToggle,
         click: async () => {
@@ -67,9 +83,9 @@ export class RightPanelPageObject {
         outline: displayMode('outline'),
         fill: displayMode('fill'),
       },
-      opacity: this.getNumericConfig(`segmentation-config-opacity-${typeSuffix}`),
-      border: this.getNumericConfig(`segmentation-config-border-${typeSuffix}`),
-      opacityInactive: this.getNumericConfig(`segmentation-config-opacity-inactive-${typeSuffix}`),
+      opacity: this.getNumericConfig('opacity', typeSuffix),
+      border: this.getNumericConfig('border', typeSuffix),
+      opacityInactive: this.getNumericConfig('opacity-inactive', typeSuffix),
     };
   }
 

--- a/tests/pages/RightPanelPageObject.ts
+++ b/tests/pages/RightPanelPageObject.ts
@@ -370,14 +370,6 @@ export class RightPanelPageObject {
       // Retrying-friendly locator for `expect(...).toHaveCount(n)` — prefer this
       // over the one-shot getSegmentCount() when asserting row counts.
       rows: page.getByTestId('data-row'),
-      /**
-       * @deprecated One-shot count that races the render. Prefer
-       * `expect(panel.rows).toHaveCount(n)` for assertions. Use this only to
-       * capture a stable baseline value (e.g. for a delta).
-       */
-      getSegmentCount: async () => {
-        return await page.getByTestId('data-row').count();
-      },
       // get all the segment titles in the panel
       getSegmentLabels: () => {
         return page.getByTestId('data-row-title');

--- a/tests/utils/drawFreehandContour.ts
+++ b/tests/utils/drawFreehandContour.ts
@@ -1,0 +1,25 @@
+import type { RightPanelPageObject } from '../pages';
+import type { IViewportPageObject } from '../pages/ViewportPageObject';
+
+/**
+ * Draws a closed freehand contour into the active segment by dragging along the given
+ * normalized viewport path. The freehand tool is activated first unless the caller states
+ * that it is already active (drawing several contours in a row keeps the tool armed).
+ */
+export async function drawFreehandContour({
+  segmentationPanel,
+  viewport,
+  path,
+  activateTool = true,
+}: {
+  segmentationPanel: RightPanelPageObject['contourSegmentationPanel'];
+  viewport: IViewportPageObject;
+  path: { x: number; y: number }[];
+  activateTool?: boolean;
+}) {
+  if (activateTool) {
+    await segmentationPanel.tools.freehandContour.click();
+  }
+
+  await viewport.normalizedPathDragAt({ path });
+}

--- a/tests/utils/index.ts
+++ b/tests/utils/index.ts
@@ -25,6 +25,7 @@ import {
   measurementTextFormatters,
 } from './expectAnnotationText';
 import { clearAllAnnotations } from './clearAllAnnotations';
+import { drawFreehandContour } from './drawFreehandContour';
 import { scrollVolumeViewport } from './scrollVolumeViewport';
 import { attemptAction } from './attemptAction';
 import { addLengthMeasurement } from './addLengthMeasurement';
@@ -68,6 +69,7 @@ export {
   expectAnnotationStatsText,
   measurementTextFormatters,
   clearAllAnnotations,
+  drawFreehandContour,
   scrollVolumeViewport,
   attemptAction,
   addLengthMeasurement,


### PR DESCRIPTION
### Context

The contour segmentation appearance config had no E2E coverage: nothing asserted that the
display mode tabs (fill / outline / fill & outline), the fill opacity and the outline width
actually change what is rendered. This adds that coverage and extends the contour test suite
(#6117, #6206, #6236).

### Changes & Results

**New spec (`ContourSegmentationFillOutlineOpacity.spec.ts`, 6 tests)**

- A panel-created contour renders with both fill and outline by default.
- Switching display modes toggles fill and outline on the rendered contour.
- A display mode applies to contours drawn afterwards *and* re-renders existing ones, across
  two segments.
- Typing an opacity value changes the fill alpha, leaves the outline untouched, and a zero
  alpha does not silently turn the fill display off.
- Typing a border value changes the outline width and leaves the fill untouched.
- Changing the opacity while in outline mode keeps the fill hidden, and re-enabling fill
  applies the alpha chosen while it was hidden.

Every assertion reads the rendered SVG (`fill-opacity`, `stroke-width`, `fill`) rather than the
state of the panel control, so the tests verify the effect rather than the widget. No
screenshots were added.

**Page object (`RightPanelPageObject`)**

- The contour and labelmap appearance config are unified into `getSegmentationConfig(typeSuffix)`
  and `getNumericConfig(control, typeSuffix)`, replacing two near-identical copies. The display
  tabs now expose the `button` locator, which carries the `data-state` reflecting the selected
  mode.
- Config actions expand the section themselves, so a caller no longer has to remember to open it
  first, matching the way `MainToolbarPageObject` combines opening a menu with clicking one of
  its items. The expand is guarded on the section already being visible, because the toggle
  collapses a section that is already expanded.
- The three call sites that used `config.toggle.click()` to *open* the section now call
  `config.open()`. This removes a latent race: the raw toggle never waited for the section to
  settle, so a following action could run against a section that had not finished expanding.
  `toggle` remains for deliberately collapsing.

**New utility**

- `drawFreehandContour({ segmentationPanel, viewport, path, activateTool })` draws a closed
  freehand contour along a normalized viewport path, with `activateTool: false` for the case
  where the tool is still armed from a previous contour.

### Testing

```sh
pnpm run test:e2e tests/ContourSegmentationFillOutlineOpacity.spec.ts tests/SegmentationPanel.spec.ts
```

### Checklist

#### PR

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] OS: macOS 26.5.1 (arm64)
- [x] Node version: 25.4.0 (pnpm 11.5.2)
- [x] Browser: Playwright 1.56.1 bundled Chromium 141.0.7390.37


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for contour segmentation display modes, including fill, outline, opacity, and border width.
  * Added validation for independent active and inactive segmentation rendering, opacity settings, visibility toggling, and switching between segmentations.
  * Improved coverage for drawing contours across multiple segmentations and applying display settings before and after drawing.
  * Strengthened validation of segmentation panel controls and configuration interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->