### PR TITLE
fix(default): tolerate display sets without image view codes

### DIFF
--- a/extensions/default/src/hangingprotocols/utils/viewCode.test.js
+++ b/extensions/default/src/hangingprotocols/utils/viewCode.test.js
@@ -1,0 +1,27 @@
+import viewCode from './viewCode';
+
+describe('viewCode', () => {
+  it.each([undefined, {}, { images: [] }, { images: [{}] }])(
+    'returns undefined when a display set has no view-code metadata: %p',
+    displaySet => {
+      expect(viewCode(displaySet)).toBeUndefined();
+    }
+  );
+
+  it('returns the coding scheme and value from the first image', () => {
+    expect(
+      viewCode({
+        images: [
+          {
+            ViewCodeSequence: [
+              {
+                CodingSchemeDesignator: 'SRT',
+                CodeValue: 'R-10242',
+              },
+            ],
+          },
+        ],
+      })
+    ).toBe('SRT:R-10242');
+  });
+});

--- a/extensions/default/src/hangingprotocols/utils/viewCode.ts
+++ b/extensions/default/src/hangingprotocols/utils/viewCode.ts
@@ -1,5 +1,5 @@
 export default displaySet => {
-  const ViewCodeSequence = displaySet?.images[0]?.ViewCodeSequence[0];
+  const ViewCodeSequence = displaySet?.images?.[0]?.ViewCodeSequence?.[0];
   if (!ViewCodeSequence) {
     return undefined;
   }


### PR DESCRIPTION
<!-- pr_template -->
### Context

The hanging-protocol view-code helper throws `TypeError: Cannot read properties of undefined (reading '0')` for a partial display set without `images`, or for an image without `ViewCodeSequence`. These missing optional values should reach its existing `undefined` fallback.

### Changes & Results

Use optional element access for both arrays. Complete image metadata still returns the same `CodingSchemeDesignator:CodeValue` string.

### Testing

- Node 24.20.0, focused Jest suite: 5 passed. Cases cover undefined display set, absent/empty images, absent view-code sequence, and complete metadata.
- Prettier and `git diff --check`: passed.
- This pure helper was tested with Jest/jsdom; the full viewer/browser build was not run. The current installation exposes no ESLint command, so no full lint pass is claimed.

### Checklist

#### PR
- [x] Descriptive title follows semantic-release format.

#### Code
- [x] The existing fallback and regression cases document the intended behavior.

#### Public Documentation Updates
- [x] Not applicable: no public API added or removed.

#### Tested Environment
- [x] OS: macOS.
- [x] Node version: 24.20.0.
- [x] Browser: Jest/jsdom for this pure helper; no manual browser validation claimed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of display sets without image data or view-code metadata.
  - Prevented errors when image arrays are missing while preserving existing view-code results.
- **Tests**
  - Added coverage for missing metadata, empty image lists, incomplete image entries, and valid view-code values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->